### PR TITLE
Include the metadata diff as a Slack attachment

### DIFF
--- a/bin/notify-on-metadata-change
+++ b/bin/notify-on-metadata-change
@@ -20,7 +20,7 @@ diff="$(
 
 if [[ -n "$diff" ]]; then
     echo "Notifying Slack about metadata change."
-    "$bin"/notify-slack "Metadata changes: \`\`\`$diff\`\`\`"
+    "$bin"/notify-slack "Metadata changes" <<<"$diff"
 else
     echo "No metadata change."
 fi

--- a/bin/notify-slack
+++ b/bin/notify-slack
@@ -4,8 +4,21 @@ set -euo pipefail
 : "${SLACK_INCOMING_WEBHOOK:?The SLACK_INCOMING_WEBHOOK environment variable is required.}"
 
 text="${1:?Some message text is required as the first and only argument.}"
+data=""
 
-slack_message="$(jq --arg text "$text" --null-input '{"text": $text}')"
+# If stdin isn't an interactive terminal, then read data from it.
+if [[ ! -t 0 ]]; then
+    data="$(< /dev/stdin)"
+fi
+
+if [[ -z "$data" ]]; then
+    slack_message="$(jq '{"text": $text}' --arg text "$text" --null-input)"
+else
+    slack_message="$(jq '{"text": $text, "attachments": [{"text": "```\($data)```", "fallback": ($data | split("\n\n") | .[0])}]}' \
+        --arg text "$text" \
+        --arg data "$data" \
+        --null-input)"
+fi
 
 echo "Prepared Slack message:"
 echo "$slack_message"


### PR DESCRIPTION
…instead of as part of the primary message.  Attachments are displayed as secondary content¹ which, when lengthy, is hidden behind a link to disclose the rest.  This is nice for reducing the noise of notifications, while keeping the useful diff available.

¹ https://api.slack.com/messaging/composing/layouts#attachments

---

Example:

![image](https://user-images.githubusercontent.com/79913/75277721-69948d00-57bd-11ea-820a-1add876a8fa4.png)

