### PR TITLE
Annotation errors

### DIFF
--- a/bin/check-annotations
+++ b/bin/check-annotations
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""
+Check annotations for potential errors / missing data
+"""
+
+## Not part of this script, but you can check if a strain has duplica
+# 
+
+import pandas as pd
+import sys
+
+annotations = pd.read_csv("./source-data/annotations.tsv", header=None, sep='\t', comment="#")
+annotations.columns = ['strain', 'trait', 'value']
+
+try:
+  annotations = annotations.pivot(index="strain", columns="trait", values="value")
+except ValueError:
+  print("Error reshaping the annotations table. This is potentially because there are duplicate definitions in the TSV.")
+  print("You may see these by running:")
+  print("cat source-data/annotations.tsv | grep -v '^#' | cut -f1,2 | sort | uniq -c | sort | grep -v -E '^[[:space:]]+1'")
+  sys.exit(2)
+
+
+print("The following strains have a country_exposure but not a region_exposure.")
+print("This is ok if the region_exposure happens to match the region, but problems arise if this is not the case.")
+print("To make this clear, region_exposure should be explicitly set for the following:")
+print(annotations.loc[pd.isnull(annotations.region_exposure)].loc[pd.notnull(annotations.country_exposure)].loc[:, "strain"])
+
+
+

--- a/bin/check-annotations
+++ b/bin/check-annotations
@@ -9,6 +9,12 @@ Check annotations for potential errors / missing data
 import pandas as pd
 import sys
 
+ALLOWED_TRAIT_NAMES = set([
+  'strain', 'authors', 'host', 'date', 'genbank_accession',
+  'region',          'country',          'division',            'location',
+  'region_exposure', 'country_exposure', 'division_exposure'
+])
+
 annotations = pd.read_csv("./source-data/annotations.tsv", header=None, sep='\t', comment="#")
 annotations.columns = ['strain', 'trait', 'value']
 
@@ -20,11 +26,23 @@ except ValueError:
   print("cat source-data/annotations.tsv | grep -v '^#' | cut -f1,2 | sort | uniq -c | sort | grep -v -E '^[[:space:]]+1'")
   sys.exit(2)
 
+print()
+print("Ensuring that there are no unexpected trait names defined in the annotations...")
+invalid_traits = set(annotations.columns) - ALLOWED_TRAIT_NAMES
+if len(invalid_traits):
+  print("The following traits are unexpected and probably shouldn't be in the TSV:")
+  print(invalid_traits)
 
+
+print()
+print("The following strains have a division_exposure but not a country_exposure.")
+print("This is ok if the country_exposure happens to match the country, but problems arise if this is not the case.")
+print("To make this clear, country_exposure should be explicitly set for the following:")
+print(annotations.loc[pd.isnull(annotations.country_exposure)].loc[pd.notnull(annotations.division_exposure)].loc[:, "strain"])
+
+print()
 print("The following strains have a country_exposure but not a region_exposure.")
 print("This is ok if the region_exposure happens to match the region, but problems arise if this is not the case.")
 print("To make this clear, region_exposure should be explicitly set for the following:")
 print(annotations.loc[pd.isnull(annotations.region_exposure)].loc[pd.notnull(annotations.country_exposure)].loc[:, "strain"])
-
-
 

--- a/source-data/annotations.tsv
+++ b/source-data/annotations.tsv
@@ -29,17 +29,22 @@
 ## Kuwait samples have their division set to what should be the location
 #note UPHL-03 and -04 are same patient
 #note UPHL-05 and -06 are same patient
+Argentina/PAIS_A005/2020	region_exposure	North America
 Argentina/PAIS_A005/2020	country_exposure	Mexico
 Argentina/PAIS_A005/2020	division_exposure	Mexico
 Argentina/PAIS_A006/2020	location	Quilmes
+Argentina/PAIS_A009/2020	region_exposure	South America
 Argentina/PAIS_A009/2020	country_exposure	Brazil
 Argentina/PAIS_A009/2020	division_exposure	Brazil
 Argentina/PAIS_A011/2020	location	Bahia Blanca
+Argentina/PAIS_A013/2020	region_exposure	Europe
 Argentina/PAIS_A013/2020	country_exposure	Spain
 Argentina/PAIS_A013/2020	division_exposure	Spain
 Argentina/PAIS_A014/2020	location	Bahia Blanca
+Argentina/PAIS_A015/2020	region_exposure	Asia
 Argentina/PAIS_A015/2020	country_exposure	Israel
 Argentina/PAIS_A015/2020	division_exposure	Israel
+Argentina/PAIS_A016/2020	region_exposure	Europe
 Argentina/PAIS_A016/2020	country_exposure	France
 Argentina/PAIS_A016/2020	division_exposure	France
 Argentina/PAIS_A017/2020	location	San Carlos de Bariloche
@@ -389,6 +394,7 @@ CostaRica/0003/2020	authors	Duarte et al
 CostaRica/0004/2020	region	North America
 CostaRica/0004/2020	division	La Union
 CostaRica/0004/2020	location	Cartago
+CostaRica/0004/2020	region_exposure	North America
 CostaRica/0004/2020	country_exposure	USA
 CostaRica/0004/2020	division_exposure	New York
 CostaRica/0004/2020	authors	Duarte et al
@@ -9804,7 +9810,7 @@ Iceland/504/2020	region_exposure	Europe #gisaid
 Iceland/506/2020	region_exposure	Europe #gisaid
 Iceland/427/2020	region_exposure	Europe #gisaid
 Iceland/503/2020	region_exposure	Europe #gisaid
-Iceland/602/2020	region_expsoure	Europe #GISAID
+Iceland/602/2020	region_exposure	Europe #GISAID
 Iceland/439/2020	region_exposure	North America #GISAID
 Iceland/508/2020	region_exposure	North America #GISAID
 Iceland/490/2020	region_exposure	South America #GISAID
@@ -9846,17 +9852,17 @@ India/1616/2020	division_exposure	Iran #GISAID
 India/1617/2020	division_exposure	Iran #GISAID
 India/1621/2020	division_exposure	Iran #GISAID
 India/1644/2020	division_exposure	Iran #GISAID
-India/1073/2020	regions_exposure	Asia #GISAID
-India/1093/2020	regions_exposure	Asia #GISAID
-India/1100/2020	regions_exposure	Asia #GISAID
-India/1104/2020	regions_exposure	Asia #GISAID
-India/1111/2020	regions_exposure	Asia #GISAID
-India/1115/2020	regions_exposure	Asia #GISAID
-India/1125/2020	regions_exposure	Asia #GISAID
-India/1616/2020	regions_exposure	Asia #GISAID
-India/1617/2020	regions_exposure	Asia #GISAID
-India/1621/2020	regions_exposure	Asia #GISAID
-India/1644/2020	regions_exposure	Asia #GISAID
+India/1073/2020	region_exposure	Asia #GISAID
+India/1093/2020	region_exposure	Asia #GISAID
+India/1100/2020	region_exposure	Asia #GISAID
+India/1104/2020	region_exposure	Asia #GISAID
+India/1111/2020	region_exposure	Asia #GISAID
+India/1115/2020	region_exposure	Asia #GISAID
+India/1125/2020	region_exposure	Asia #GISAID
+India/1616/2020	region_exposure	Asia #GISAID
+India/1617/2020	region_exposure	Asia #GISAID
+India/1621/2020	region_exposure	Asia #GISAID
+India/1644/2020	region_exposure	Asia #GISAID
 India/1073/2020	country_exposure	Iran #GISAID
 India/1093/2020	country_exposure	Iran #GISAID
 India/1100/2020	country_exposure	Iran #GISAID

--- a/source-data/annotations.tsv
+++ b/source-data/annotations.tsv
@@ -48,37 +48,25 @@ Argentina/PAIS_A020/2020	division_exposure	United Kingdom
 Australia/NSW01/2020	country_exposure	China
 Australia/NSW01/2020	division_exposure	Hubei
 Australia/NSW01/2020	region_exposure	Asia
-Australia/NSW05/2020	division_exposure	China
-Australia/NSW05/2020	country_exposure	China # James: data via direct contact with Aus lab
-Australia/NSW05/2020	country_exposure	Iran # James: data via direct contact with Aus lab
 Australia/NSW05/2020	division_exposure	Iran # James: data via direct contact with Aus lab
 Australia/NSW05/2020	region_exposure	Asia # James: data via direct contact with Aus lab
-Australia/NSW05/2020	region_exposure	Asia # James: data via direct contact with Aus lab
-Australia/NSW06/2020	country_exposure	China # James: data via direct contact with Aus lab
 Australia/NSW06/2020	country_exposure	Iran # James: data via direct contact with Aus lab
 Australia/NSW06/2020	division_exposure	Iran # James: data via direct contact with Aus lab
-Australia/NSW06/2020	region_exposure	Asia # James: data via direct contact with Aus lab
 Australia/NSW06/2020	region_exposure	Asia # James: data via direct contact with Aus lab
 Australia/NSW08/2020	division	New South Wales
 Australia/NSW09/2020	division	New South Wales
 Australia/NSW10/2020	division	New South Wales
 Australia/NSW11/2020	country_exposure	Iran # James: data via direct contact with Aus lab
-Australia/NSW11/2020	country_exposure	Iran # James: data via direct contact with Aus lab
 Australia/NSW11/2020	division	New South Wales
 Australia/NSW11/2020	division_exposure	Iran # James: data via direct contact with Aus lab
 Australia/NSW11/2020	region_exposure	Asia # James: data via direct contact with Aus lab
-Australia/NSW11/2020	region_exposure	Asia # James: data via direct contact with Aus lab
-Australia/NSW12/2020	country_exposure	Iran # James: data via direct contact with Aus lab
 Australia/NSW12/2020	country_exposure	Iran # James: data via direct contact with Aus lab
 Australia/NSW12/2020	division	New South Wales
 Australia/NSW12/2020	division_exposure	Iran # James: data via direct contact with Aus lab
 Australia/NSW12/2020	region_exposure	Asia # James: data via direct contact with Aus lab
-Australia/NSW12/2020	region_exposure	Asia # James: data via direct contact with Aus lab
-Australia/NSW13/2020	country_exposure	Iran # James: data via direct contact with Aus lab
 Australia/NSW13/2020	country_exposure	Iran # James: data via direct contact with Aus lab
 Australia/NSW13/2020	division	New South Wales
 Australia/NSW13/2020	division_exposure	Iran # James: data via direct contact with Aus lab
-Australia/NSW13/2020	region_exposure	Asia # James: data via direct contact with Aus lab
 Australia/NSW13/2020	region_exposure	Asia # James: data via direct contact with Aus lab
 Australia/NSW14/2020	division	New South Wales
 Australia/QLD01/2020	division_exposure	Hubei # ?
@@ -8307,8 +8295,6 @@ England/SHEF-BFD27/2020	country	United Kingdom
 England/SHEF-BFD27/2020	division	England
 England/SHEF-BFD36/2020	country	United Kingdom
 England/SHEF-BFD36/2020	division	England
-England/SHEF-BFD36/2020	division	England
-England/SHEF-BFD36/2020	division	Nottinghamshire
 England/SHEF-BFD36/2020	location	Nottinghamshire
 England/SHEF-BFD45/2020	country	United Kingdom
 England/SHEF-BFD45/2020	division	England
@@ -9008,22 +8994,14 @@ France/IDF3745/2020	division	Ile de France
 France/IDF3831/2020	division	Ile de France
 France/IDF3930/2020	division	Ile de France
 France/Lyon_487/2020	division	Auvergne-Rhône-Alpes
-France/Lyon_487/2020	division	Auvergne-Rhône-Alpes
-France/Lyon_508/2020	division	Auvergne-Rhône-Alpes
 France/Lyon_508/2020	division	Auvergne-Rhône-Alpes
 France/Lyon_0668/2020	division	Auvergne-Rhône-Alpes
 France/Lyon_683/2020	division	Auvergne-Rhône-Alpes
-France/Lyon_683/2020	division	Auvergne-Rhône-Alpes
-France/Lyon_683/2020	division	Auvergne-Rhône-Alpes
-France/Lyon_0693/2020	division	Auvergne-Rhône-Alpes
 France/Lyon_0693/2020	division	Auvergne-Rhône-Alpes
 France/Lyon_06042/2020	division	Auvergne-Rhône-Alpes
 France/Lyon_06056/2020	division	Auvergne-Rhône-Alpes
 France/Lyon_06464/2020	division	Auvergne-Rhône-Alpes
-France/Lyon_06464/2020	division	Auvergne-Rhône-Alpes
 France/Lyon_06487/2020	division	Auvergne-Rhône-Alpes
-France/Lyon_06487/2020	division	Auvergne-Rhône-Alpes
-France/Lyon_06531/2020	division	Auvergne-Rhône-Alpes
 France/Lyon_06531/2020	division	Auvergne-Rhône-Alpes
 France/Lyon_06573/2020	division	Auvergne-Rhône-Alpes
 France/Lyon_06625/2020	division	Auvergne-Rhône-Alpes
@@ -10099,7 +10077,6 @@ Luxembourg/LNS1918658/2020	division	Luxembourg
 Luxembourg/LNS1918658/2020	location	Luxembourg
 Luxembourg/LNS2013896/2020	division	Luxembourg
 Luxembourg/LNS2128808/2020	division	Luxembourg
-Luxembourg/LNS2128808/2020	division	Luxembourg
 Luxembourg/LNS2151006/2020	division	Luxembourg
 Luxembourg/LNS2151006/2020	location	Luxembourg
 Luxembourg/LNS2247193/2020	division	Luxembourg
@@ -10489,8 +10466,6 @@ Netherlands/ZuidHolland_102/2020	division	South Holland
 Netherlands/ZuidHolland_103/2020	division	South Holland
 Netherlands/ZuidHolland_104/2020	division	South Holland
 NetherlandsL/Houten_1363498/2020	division	Utrecht
-NetherlandsL/Houten_1363498/2020	division	Utrecht
-NetherlandsL/Houten_1363498/2020	location	Houten
 NetherlandsL/Houten_1363498/2020	location	Houten
 NewZealand/01/2020	country_exposure	Iran # GISAID
 NewZealand/01/2020	division_exposure	Iran # GISAID
@@ -15505,12 +15480,8 @@ SouthKorea/KCDC05/2020	location	Seoul
 SouthKorea/KCDC06/2020	location	Seoul
 SouthKorea/KCDC07/2020	location	Seoul
 SouthKorea/KCDC12/2020	division	Gyeonggi
-SouthKorea/KCDC12/2020	division	Gyeonggi
-SouthKorea/KCDC12/2020	location	Gyeonggi
 SouthKorea/KCDC12/2020	location	Gyeonggi
 SouthKorea/KCDC24/2020	division	Chungcheongnam
-SouthKorea/KCDC24/2020	division	Chungcheongnam
-SouthKorea/KCDC24/2020	location	Chungcheongnam
 SouthKorea/KCDC24/2020	location	Chungcheongnam
 SouthKorea/KUMC01/2020	division	South Korea
 SouthKorea/KUMC02/2020	division	South Korea
@@ -15590,7 +15561,6 @@ Switzerland/TI2045/2020	division	Ticino #assumed from name
 Switzerland/TI9486/2020	division	Ticino
 Switzerland/VD0503/2020	division	Geneva
 Switzerland/GE06207/2020	division	Geneva #assumed from name
-Switzerland/GE0199/2020	division	Geneva #assumed from name
 Switzerland/GE0636/2020	division	Geneva #assumed from name
 Switzerland/GE6065/2020	division	Geneva #assumed from name
 Switzerland/GE3144/2020	division	Geneva #assumed from name
@@ -15728,7 +15698,6 @@ USA/AK-PHL013/2020	location	Fairbanks
 USA/AZ_4811/2020	country	USA
 USA/AZ_4811/2020	division	Arizona
 USA/AZ_4811/2020	region	North America
-USA/AZ_4811/2020	region	North America
 USA/AZ1/2020	country_exposure	China # ?
 USA/AZ1/2020	division_exposure	Hubei # ?
 USA/AZ1/2020	genbank_accession	MN997409
@@ -15779,7 +15748,6 @@ USA/CA7/2020	division_exposure	Hubei # ?
 USA/CA7/2020	genbank_accession	MT106052
 USA/CA7/2020	region_exposure	Asia # ?
 USA/CA8/2020	genbank_accession	MT106053
-USA/CA9/2020	genbank_accession	MT118835
 USA/CA9/2020	genbank_accession	MT118835
 USA/CA9/2020	location	Solano County
 USA/CruiseA-1/2020	division	Diamond Princess
@@ -15845,26 +15813,20 @@ USA/CT-Yale-138/2020	location	Cincinnati
 USA/FL_6318/2020	country	USA
 USA/FL_6318/2020	division	Florida
 USA/FL_6318/2020	region	North America
-USA/FL_6318/2020	region	North America
 USA/GA_1299/2020	country	USA
 USA/GA_1299/2020	division	Georgia
-USA/GA_1299/2020	region	North America
 USA/GA_1299/2020	region	North America
 USA/GA_1320/2020	country	USA
 USA/GA_1320/2020	division	Georgia
 USA/GA_1320/2020	region	North America
-USA/GA_1320/2020	region	North America
 USA/GA_1445/2020	country	USA
 USA/GA_1445/2020	division	Georgia
-USA/GA_1445/2020	region	North America
 USA/GA_1445/2020	region	North America
 USA/IL_1293/2020	country	USA
 USA/IL_1293/2020	division	Illinois
 USA/IL_1293/2020	region	North America
-USA/IL_1293/2020	region	North America
 USA/IL_1375/2020	country	USA
 USA/IL_1375/2020	division	Illinois
-USA/IL_1375/2020	region	North America
 USA/IL_1375/2020	region	North America
 USA/IL1/2020	country_exposure	China # ?
 USA/IL1/2020	division_exposure	Hubei # ?
@@ -15891,14 +15853,11 @@ USA/MN3-MDH3/2020	region_exposure	North America # exposure on Grand Princess htt
 USA/NH_0004/2020	country	USA
 USA/NH_0004/2020	division	New Hampshire
 USA/NH_0004/2020	region	North America
-USA/NH_0004/2020	region	North America
 USA/NH_0008/2020	country	USA
 USA/NH_0008/2020	division	New Hampshire
 USA/NH_0008/2020	region	North America
-USA/NH_0008/2020	region	North America
 USA/NY_2929/2020	country	USA
 USA/NY_2929/2020	division	New York
-USA/NY_2929/2020	region	North America
 USA/NY_2929/2020	region	North America
 USA/NY-NYUMC1/2020	country	USA
 USA/NY-NYUMC1/2020	division	New York
@@ -15925,7 +15884,6 @@ USA/NY-Wadsworth-16080-01/2020	location	Orange County NY # two orange counties i
 USA/OR_5430/2020	country	USA
 USA/OR_5430/2020	division	Oregon
 USA/OR_5430/2020	region	North America
-USA/OR_5430/2020	region	North America
 USA/OSUP0109/2020	division	Ohio
 USA/OSUP0109/2020	location	Columbus
 USA/OSUP0112/2020	division	Ohio
@@ -15939,18 +15897,14 @@ USA/OSUP0017/2020	location	Columbus
 USA/RI_0556/2020	country	USA
 USA/RI_0556/2020	division	Rhode Island
 USA/RI_0556/2020	region	North America
-USA/RI_0556/2020	region	North America
 USA/TX_2039/2020	country	USA
 USA/TX_2039/2020	division	Texas
-USA/TX_2039/2020	region	North America
 USA/TX_2039/2020	region	North America
 USA/TX_2817/2020	country	USA
 USA/TX_2817/2020	division	Texas
 USA/TX_2817/2020	region	North America
-USA/TX_2817/2020	region	North America
 USA/TX_2967/2020	country	USA
 USA/TX_2967/2020	division	Texas
-USA/TX_2967/2020	region	North America
 USA/TX_2967/2020	region	North America
 USA/TX1/2020	country_exposure	China # ?
 USA/TX1/2020	division_exposure	Hubei # ?
@@ -16043,8 +15997,6 @@ Vietnam/CM295/2020	division	Red River Delta
 Vietnam/CM295/2020	location	Hanoi
 Vietnam/CM296/2020	division	Red River Delta
 Vietnam/CM296/2020	location	Hanoi
-Vietnam/CM296/2020	location	Hanoi
-Vietnam/CM296/2020 	division	Red River Delta
 Vietnam/VR03-38142/2020	country_exposure	China # ?
 Vietnam/VR03-38142/2020	division_exposure	Hubei # ?
 Vietnam/VR03-38142/2020	region_exposure	Asia # ?

--- a/source-data/annotations.tsv
+++ b/source-data/annotations.tsv
@@ -48,12 +48,14 @@ Argentina/PAIS_A016/2020	region_exposure	Europe
 Argentina/PAIS_A016/2020	country_exposure	France
 Argentina/PAIS_A016/2020	division_exposure	France
 Argentina/PAIS_A017/2020	location	San Carlos de Bariloche
-Argentina/PAIS_A020/2020	countryexposure	United Kingdom
+Argentina/PAIS_A020/2020	region_exposure	Europe
+Argentina/PAIS_A020/2020	country_exposure	United Kingdom
 Argentina/PAIS_A020/2020	division_exposure	United Kingdom
 Australia/NSW01/2020	country_exposure	China
 Australia/NSW01/2020	division_exposure	Hubei
 Australia/NSW01/2020	region_exposure	Asia
 Australia/NSW05/2020	division_exposure	Iran # James: data via direct contact with Aus lab
+Australia/NSW05/2020	country_exposure	Iran # James: data via direct contact with Aus lab
 Australia/NSW05/2020	region_exposure	Asia # James: data via direct contact with Aus lab
 Australia/NSW06/2020	country_exposure	Iran # James: data via direct contact with Aus lab
 Australia/NSW06/2020	division_exposure	Iran # James: data via direct contact with Aus lab
@@ -939,6 +941,8 @@ DRC/KN-0060/2020	country	Democratic Republic of the Congo
 DRC/KN-0070/2020	country	Democratic Republic of the Congo
 DRC/KN-0072/2020	country	Democratic Republic of the Congo
 DRC/KN-13/2020	country	Democratic Republic of the Congo
+Ecuador/HGSQ-USFQ-018/2020	region_exposure	South America
+Ecuador/HGSQ-USFQ-018/2020	country_exposure	Ecuador
 Ecuador/HGSQ-USFQ-018/2020	division_exposure	Guayas
 England/01/2020	country	United Kingdom
 England/01/2020	country_exposure	China # first cases were reported in media as being son & mother from China
@@ -10502,6 +10506,8 @@ Panama/328677/2020	division_exposure	Comunitat Valenciana
 Panama/328677/2020	region	North America
 Panama/328677/2020	region_exposure	Europe
 Poland/Pom1/2020	division	Pomorskie
+Poland/Pom1/2020	region_exposure	Europe
+Poland/Pom1/2020	country_exposure	Poland
 Poland/Pom1/2020	division_exposure	Pomorskie
 Portugal/CV62/2020	division	Portugal
 Portugal/CV62/2020	division_exposure	Italy #"Travel association (Italy, Germany) (GISAID) and clusters with other seqs with Italy travel history on nextstrain"
@@ -15715,11 +15721,19 @@ USA/CA-CDPH-UC6/2020	division	Grand Princess # from GISAID
 USA/CA-CDPH-UC7/2020	division	Grand Princess # from GISAID
 USA/CA-CDPH-UC8/2020	division	Grand Princess # from GISAID
 USA/CA-CDPH-UC9/2020	division	Grand Princess # from GISAID
+USA/CA-CDPH-UC19/2020	region_exposure	North America # GISAID
+USA/CA-CDPH-UC19/2020	country_exposure	USA # GISAID
 USA/CA-CDPH-UC19/2020	division_exposure	Grand Princess # GISAID
+USA/CA-CDPH-UC20/2020	region_exposure	North America # GISAID
+USA/CA-CDPH-UC20/2020	country_exposure	USA # GISAID
 USA/CA-CDPH-UC20/2020	division_exposure	Grand Princess # GISAID
 USA/CA-CDPH-UC30/2020	location	Grand Princess cruise ship
+USA/CA-CDPH-UC30/2020	region_exposure	North America # GISAID
+USA/CA-CDPH-UC30/2020	country_exposure	USA # GISAID
 USA/CA-CDPH-UC30/2020	division_exposure	Grand Princess 2nd cruise #GISAID
 USA/CA-CDPH-UC31/2020	location	Grand Princess cruise ship
+USA/CA-CDPH-UC31/2020	region_exposure	North America # GISAID
+USA/CA-CDPH-UC31/2020	country_exposure	USA # GISAID
 USA/CA-CDPH-UC31/2020	division_exposure	Grand Princess 2nd cruise #GISAID
 USA/CA-CDPH-UC26/2020	location	San Francisco
 USA/CA-CDPH-UC27/2020	location	San Francisco
@@ -15727,6 +15741,8 @@ USA/CA-CDPH-UC28/2020	location	San Francisco
 USA/CA-UCSF-UC32/2020	location	San Francisco
 USA/CA-UCSF-UC33/2020	location	San Francisco
 USA/CA-UCSF-UC36/2020	location	San Francisco
+USA/CA-UCSF-UC36/2020	region_exposure	North America # GISAID
+USA/CA-UCSF-UC36/2020	country_exposure	USA # GISAID
 USA/CA-UCSF-UC36/2020	division_exposure	New York #GISAID
 # USA/CA-UCSF-UC32/2020 close contact of UC34
 # USA/CA-UCSF-UC33/2020 works at airport, community acquired


### PR DESCRIPTION
This PR fixes the root cause of a number of errors noticed by @lmoncla and @trvrb.

These errors arise in regional subsampled builds due to our handling of exposure history (which explains the stochasticity as they depend on which samples are included in the build). Specifically, if a genome had `country_exposure` defined in the annotation but not `region_exposure` then this `country_exposure` would appear as a country in the final auspice build. If this country was outside the desired focal region, the result would be a legend such as 👇  ("Israel" should be "Asia", and "Mexico" should be "North America" in this example which is a South American regional build). The fix is to define `region_exposure` for these samples.

![image](https://user-images.githubusercontent.com/8350992/80776216-f4c34200-8bb5-11ea-950d-f6447f8a355c.png)

---

This PR changes a number of things:

1. Duplicate entries are removed from the annotations TSV. There were a few ones with different values, most of which were obvious to choose between except for NSW05 which was annotated as Iran (me) but China (Emma). cc @emmahodcroft 

2. A helper script is added to check that if `country_exposure` is set then `region_exposure` is explicitly set. Similarly for `division_exposure` and `country_exposure`. This script is not run automatically but it would be a good idea in my option.

3. Annotations are updated for the samples identified by (2). 

### Testing
I've regenerated data locally and am running builds on AWS now to make sure this works as desired
