### PR TITLE
Rework check-annotations in prevision to more checks + add it to CI

### DIFF
--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -21,6 +21,7 @@ jobs:
         python3 -m pip install --upgrade pip setuptools
         python3 -m pip install pipenv
         pipenv sync
+        pipenv run ./bin/check-annotations
         pipenv run ./bin/ingest
       env:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}

--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -21,7 +21,6 @@ jobs:
         python3 -m pip install --upgrade pip setuptools
         python3 -m pip install pipenv
         pipenv sync
-        pipenv run ./bin/check-annotations
         pipenv run ./bin/ingest
       env:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}

--- a/bin/check-annotations
+++ b/bin/check-annotations
@@ -7,8 +7,10 @@ Check annotations for potential errors / missing data
 
 import sys
 import pandas as pd
+import argparse
+from pathlib import Path
 
-ANNOTATIONS_FILE = "./source-data/annotations.tsv"
+
 ALLOWED_TRAIT_NAMES = set(
     [
         "strain",
@@ -101,9 +103,23 @@ def check_annotation(annotations):
 
 
 if __name__ == "__main__":
-    print("Ensuring that there are no unexpected trait names defined in the annotations...")
+    base = Path(__file__).resolve().parent.parent
+
+    parser = argparse.ArgumentParser(
+        description="Check if annotations from a metadata file is valid.",
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+
+    parser.add_argument(
+            "--annotations",
+            default=base / "source-data/annotations.tsv",
+            help="Annotation file (in TSV format) to be checked.\n")
+
+    args = parser.parse_args()
+
+    print("Ensuring that there are no unexpected trait names defined in the annotations file {}...".format(args.annotations))
     try:
-        ann = read_annotations_file(ANNOTATIONS_FILE)
+        ann = read_annotations_file(args.annotations)
         ann = reshape_annotations(ann)
         check_annotation(ann)
     except Exception as e:

--- a/bin/check-annotations
+++ b/bin/check-annotations
@@ -4,45 +4,108 @@ Check annotations for potential errors / missing data
 """
 
 ## Not part of this script, but you can check if a strain has duplica
-# 
 
-import pandas as pd
 import sys
+import pandas as pd
 
-ALLOWED_TRAIT_NAMES = set([
-  'strain', 'authors', 'host', 'date', 'genbank_accession',
-  'region',          'country',          'division',            'location',
-  'region_exposure', 'country_exposure', 'division_exposure'
-])
-
-annotations = pd.read_csv("./source-data/annotations.tsv", header=None, sep='\t', comment="#")
-annotations.columns = ['strain', 'trait', 'value']
-
-try:
-  annotations = annotations.pivot(index="strain", columns="trait", values="value")
-except ValueError:
-  print("Error reshaping the annotations table. This is potentially because there are duplicate definitions in the TSV.")
-  print("You may see these by running:")
-  print("cat source-data/annotations.tsv | grep -v '^#' | cut -f1,2 | sort | uniq -c | sort | grep -v -E '^[[:space:]]+1'")
-  sys.exit(2)
-
-print()
-print("Ensuring that there are no unexpected trait names defined in the annotations...")
-invalid_traits = set(annotations.columns) - ALLOWED_TRAIT_NAMES
-if len(invalid_traits):
-  print("The following traits are unexpected and probably shouldn't be in the TSV:")
-  print(invalid_traits)
+ANNOTATIONS_FILE = "./source-data/annotations.tsv"
+ALLOWED_TRAIT_NAMES = set(
+    [
+        "strain",
+        "authors",
+        "host",
+        "date",
+        "genbank_accession",
+        "region",
+        "country",
+        "division",
+        "location",
+        "region_exposure",
+        "country_exposure",
+        "division_exposure",
+    ]
+)
 
 
-print()
-print("The following strains have a division_exposure but not a country_exposure.")
-print("This is ok if the country_exposure happens to match the country, but problems arise if this is not the case.")
-print("To make this clear, country_exposure should be explicitly set for the following:")
-print(annotations.loc[pd.isnull(annotations.country_exposure)].loc[pd.notnull(annotations.division_exposure)].loc[:, "strain"])
+def read_annotations_file(file_name):
+    """Read the annotations TSV file"""
+    annotations = pd.read_csv(file_name, header=None, sep="\t", comment="#")
+    annotations.columns = ["strain", "trait", "value"]
+    return annotations
 
-print()
-print("The following strains have a country_exposure but not a region_exposure.")
-print("This is ok if the region_exposure happens to match the region, but problems arise if this is not the case.")
-print("To make this clear, region_exposure should be explicitly set for the following:")
-print(annotations.loc[pd.isnull(annotations.region_exposure)].loc[pd.notnull(annotations.country_exposure)].loc[:, "strain"])
 
+def print_duplicates(annotations):
+    """Print rows having the same strain and trait"""
+    keys = []
+    for index, row in annotations.iterrows():
+        key = row["strain"] + "_" + row["trait"]
+        if key in keys:
+            print("{}: {} {}".format(index, row["strain"], row["trait"]))
+        keys.append(key)
+
+
+def reshape_annotations(annotations):
+    """Pivot the table and print duplicates"""
+    try:
+        annotations = annotations.pivot(index="strain", columns="trait", values="value")
+    except ValueError as ve:
+        print("Error reshaping the annotations table.")
+        print("This is potentially because there are duplicate definitions in the TSV.")
+        print("The following are matched as duplicate: (lineno: strain trait)")
+        print_duplicates(annotations)
+        raise ve
+    return annotations
+
+
+def check_division_exposure(annotations):
+    """Check if annotations have a division_exposure but not a country_exposure"""
+    mismatched_strains = (
+        annotations.loc[pd.isnull(annotations.country_exposure)]
+        .loc[pd.notnull(annotations.division_exposure)]
+        .loc[:, "strain"]
+    )
+    if len(mismatched_strains):
+        print()
+        print("The following strains have a division_exposure but not a country_exposure.")
+        print("This is ok if the country_exposure happens to match the country, but problems arise if this is not the case.")
+        print("To make this clear, country_exposure should be explicitly set for the following:")
+        print(mismatched_strains)
+        raise Exception("strains have a division_exposure but not a country_exposure")
+
+
+def check_country_exposure(annotations):
+    """Check if annotations have a country_exposure but not a region_exposure"""
+    mismatched_strains = (
+        annotations.loc[pd.isnull(annotations.region_exposure)]
+        .loc[pd.notnull(annotations.country_exposure)]
+        .loc[:, "strain"]
+    )
+    if len(mismatched_strains):
+        print()
+        print("The following strains have a country_exposure but not a region_exposure.")
+        print("This is ok if the region_exposure happens to match the region, but problems arise if this is not the case.")
+        print("To make this clear, region_exposure should be explicitly set for the following:")
+        print(mismatched_strains)
+        raise Exception("strains have a country_exposure but not a region_exposure")
+
+
+def check_annotation(annotations):
+    """Check annotations with several rules"""
+    invalid_traits = set(annotations.columns) - ALLOWED_TRAIT_NAMES
+    if len(invalid_traits):
+        print("The following traits are unexpected and probably shouldn't be in the TSV:")
+        print(invalid_traits)
+        raise Exception("Found traits that aren't allowed")
+    check_division_exposure(annotations)
+    check_country_exposure(annotations)
+
+
+if __name__ == "__main__":
+    print("Ensuring that there are no unexpected trait names defined in the annotations...")
+    try:
+        ann = read_annotations_file(ANNOTATIONS_FILE)
+        ann = reshape_annotations(ann)
+        check_annotation(ann)
+    except Exception as e:
+        sys.exit(e)
+    print("Everything looks fine!")


### PR DESCRIPTION
### Description of proposed changes    
Rework `bin/check-annotations` to make it more modular and be able to add more checks later on.
I've also added it to CI as mentioned in the original issue.

### Related issue(s)  
Fixes #39 

### Testing
The CI should run the script. I've checked that it reports error with the annotation file before #38 .