### PR TITLE
rebuild-staging: Fix nextstrain-jobs permissions

### DIFF
--- a/bin/rebuild-staging
+++ b/bin/rebuild-staging
@@ -42,6 +42,8 @@ else
     git clone https://github.com/nextstrain/ncov.git
 fi
 
+unset AWS_ACCESS_KEY_ID
+unset AWS_SECRET_ACCESS_KEY
 
 output=$(
     nextstrain build --aws-batch --detach \


### PR DESCRIPTION
We started proxying AWS credentials into the nextstrain build job.
Unset the AWS credentials used by `nextstrain-ncov-ingest-uploader` to
not override the `NextstrainJobsRole` credentials.

-----------------------------

I've attempted a fix for this problem, but I'm not sure how to test it. Now when I run the `rebuild-staging` script locally, I get the same permission we're seeing on AWS Batch that the bucket named `nextstrain-jobs` does not exist. 