### PR TITLE
transform: Send Slack message with future dates

### DIFF
--- a/bin/flag-metadata
+++ b/bin/flag-metadata
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""
+Creates a list of flagged sequences from the provided metadata TSV in the
+Nextstrain exclusions.txt convention. Prints the list to stdout.
+"""
+import logging
+import argparse
+import pandas as pd
+from pathlib import Path
+from datetime import date
+
+
+LOG = logging.getLogger(__name__)
+
+
+if __name__ == '__main__':
+    base = Path(__file__).resolve().parent.parent
+
+    parser = argparse.ArgumentParser(
+        description="Warn about future dates in a metadata TSV file.",
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+    parser.add_argument("metadata",
+        nargs="?",
+        default=base / "data/gisaid/metadata.tsv",
+        help="Location of generated metadata tsv. Defaults to `data/gisaid/metadata.tsv`")
+    args = parser.parse_args()
+
+    metadata = pd.read_csv(args.metadata, sep="\t")
+    metadata.loc[metadata.date > str(date.today()), 'reason'] = '# Collection date in the future'
+    flagged_strains = metadata.loc[metadata.reason.notnull()]
+
+    print(flagged_strains[['strain', 'reason']].to_csv(header=False, index=False, sep='\t'))

--- a/bin/ingest-gisaid
+++ b/bin/ingest-gisaid
@@ -51,9 +51,12 @@ fi
   --output-metadata data/gisaid/metadata.tsv \
   --output-fasta data/gisaid/sequences.fasta
 
+./bin/flag-metadata data/gisaid/metadata.tsv > data/gisaid/flagged_metadata.txt
+
 if [[ "$branch" == master ]]; then
     ./bin/notify-on-metadata-change data/gisaid/metadata.tsv "$S3_SRC/metadata.tsv.gz" gisaid_epi_isl
     ./bin/notify-on-additional-info-change data/gisaid/additional_info.tsv "$S3_SRC/additional_info.tsv.gz"
+    ./bin/notify-on-flagged-metadata-change data/gisaid/flagged_metadata.txt "$S3_SRC/flagged_metadata.txt.gz"
 
     ./bin/rebuild-staging data/gisaid/metadata.tsv "$S3_SRC/metadata.tsv.gz" \
       data/gisaid/sequences.fasta "$S3_SRC/sequences.fasta.gz"
@@ -61,4 +64,5 @@ fi
 
 ./bin/upload-to-s3 ${silent:+--quiet} data/gisaid/metadata.tsv "$S3_DST/metadata.tsv.gz"
 ./bin/upload-to-s3 ${silent:+--quiet} data/gisaid/additional_info.tsv "$S3_DST/additional_info.tsv.gz"
+./bin/upload-to-s3 ${silent:+--quiet} data/gisaid/flagged_metadata.txt "$S3_DST/flagged_metadata.txt.gz"
 ./bin/upload-to-s3 ${silent:+--quiet} data/gisaid/sequences.fasta "$S3_DST/sequences.fasta.gz"

--- a/bin/notify-on-flagged-metadata-change
+++ b/bin/notify-on-flagged-metadata-change
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+: "${SLACK_TOKEN:?The SLACK_TOKEN environment variable is required.}"
+
+bin="$(dirname "$0")"
+
+src="${1:?A source flagged metadata txt file is required as the first argument.}"
+dst="${2:?A destination flagged metadata txt s3:// URL is required as the second argument.}"
+
+dst_local="$(mktemp -t flagged-metadata-XXXXXX.txt)"
+
+diff="$(mktemp -t flagged-metadata-additions-XXXXXX)"
+
+trap "rm -f '$dst_local' '$diff'" EXIT
+
+aws s3 cp --no-progress "$dst" - | gunzip -cfq > "$dst_local"
+
+comm -13 \
+    <(sort "$dst_local") \
+    <(sort "$src") \
+    > "$diff"
+
+if [[ -s "$diff" ]]; then
+    echo
+    echo "Notifying Slack about flagged metadata additions."
+    "$bin"/notify-slack ":waving_black_flag: Newly flagged metadata"
+    "$bin"/notify-slack --upload "flagged-metadata-additions.txt" < "$diff"
+else
+    echo "No flagged metadata additions."
+fi


### PR DESCRIPTION
Sometimes we receive data from GISAID with collection dates in the
future. This causes a big headache for the Nextstrain nCoV build
maintainers when left uncaught until the end of a multi hour long build.
    
Send a Slack message containing the GISAID EPI ISL ID and collection
date for every strain that has a collection date from the future (e.g.
a date > now). Emma specifically requested that this Slack message be
formatted differently from the others so that it stands out.

### Related issue(s)  
#33
