### PR TITLE
Ensure Nextstrain CLI installed

### DIFF
--- a/bin/rebuild-staging
+++ b/bin/rebuild-staging
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+if ! hash nextstrain 2>/dev/null; then
+    echo "The Nextstrain CLI must be installed." >&2
+    exit 1
+fi
+
 : "${SLACK_TOKEN:?The SLACK_TOKEN environment variable is required.}"
 : "${NEXTSTRAIN_AWS_BATCH_CPUS:=8}"
 : "${NEXTSTRAIN_AWS_BATCH_MEMORY:=62000}"


### PR DESCRIPTION
If the Nextstrain CLI is not installed, exit the `rebuild-staging`
script.
