### PR TITLE
Limit what kinds of pushes trigger the ingest workflow

### DIFF
--- a/.github/workflows/ingest-branch.yml
+++ b/.github/workflows/ingest-branch.yml
@@ -1,0 +1,28 @@
+name: '[branch] Ingest 2019-nCov/SARS-CoV-2 data from GISAID for nextstrain.org/ncov'
+
+on:
+  push:
+    branches-ignore:
+      - master
+    tags-ignore:
+      - '**'
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: ingest
+      run: |
+        PATH="$HOME/.local/bin:$PATH"
+        python3 -m pip install --upgrade pip setuptools
+        python3 -m pip install pipenv
+        pipenv sync
+        pipenv run ./bin/ingest
+      env:
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        GISAID_API_ENDPOINT: ${{ secrets.GISAID_API_ENDPOINT }}
+        GISAID_USERNAME_AND_PASSWORD: ${{ secrets.GISAID_USERNAME_AND_PASSWORD }}
+        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}

--- a/.github/workflows/ingest-master.yml
+++ b/.github/workflows/ingest-master.yml
@@ -2,6 +2,13 @@ name: Ingest 2019-nCov/SARS-CoV-2 data from GISAID for nextstrain.org/ncov
 
 on:
   push:
+    branches:
+      - master
+    tags-ignore:
+      - '**'
+    paths:
+      - source-data/annotations.tsv
+
   schedule:
     # * is a special character in YAML so you have to quote this string
     # "At minute 0 past every 6th hour"

--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -4,7 +4,7 @@ on:
   push:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    # "At minute 0 past every 4th hour"
+    # "At minute 0 past every 6th hour"
     - cron:  '0 */6 * * *'
 
   # Manually triggered using `./bin/trigger ingest`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you're using Pipenv (see below), then run commands from `./bin/…` inside a 
 
 ## Running automatically
 The fetch and transform pipeline exists as a GitHub workflow at `.github/workflows/fetch-and-transform.yml`.
-It is scheduled to run every 15 minutes and on pushes to `master`.
+It is scheduled to run every 6 hours and on pushes to `master`.
 
 AWS credentials are stored in this repository's secrets and are associated with the `nextstrain-ncov-ingest-uploader` IAM user in the Bedford Lab AWS account, which is locked down to reading and publishing only the `gisaid.ndjson`, `metadata.tsv`, and `sequences.fasta` files and their zipped equivalents in the `nextstrain-ncov-private` S3 bucket.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ If you're using Pipenv (see below), then run commands from `./bin/…` inside a 
 
 ## Running automatically
 The fetch and transform pipeline exists as a GitHub workflow at `.github/workflows/fetch-and-transform.yml`.
-It is scheduled to run every 6 hours and on pushes to `master`.
+It is scheduled to run every 6 hours and on pushes.
+Pushes to branches other than `master` upload files to branch-specific paths in the S3 bucket, don't send notifications, and don't trigger Nextstrain rebuilds, so that they don't interfere with the production data.
 
 AWS credentials are stored in this repository's secrets and are associated with the `nextstrain-ncov-ingest-uploader` IAM user in the Bedford Lab AWS account, which is locked down to reading and publishing only the `gisaid.ndjson`, `metadata.tsv`, and `sequences.fasta` files and their zipped equivalents in the `nextstrain-ncov-private` S3 bucket.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you're using Pipenv (see below), then run commands from `./bin/…` inside a 
 
 ## Running automatically
 The fetch and transform pipeline exists as a GitHub workflow at `.github/workflows/fetch-and-transform.yml`.
-It is scheduled to run every 6 hours and on pushes.
+It is scheduled to run every 6 hours, on pushes to `master` that modify `source-data/annotations.tsv`, and on pushes to other branches.
 Pushes to branches other than `master` upload files to branch-specific paths in the S3 bucket, don't send notifications, and don't trigger Nextstrain rebuilds, so that they don't interfere with the production data.
 
 AWS credentials are stored in this repository's secrets and are associated with the `nextstrain-ncov-ingest-uploader` IAM user in the Bedford Lab AWS account, which is locked down to reading and publishing only the `gisaid.ndjson`, `metadata.tsv`, and `sequences.fasta` files and their zipped equivalents in the `nextstrain-ncov-private` S3 bucket.


### PR DESCRIPTION
Pushes to master now only trigger the workflow if our manual annotations are modified.  Code changes won't trigger it anymore.  Now that we're aiming for a less rapid pace of updates—scheduled builds are only every 6 hours—this makes more sense than triggering builds off that schedule.  Ingest on master can still be triggered manually with `./bin/trigger ingest`.

Pushes to branches other than master still always run, with the idea that this is useful for testing during development.

The easiest way to express this without writing a bit of code to parse the GitHub event payload and `git log --stat` was to split the workflow definition into two and use the built-in push filtering affordances.
