### PR TITLE
Add support for new ncov build interface with profiles

### DIFF
--- a/bin/rebuild-staging
+++ b/bin/rebuild-staging
@@ -57,8 +57,7 @@ main() {
             --config slack_token="$SLACK_TOKEN" \
             --cores "$NEXTSTRAIN_AWS_BATCH_CPUS" \
             --resources mem_mb="$NEXTSTRAIN_AWS_BATCH_MEMORY" \
-            --snakefile Snakefile_Regions \
-            --stats stats.json
+            --profile profiles/nextstrain
     )
 
     echo "$output"


### PR DESCRIPTION
Region-specific builds are now managed through Snakemake configuration files and
profiles. Profiles include default arguments to use when running Snakemake (like
`--keep-going` and `--printshellcmds`). This interface moves logic about how the
Nextstrain team runs builds into the ncov repository.

This PR supersedes #42, if [the simple-build PR for ncov](https://github.com/nextstrain/ncov/pull/375/) is merged first.