### PR TITLE
transform: standardize date format

### DIFF
--- a/bin/transform-genbank
+++ b/bin/transform-genbank
@@ -152,19 +152,6 @@ def parse_authors(genbank_data: pd.DataFrame) -> pd.DataFrame:
     return genbank_data
 
 
-def format_date_columns(genbank_data: pd.DataFrame) -> pd.DataFrame:
-    """
-    Format the date columns of *genbank_data* to have the format
-    %Y-%m-%d and return the modified DataFrame.
-    """
-    date_columns = ['date', 'date_submitted']
-
-    for column in date_columns:
-        genbank_data[column] = pd.to_datetime(genbank_data[column]).dt.strftime('%Y-%m-%d')
-
-    return genbank_data
-
-
 def generate_hardcoded_metadata(genbank_data: pd.DataFrame) -> pd.DataFrame:
     """
     Returns a DataFrame with a column for GenBank accession plus
@@ -282,7 +269,6 @@ if __name__ == '__main__':
     genbank_data = standardize_strain_names(genbank_data)
     genbank_data = parse_geographic_columns(genbank_data)
     genbank_data = parse_authors(genbank_data)
-    genbank_data = format_date_columns(genbank_data)
     genbank_data = update_metadata(genbank_data)
     genbank_data = find_and_drop_problem_records(genbank_data)
 

--- a/lib/utils/transform.py
+++ b/lib/utils/transform.py
@@ -146,6 +146,9 @@ def format_date(date_string: str, expected_formats: set) -> str:
     >>> format_date("2020-1-15", expected_formats)
     '2020-01-15'
 
+    >>> format_date("2020-1-1", expected_formats)
+    '2020-01-01'
+
     >>> format_date("2020-01-15", expected_formats)
     '2020-01-15'
 

--- a/lib/utils/transform.py
+++ b/lib/utils/transform.py
@@ -155,9 +155,9 @@ def format_date(date_string: str, expected_formats: set) -> str:
     >>> format_date("2020-01-15T00:00:00Z", expected_formats)
     '2020-01-15'
     """
-    for format in expected_formats:
+    for date_format in expected_formats:
         try:
-            return datetime.strptime(date_string, format).strftime('%Y-%m-%d')
+            return datetime.strptime(date_string, date_format).strftime('%Y-%m-%d')
         except ValueError:
             continue
 


### PR DESCRIPTION
### Description of proposed changes    
Standardize date columns within shared function `standardize_dataframe`
instead of just in `transform-genbank` since it's become apparent that
GISAID dates may not be in ISO 8601 date format.

Stop relying on pandas `to_datetime` function to format date columns
since it infers the dates from incomplete date strings
(e.g. 2020 -> 2020-01-01 and 2020-01 -> 2020-01-01).

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #69 