### PR TITLE
fetch-from-genbank: Add contact information to our NCBI requests

### DIFF
--- a/bin/fetch-from-genbank
+++ b/bin/fetch-from-genbank
@@ -62,9 +62,17 @@ params = {
     # Stable sort with newest last so diffs work nicely.  Columns are source
     # data fields, not our output columns.
     'sort': 'SourceDB_s desc, CollectionDate_s asc, id asc',
+
+    # This isn't Entrez, but include the same email parameter it requires just
+    # to be nice.
+    'email': 'hello@nextstrain.org',
 }
 
-response = requests.get(endpoint, params = params, stream = True)
+headers = {
+    'User-Agent': 'https://github.com/nextstrain/ncov-ingest (hello@nextstrain.org)',
+}
+
+response = requests.get(endpoint, params = params, headers = headers, stream = True)
 response.raise_for_status()
 
 response_content = response.iter_lines(decode_unicode = True)


### PR DESCRIPTION
The NCBI's Entrez API requires an "email" parameter¹ and while this
isn't Entrez, include it anyway to be nice.  For good measure, also
include contact information in the User-Agent header.  Both of these can
help the NCBI reach out if our fetches are causing issues, rather than
having no clue where they're coming from.

¹ https://www.ncbi.nlm.nih.gov/home/about/policies/
