### PR TITLE
Alert certain users of new GISAID data from their interested location hierarchy areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ A common pattern is expected to be:
  3. Update `source-data/location_hierarchy.tsv`.
  4. Push changes to `master` so the next ingest will have an updated "source of truth" to draw from.
 
+## Configuring alerts for new GISAID data from specific location hierarchy areas
+Some Nextstrain team members may be interested in receiving alerts when new GISAID strains are added from specific locations, e.g. Portugal or Louisiana.
+To add a custom alert configuration, create a new entry in `new-sequence-alerts-config.json`.
+Each resolution (region, division, country, location) accepts a list of strings of areas of interest.
+Note that these strings must match the area name exactly.
+
+To set up custom alerts, you'll need to retrieve your Slack member ID.
+Note that the `user` field in each alert configuration is for human use only -- it need not match your Slack display name or username.
+To view your Slack member ID, open up the Slack menu by clicking your name at the top, and click on 'View profile'.
+Then, click on 'More'.
+You can then copy your Slack member ID from the menu that appears.
+Enter this into the `slack_member_id` field of your alert configuration.
+
 ## Required dependencies
 Run `pipenv sync` to setup an isolated Python 3.6 environment using the pinned dependencies.
 

--- a/bin/notify-on-metadata-change
+++ b/bin/notify-on-metadata-change
@@ -44,4 +44,8 @@ fi
 if [[ -s "$additions" ]]; then
     echo "Notifying Slack about metadata additions."
     "$bin"/notify-slack --upload "metadata-additions.tsv" < "$additions"
+
+    if [[ "$key" == "gisaid_epi_isl" ]]; then
+        "$bin"/notify-users-on-new-locations "$additions"
+    fi
 fi

--- a/bin/notify-users-on-new-locations
+++ b/bin/notify-users-on-new-locations
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Notifies specified users of new data for their interested locations
+"""
+import sys
+import json
+import argparse
+import subprocess
+import pandas as pd
+from pathlib import Path
+from typing import Dict, Iterable, List, Union
+
+
+LOCATION_HIERARCHY_COLUMNS = ['region', 'country', 'division', 'location']
+base = Path(__file__).resolve().parent.parent
+
+
+def create_new_areas_lists(metadata: pd.DataFrame) -> Dict[str, List[str]]:
+    """
+    Returns a dictionary with keys of every location hierarchy resolution and
+    values containing a list of unique area names at each resolution in the
+    given *metadata*.
+    """
+    def unique_resolution_areas(series: Iterable[pd.Series]) -> List[str]:
+        """ Returns a list of unique, non-null items in the given *series*. """
+        return list(
+            pd.concat(series) \
+                .dropna() \
+                .unique()
+        )
+
+    # Locations do not have an associated exposure column
+    resolutions_with_exposure = LOCATION_HIERARCHY_COLUMNS.copy()
+    resolutions_with_exposure.remove('location')
+
+    areas: Dict[str, List] = {}
+
+    for r in resolutions_with_exposure:
+        areas[r] = unique_resolution_areas(
+            [incoming_metadata[r], incoming_metadata[f'{r}_exposure']]
+        )
+
+    # Handle location edge case
+    areas['location'] = unique_resolution_areas([incoming_metadata['location']])
+
+    return areas
+
+
+def alert_user_of_new_strains(entry: Dict[str, Union[str, List[str]]],
+    new_areas: Dict[str, List[str]]):
+    """
+    Using the given configuration *entry*, sends a Slack alert to the configured
+    user if there are new strains in the user's interested location hierarchy
+    areas.
+    """
+    member_id = entry.get('slack_member_id')
+
+    if not member_id:
+        # We can't send a Slack notification to a specified user without this
+        # field
+        return
+
+    alerts: List[str] = []
+
+    for resolution in LOCATION_HIERARCHY_COLUMNS:
+        if not entry.get(resolution):
+            # No alert has been configured at this resolution
+            continue
+
+        alerts += [ area for area in entry[resolution] if area in new_areas[resolution] ]
+
+    if not alerts:
+        return
+
+    alert_text = f"There are new strains from {', '.join(alerts)}"
+
+    subprocess.run([
+        f"{base}/bin/notify-slack", f"<@{member_id}>: {alert_text}"
+    ])
+
+
+parser = argparse.ArgumentParser(
+    description="Sends Slack alerts to certain, configurable users when "
+        "there are new strains available from their interested areas.",
+    formatter_class=argparse.RawTextHelpFormatter
+)
+parser.add_argument("incoming_metadata",
+    default=sys.stdin,
+    help="A TSV of incoming metadata.")
+parser.add_argument("--config",
+    default=base / "new-sequence-alerts-config.json",
+    help="A config file declaring which users want to be notified of new strains in which areas.")
+
+args = parser.parse_args()
+
+with open(args.config, 'r') as f:
+    config = json.load(f)
+
+incoming_metadata = pd.read_csv(args.incoming_metadata, sep='\t')
+new_areas = create_new_areas_lists(incoming_metadata)
+
+for entry in config:
+    alert_user_of_new_strains(entry, new_areas)

--- a/new-sequence-alerts-config.json
+++ b/new-sequence-alerts-config.json
@@ -1,0 +1,8 @@
+[{
+    "user": "Kairsten",
+    "slack_member_id": "UHE6TH9EE",
+    "region": [],
+    "country": [],
+    "division": [],
+    "location": ["Seattle"]
+}]


### PR DESCRIPTION
Notify certain users of new GISAID data from specified location hierarchy areas of interest. 
Resolves #79.

Open questions:
* What should this config JSON be called?
* What's the best place for this new config JSON to live?
* Where's the best place to document instructions for retrieving a Slack member ID? The README? 