### PR TITLE
Skip notifications if the remote object doesn't exist

### DIFF
--- a/bin/notify-on-additional-info-change
+++ b/bin/notify-on-additional-info-change
@@ -8,6 +8,9 @@ bin="$(dirname "$0")"
 src="${1:?A source additional info TSV file is required as the first argument.}"
 dst="${2:?A destination additional info TSV s3:// URL is required as the second argument.}"
 
+# if the file is not already present, just exit
+"$bin"/s3-object-exists "$dst" || exit 0
+
 # Remove rows where columns 3 (additional_host_info) and 4 (additional_location_info) are empty.
 # Compare the S3 version with the local version.
 diff="$(

--- a/bin/notify-on-gisaid-change
+++ b/bin/notify-on-gisaid-change
@@ -8,6 +8,9 @@ bin="$(dirname "$0")"
 src="${1:?A source GISAID ndjson file is required as the first argument.}"
 dst="${2:?A destination GISAID ndjson s3:// URL is required as the second argument.}"
 
+# if the file is not already present, just exit
+"$bin"/s3-object-exists "$dst" || exit 0
+
 src_record_count="$(wc -l < "$src")"
 dst_record_count="$(wc -l < <(aws s3 cp --no-progress "$dst" - | gunzip -cfq))"
 added_records="$(( $src_record_count - $dst_record_count ))"

--- a/bin/notify-on-metadata-change
+++ b/bin/notify-on-metadata-change
@@ -15,6 +15,9 @@ additions="$(mktemp -t metadata-additions-XXXXXX)"
 
 trap "rm -f '$dst_local' '$diff' '$additions'" EXIT
 
+# if the file is not already present, just exit
+"$bin"/s3-object-exists "$dst" || exit 0
+
 aws s3 cp --no-progress "$dst" - | gunzip -cfq > "$dst_local"
 
 csv-diff \

--- a/bin/s3-object-exists
+++ b/bin/s3-object-exists
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+url="${1#s3://}"
+bucket="${url%%/*}"
+key="${url#*/}"
+
+aws s3api head-object --bucket "$bucket" --key "$key" &>/dev/null


### PR DESCRIPTION
This happens, for example, when pointing the ingest workflow at a new
destination bucket, which poses a problem for bootstrapping new copies
of the ingest.

Co-authored-by: Tony Tung <ttung@chanzuckerberg.com>

Based on #58.