### PR TITLE
transform: Stabilize strain sort

### DIFF
--- a/bin/transform
+++ b/bin/transform
@@ -56,8 +56,11 @@ def preprocess(gisaid_data: pd.DataFrame) -> pd.DataFrame:
     # Drop entries with length less than 15kb
     gisaid_data.drop(gisaid_data[gisaid_data.length < 15000].index, inplace=True)
 
-    # Drop duplicates, prefer longest sequence
-    gisaid_data.sort_values('length', ascending=False, inplace=True)
+    # Drop duplicates, prefer longest and earliest sequence (assuming accessions
+    # are chronological)
+    gisaid_data.sort_values(['strain', 'length', 'gisaid_epi_isl'],
+        ascending=[True, False, True], inplace=True)
+
     gisaid_data.drop_duplicates('strain', inplace=True)
 
     # Sort by strain name


### PR DESCRIPTION
Stabilize the strain sort for sequences sharing a strain name by
preferring the longest sequence which was submitted earliest (assuming
accessions are chronological).