### PR TITLE
upload-to-s3: Store sha256sum in object metadata

### DIFF
--- a/bin/rebuild-staging
+++ b/bin/rebuild-staging
@@ -18,10 +18,9 @@ main() {
         local sequences_src="${3:?A source sequences fasta file is required as the first argument.}"
         local sequences_dst="${4:?A destination sequences fasta s3:// URL is required as the second argument.}"
 
-        local metadata_match=$(hashes_match $metadata_src $metadata_dst)
-        local sequences_match=$(hashes_match $sequences_src $sequences_dst)
-
-        if [[ $metadata_match -eq 1 && $sequences_match -eq 1 ]]; then
+        if hashes-match "$metadata_src" "$metadata_dst" &&
+           hashes-match "$sequences_src" "$sequences_dst"
+        then
             echo "No metadata or sequence changes"
             echo "Exiting"
             exit 0
@@ -72,15 +71,11 @@ main() {
 }
 
 # Returns 1 if both files match (have identical hashes). Else returns 0.
-hashes_match() {
-    src_hash="$("$bin/sha256sum" < "$1")"
-    dst_hash="$("$bin/sha256sum" < <(aws s3 cp --no-progress "$2" -))"
+hashes-match() {
+    local src_hash="$("$bin/sha256sum" < "$1")"
+    local dst_hash="$("$bin/sha256sum" < <(aws s3 cp --no-progress "$2" -))"
 
-    if [[ $src_hash = $dst_hash ]]; then
-        echo 1
-    else
-        echo 0
-    fi
+    [[ "$src_hash" == "$dst_hash" ]]
 }
 
 main "$@"

--- a/bin/rebuild-staging
+++ b/bin/rebuild-staging
@@ -73,7 +73,11 @@ main() {
 # Returns 1 if both files match (have identical hashes). Else returns 0.
 hashes-match() {
     local src_hash="$("$bin/sha256sum" < "$1")"
-    local dst_hash="$("$bin/sha256sum" < <(aws s3 cp --no-progress "$2" -))"
+
+    local dst_s3path="${2#s3://}"
+    local dst_bucket="${dst_s3path%%/*}"
+    local dst_key="${dst_s3path#*/}"
+    local dst_hash="$(aws s3api head-object --bucket "$dst_bucket" --key "$dst_key" --query Metadata.sha256sum --output text)"
 
     [[ "$src_hash" == "$dst_hash" ]]
 }

--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -24,7 +24,7 @@ main() {
     local bucket="${s3path%%/*}"
     local key="${s3path#*/}"
 
-    local dst_hash="$(aws s3api head-object --bucket $bucket --key $key --query Metadata.sha256sum --output text)"
+    local dst_hash="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text)"
 
     echo "$src_hash $src"
     echo "$dst_hash $dst"

--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -20,14 +20,19 @@ main() {
     local dst="${2:?A destination s3:// URL is required as the second argument.}"
 
     local src_hash="$("$bin/sha256sum" < "$src")"
-    local dst_hash="$("$bin/sha256sum" < <(aws s3 cp --no-progress "$dst" -))"
+    local s3path="${dst#s3://}"
+    local bucket="${s3path%%/*}"
+    local key="${s3path#*/}"
+
+    local dst_hash="$(aws s3api head-object --bucket $bucket --key $key \
+        | jq -r .Metadata.sha256sum)"
 
     echo "$src_hash $src"
     echo "$dst_hash $dst"
 
     if [[ $src_hash != $dst_hash ]]; then
         echo "Uploading $src → $dst"
-        aws s3 cp --no-progress "$src" "$dst"
+        aws s3 cp --no-progress "$src" "$dst" --metadata sha256sum="$src_hash"
 
         if [[ $quiet == 1 ]]; then
             echo "Quiet mode. No Slack notification sent."

--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -24,8 +24,7 @@ main() {
     local bucket="${s3path%%/*}"
     local key="${s3path#*/}"
 
-    local dst_hash="$(aws s3api head-object --bucket $bucket --key $key \
-        | jq -r .Metadata.sha256sum)"
+    local dst_hash="$(aws s3api head-object --bucket $bucket --key $key --query Metadata.sha256sum --output text)"
 
     echo "$src_hash $src"
     echo "$dst_hash $dst"


### PR DESCRIPTION
### Description of proposed changes    
On upload to S3, store a given file's sha256sum in the object metadata.
Retrieve this property later for object comparison instead of hashing
the remote S3 file every time.

### Related issue(s)  
https://github.com/nextstrain/ncov-ingest/issues/35
