### PR TITLE
Replace blank division with country to prevent unexpected subsampling

### DIFF
--- a/bin/transform
+++ b/bin/transform
@@ -91,6 +91,9 @@ def parse_geographic_columns(gisaid_data: pd.DataFrame) -> pd.DataFrame:
     gisaid_data['region']      = geographic_data[0]
     gisaid_data['country']     = geographic_data[1]
     gisaid_data['division']    = geographic_data[2]
+
+    gisaid_data.loc[pd.isnull(gisaid_data['division']), 'division'] = gisaid_data[pd.isnull(gisaid_data['division'])]['country']
+
     gisaid_data['location']    = geographic_data[3]
 
     return gisaid_data

--- a/bin/transform
+++ b/bin/transform
@@ -93,9 +93,6 @@ def parse_geographic_columns(gisaid_data: pd.DataFrame) -> pd.DataFrame:
     gisaid_data['division']    = geographic_data[2]
     gisaid_data['location']    = geographic_data[3]
 
-    # if division is blank, replace with country data, to avoid unexpected effects when subsampling by division
-    # (where an empty division is counted as a 'division' group)
-    gisaid_data.loc[pd.isnull(gisaid_data['division']), 'division'] = gisaid_data['country']
 
     return gisaid_data
 
@@ -240,6 +237,10 @@ def update_metadata(curated_gisaid_data: pd.DataFrame) -> pd.DataFrame:
         curated_gisaid_data['division_exposure'].fillna(curated_gisaid_data['division'], inplace=True)
     else:
         curated_gisaid_data['division_exposure'] = curated_gisaid_data['division']
+
+    # if division is blank, replace with country data, to avoid unexpected effects when subsampling by division
+    # (where an empty division is counted as a 'division' group)
+    curated_gisaid_data.loc[pd.isnull(curated_gisaid_data['division']), 'division'] = curated_gisaid_data['country']
 
     return curated_gisaid_data
 

--- a/bin/transform
+++ b/bin/transform
@@ -95,7 +95,7 @@ def parse_geographic_columns(gisaid_data: pd.DataFrame) -> pd.DataFrame:
 
     # if division is blank, replace with country data, to avoid unexpected effects when subsampling by division
     # (where an empty division is counted as a 'division' group)
-    gisaid_data.loc[pd.isnull(gisaid_data['division']), 'division'] = gisaid_data[pd.isnull(gisaid_data['division'])]['country']
+    gisaid_data.loc[pd.isnull(gisaid_data['division']), 'division'] = gisaid_data['country']
 
     return gisaid_data
 

--- a/bin/transform
+++ b/bin/transform
@@ -91,10 +91,11 @@ def parse_geographic_columns(gisaid_data: pd.DataFrame) -> pd.DataFrame:
     gisaid_data['region']      = geographic_data[0]
     gisaid_data['country']     = geographic_data[1]
     gisaid_data['division']    = geographic_data[2]
-
-    gisaid_data.loc[pd.isnull(gisaid_data['division']), 'division'] = gisaid_data[pd.isnull(gisaid_data['division'])]['country']
-
     gisaid_data['location']    = geographic_data[3]
+
+    # if division is blank, replace with country data, to avoid unexpected effects when subsampling by division
+    # (where an empty division is counted as a 'division' group)
+    gisaid_data.loc[pd.isnull(gisaid_data['division']), 'division'] = gisaid_data[pd.isnull(gisaid_data['division'])]['country']
 
     return gisaid_data
 


### PR DESCRIPTION
### Description of proposed changes    
Adds a line to ingest so that if a sample has no `division`, the entry for `country` is copied over.

This is because in the pipeline we often filter by `division` per month per year. It turns out if `division` is missing, then `''` is counted as a division group. There are hundreds of these, so they do end up getting subsampled down by `''` - even though this isn't sensible. This produces unexpected output, as sequences seem to rather randomly go missing when they shouldn't.

The downside is that `country` isn't a division either, so we're likely to grab a few more sequences than we intend - however I feel this behaviour is less worrying & more transparent than sequences going missing. 

### Testing
I ran this locally. Seemed to work.

### Note
This is likely to cause a deluge of missing colours and lat-longs in the next run after this is pushed - due to new `division`s which are `country`s.... So should be aware of these. These should be fairly easy to fix (all should be present as `country` entries - so just copy over and change `country` to `division`!), but putting so nobody gets alarmed.

### Thank you for contributing to Nextstrain!
You're very welcome, lovely template. 
