### PR TITLE
Fetch all GenBank sequences + metadata from NCBI Virus

### DIFF
--- a/bin/fetch-from-genbank
+++ b/bin/fetch-from-genbank
@@ -1,40 +1,72 @@
 #!/usr/bin/env python3
-import pandas as pd
-from Bio import Entrez
-from os import environ
-from shutil import copyfileobj
-from sys import argv, exit, stdin, stdout, stderr
+"""
+Download all SARS-CoV-2 sequences and their curated metadata from GenBank via
+NCBI Virus.
 
-Entrez.email = environ.get("NCBI_EMAIL", "hello@nextstrain.org")
+Outputs newline-delimited JSON records.
 
-if not argv[1:]:
-    print(f"Reading metadata.tsv from stdin", file = stderr)
-    metadata_file = stdin
+The request this program makes is based on observing the network activity that
 
-elif len(argv[1:]) == 1:
-    print(f"Reading metadata.tsv from {argv[1]!r}", file = stderr)
-    metadata_file = argv[1]
+    https://www.ncbi.nlm.nih.gov/labs/virus/vssi/#/virus?SeqType_s=Nucleotide&VirusLineage_ss=Severe%20acute%20respiratory%20syndrome%20coronavirus%202,%20taxid:2697049
 
-else:
-    print(f"usage: {__file__} [<metadata.tsv>]", file = stderr)
-    exit(1)
+performs after clicking through the download interface.  Some tweaks were made
+by comparing different download requests and guessing, which allows us to
+download the metadata + sequence in the same request instead of two.
+"""
+import csv
+import json
+import requests
+from sys import stdout
 
-metadata = pd.read_table(metadata_file)
+endpoint = "https://www.ncbi.nlm.nih.gov/genomes/VirusVariation/vvsearch2/"
+params = {
+    # Search criteria
+    'fq': [
+        '{!tag=SeqType_s}SeqType_s:("Nucleotide")', # Nucleotide sequences (as opposed to protein)
+        'VirusLineageId_ss:(2697049)',              # NCBI Taxon id for SARS-CoV-2
+    ],
 
-accessions = list(
-    metadata["genbank_accession"]
-        .replace("?", pd.NA)
-        .dropna()
-        .drop_duplicates()
-)
+    # Unclear, but seems necessary.
+    'q': '*:*',
 
-print(f"Fetching {len(accessions):,} accessions from GenBank", file = stderr)
+    # Response format
+    'cmd': 'download',
+    'dlfmt': 'csv',
+    'fl': ','.join(
+        ':'.join(names) for names in [
+            # Pairs of (output column name, source data field).  These are pulled
+            # from watching requests from the UI.
+            #
+            # XXX TODO: Is the full set source data fields documented
+            # somewhere?  Is there more info we could be pulling that'd be
+            # useful?
+            #   -trs, 13 May 2020
+            ('genbank_accession',       'id'),
+            ('database',                'SourceDB_s'),
+            ('title',                   'Definition_s'),
+            ('location',                'CountryFull_s'),
+            ('collected',               'CollectionDate_s'),
+            ('submitted',               'CreateDate_dt'),
+            ('length',                  'SLen_i'),
+            ('host',                    'Host_s'),
+            ('isolation_source',        'Isolation_csv'),
+            ('biosample_accession',     'BioSample_s'),
+            ('authors',                 'Authors_csv'),
+            ('publications',            'PubMed_csv'),
+            ('sequence',                'Nucleotide_seq'),
+        ]
+    ),
 
-sequences = Entrez.efetch(
-    db = "nucleotide",
-    id = accessions,
-    rettype = "fasta",
-    retmode = "text",
-)
+    # Stable sort with newest last so diffs work nicely.  Columns are source
+    # data fields, not our output columns.
+    'sort': 'SourceDB_s desc, CollectionDate_s asc, id asc',
+}
 
-copyfileobj(sequences, stdout)
+response = requests.get(endpoint, params = params, stream = True)
+response.raise_for_status()
+
+response_content = response.iter_lines(decode_unicode = True)
+
+for row in csv.DictReader(response_content):
+    json.dump(row, stdout, allow_nan = False, indent = None, separators = ',:')
+    print()

--- a/bin/fetch-from-genbank
+++ b/bin/fetch-from-genbank
@@ -43,7 +43,8 @@ params = {
             #   -trs, 13 May 2020
             ('genbank_accession',       'id'),
             ('database',                'SourceDB_s'),
-            ('title',                   'Definition_s'),
+            ('strain',                  'Isolate_s'),
+            ('region',                  'Region_s'),
             ('location',                'CountryFull_s'),
             ('collected',               'CollectionDate_s'),
             ('submitted',               'CreateDate_dt'),
@@ -51,6 +52,7 @@ params = {
             ('host',                    'Host_s'),
             ('isolation_source',        'Isolation_csv'),
             ('biosample_accession',     'BioSample_s'),
+            ('title',                   'Definition_s'),
             ('authors',                 'Authors_csv'),
             ('publications',            'PubMed_csv'),
             ('sequence',                'Nucleotide_seq'),

--- a/bin/ingest
+++ b/bin/ingest
@@ -63,5 +63,5 @@ fi
 ./bin/upload-to-s3 ${silent:+--quiet} data/additional_info.tsv "$S3_DST/additional_info.tsv.gz"
 ./bin/upload-to-s3 ${silent:+--quiet} data/sequences.fasta "$S3_DST/sequences.fasta.gz"
 
-./bin/fetch-from-genbank data/metadata.tsv > data/genbank.fasta
-./bin/upload-to-s3 ${silent:+--quiet} data/genbank.fasta "$S3_DST/genbank.fasta.gz"
+./bin/fetch-from-genbank > data/genbank.ndjson
+./bin/upload-to-s3 ${silent:+--quiet} data/genbank.ndjson "$S3_DST/genbank.ndjson.gz"


### PR DESCRIPTION
This adds a new file, genbank.ndjson.gz, which currently contains about
~3,600 sequences.  The previous genbank.fasta.gz file will no longer be
updated; it was a small subset of just 62 sequences which we'd manually
linked between GISAID and GenBank.  58 of those sequences are in the new
file; the remainder were removed from GenBank in the interim.

Note that the GenBank data is still not ingested, just fetched and
tracked.  The next steps are to incorporate it into the "transform" step
such that it ends up mixed in with the GISAID data in metadata.tsv and
sequences.fasta by:

  1. Aligning the fields and values between GISAID and GenBank

  2. ~Matching sequences in both repositories, likely by strain name
     heuristics, and then deduplicating matches.  Emma has already started
     scoping out the feasibility of this.~ Nevermind! It looks like we're leaning
     towards separate builds here for the two data sources.