### PR TITLE
Improve failure mode for jobs running on AWS Batch

### DIFF
--- a/bin/rebuild-staging
+++ b/bin/rebuild-staging
@@ -58,7 +58,9 @@ main() {
             --cores "$NEXTSTRAIN_AWS_BATCH_CPUS" \
             --resources mem_mb="$NEXTSTRAIN_AWS_BATCH_MEMORY" \
             --snakefile Snakefile_Regions \
-            --stats stats.json
+            --stats stats.json \
+            --keep-going \
+            --restart-times 1
     )
 
     echo "$output"


### PR DESCRIPTION
If one job fails, continue to run other parallel jobs with snakemake's
`--keep-going` flag such that as much work gets completed in the current AWS
Batch job as possible before exiting. Additionally, anticipate stochastic errors
with augur refine by asking snakemake to retry failed jobs one time with
`--restart-times 1`.

In the best case, the restart argument allows augur refine to complete without
error so the rest of the workflow can complete. In the worst case, augur
refine (or another long-running job like augur tree) always fails on the second
attempt and the overall runtime of the workflow to fail extends by an hour or
more.