### PR TITLE
notify scripts should just exit cleanly if the destination key doesn't exist

### DIFF
--- a/bin/notify-on-additional-info-change
+++ b/bin/notify-on-additional-info-change
@@ -8,6 +8,12 @@ bin="$(dirname "$0")"
 src="${1:?A source additional info TSV file is required as the first argument.}"
 dst="${2:?A destination additional info TSV s3:// URL is required as the second argument.}"
 
+# if the file is not already present, just exit
+s3path="${2#s3://}"
+bucket="${dst_s3path%%/*}"
+key="${dst_s3path#*/}"
+aws s3api head-object --bucket $bucket --key $key || exit 0
+
 # Remove rows where columns 3 (additional_host_info) and 4 (additional_location_info) are empty.
 # Compare the S3 version with the local version.
 diff="$(

--- a/bin/notify-on-gisaid-change
+++ b/bin/notify-on-gisaid-change
@@ -8,6 +8,12 @@ bin="$(dirname "$0")"
 src="${1:?A source GISAID ndjson file is required as the first argument.}"
 dst="${2:?A destination GISAID ndjson s3:// URL is required as the second argument.}"
 
+# if the file is not already present, just exit
+s3path="${2#s3://}"
+bucket="${dst_s3path%%/*}"
+key="${dst_s3path#*/}"
+aws s3api head-object --bucket $bucket --key $key || exit 0
+
 src_record_count="$(wc -l < "$src")"
 dst_record_count="$(wc -l < <(aws s3 cp --no-progress "$dst" - | gunzip -cfq))"
 added_records="$(( $src_record_count - $dst_record_count ))"

--- a/bin/notify-on-metadata-change
+++ b/bin/notify-on-metadata-change
@@ -15,6 +15,12 @@ additions="$(mktemp -t metadata-additions-XXXXXX)"
 
 trap "rm -f '$dst_local' '$diff' '$additions'" EXIT
 
+# if the file is not already present, just exit
+s3path="${2#s3://}"
+bucket="${dst_s3path%%/*}"
+key="${dst_s3path#*/}"
+aws s3api head-object --bucket $bucket --key $key || exit 0
+
 aws s3 cp --no-progress "$dst" - | gunzip -cfq > "$dst_local"
 
 csv-diff \


### PR DESCRIPTION
### Description of proposed changes    
Right now, the notify scripts will error out if the destination key doesn't exist.  That means the ingest script cannot be run until it has succeeded in uploading data, which is a bootstrapping obstacle.

### Testing
Deleted the metadata key, then ran the script and it started the batch run.
