### PR TITLE
Local GISAID ingest script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ ncov/
 Icon?
 ehthumbs.db
 Thumbs.db
+
+.env

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -95,9 +95,10 @@ download-gisaid() {
     --directory-prefix="${TMP_DIR}" \
     --http-user="${GISAID_USERNAME}" \
     --http-password="${GISAID_PASSWORD}" \
-    "${GISAID_URL}"
+    "${GISAID_URL}" \
+    -O "${TMP_DIR}/gisaid.ndjson.bz2"
 
-  bzip2 -cdk "${TMP_DIR}/corona2020_fulldump.json.bz2" > "${GISAID_NDJSON}"
+  bzip2 -cdk "${TMP_DIR}/gisaid.ndjson.bz2" > "${GISAID_NDJSON}"
 }
 
 ingest() {

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -25,7 +25,7 @@ main() {
   ADDITIONAL_INFO_NEW="${OUTPUT_DIR}/additional_info.tsv"
   ADDITIONAL_INFO_CHANGES="${OUTPUT_DIR}/additional-info-changes.txt"
 
-  LOCATION_HIERARCHY_NEW="${INPUT_DIR}/location_hierarchy.tsv"
+  LOCATION_HIERARCHY_NEW="${OUTPUT_DIR}/location_hierarchy.tsv"
   LOCATION_HIERARCHY_REFERENCE="source-data/location_hierarchy.tsv"
   LOCATION_HIERARCHY_ADDITIONS="${OUTPUT_DIR}/location-hierarchy-additions.tsv"
 

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -23,8 +23,11 @@ trap "exit" INT
 
 set -x
 
+TMP_DIR="data/gisaid/tmp"
 INPUT_DIR="data/gisaid/inputs"
 OUTPUT_DIR="data/gisaid/outputs"
+
+GISAID_NDJSON="${INPUT_DIR}/gisaid.ndjson"
 
 METADATA_OLD="${INPUT_DIR}/metadata.tsv"
 METADATA_NEW="${OUTPUT_DIR}/metadata.tsv"
@@ -56,6 +59,10 @@ main() {
       download-inputs
       exit
       ;;
+    --download-gisaid)
+      download-gisaid
+      exit
+      ;;
     --ingest)
       ingest
       exit
@@ -75,6 +82,22 @@ download-inputs() {
 
   aws s3 cp "${S3_BUCKET}/additional_info.tsv.gz" - | gunzip -cq >"data/gisaid/inputs/additional_info.tsv"
   aws s3 cp "${S3_BUCKET}/metadata.tsv.gz" - | gunzip -cq >"data/gisaid/inputs/metadata.tsv"
+}
+
+download-gisaid() {
+  [ -f ".env" ] && source ".env"
+  [ -f "../.env" ] && source "../.env"
+
+  mkdir -p "${INPUT_DIR}"
+  mkdir -p "${TMP_DIR}"
+
+  wget \
+    --directory-prefix="${TMP_DIR}" \
+    --http-user="${GISAID_USERNAME}" \
+    --http-password="${GISAID_PASSWORD}" \
+    "${GISAID_URL}"
+
+  bzip2 -cdk "${TMP_DIR}/corona2020_fulldump.json.bz2" > "${GISAID_NDJSON}"
 }
 
 ingest() {

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -1,4 +1,20 @@
 #!/usr/bin/env bash
+# usage: local-ingest-gisaid [flags]
+#        local-ingest-gisaid --help
+#
+# flags:
+#
+#  --help             Print this help message
+#
+#  --download-inputs  Download required input files from AWS S3 bucket
+#                     (Note: required gisaid.ndjson file should be downloaded
+#                     separately)
+#
+#  --ingest           Run ingest scripts offline locally. This will take input
+#                     files, perform transformations and will write output files
+#
+#  --upload-outputs   Upload output files to AWS S3 bucket
+#
 
 set -o errexit
 set -o nounset
@@ -10,26 +26,59 @@ set -x
 INPUT_DIR="data/gisaid/inputs"
 OUTPUT_DIR="data/gisaid/outputs"
 
+METADATA_OLD="${INPUT_DIR}/metadata.tsv"
+METADATA_NEW="${OUTPUT_DIR}/metadata.tsv"
+METADATA_CHANGES="${OUTPUT_DIR}/metadata-changes.txt"
+METADATA_ADDITIONS="${OUTPUT_DIR}/metadata-additions.tsv"
+
+ADDITIONAL_INFO_OLD="${INPUT_DIR}/additional_info.tsv"
+ADDITIONAL_INFO_NEW="${OUTPUT_DIR}/additional_info.tsv"
+ADDITIONAL_INFO_CHANGES="${OUTPUT_DIR}/additional-info-changes.txt"
+
+LOCATION_HIERARCHY_NEW="${OUTPUT_DIR}/location_hierarchy.tsv"
+LOCATION_HIERARCHY_REFERENCE="source-data/location_hierarchy.tsv"
+LOCATION_HIERARCHY_ADDITIONS="${OUTPUT_DIR}/location-hierarchy-additions.tsv"
+
+S3_BUCKET="s3://nextstrain-ncov-private"
+
+KEY="gisaid_epi_isl"
+
 main() {
   cd "$(dirname "$0")/.."
 
+  for arg; do
+    case "$arg" in
+    -h | --help)
+      print-help
+      exit
+      ;;
+    --download-inputs)
+      download-inputs
+      exit
+      ;;
+    --ingest)
+      ingest
+      exit
+      ;;
+    --upload-outputs)
+      upload-outputs
+      exit
+      ;;
+    esac
+  done
+
+  print-help
+}
+
+download-inputs() {
   mkdir -p "${INPUT_DIR}"
+
+  aws s3 cp "${S3_BUCKET}/additional_info.tsv.gz" - | gunzip -cq >"data/gisaid/inputs/additional_info.tsv"
+  aws s3 cp "${S3_BUCKET}/metadata.tsv.gz" - | gunzip -cq >"data/gisaid/inputs/metadata.tsv"
+}
+
+ingest() {
   mkdir -p "${OUTPUT_DIR}"
-
-  METADATA_OLD="${INPUT_DIR}/metadata.tsv"
-  METADATA_NEW="${OUTPUT_DIR}/metadata.tsv"
-  METADATA_CHANGES="${OUTPUT_DIR}/metadata-changes.txt"
-  METADATA_ADDITIONS="${OUTPUT_DIR}/metadata-additions.tsv"
-
-  ADDITIONAL_INFO_OLD="${INPUT_DIR}/additional_info.tsv"
-  ADDITIONAL_INFO_NEW="${OUTPUT_DIR}/additional_info.tsv"
-  ADDITIONAL_INFO_CHANGES="${OUTPUT_DIR}/additional-info-changes.txt"
-
-  LOCATION_HIERARCHY_NEW="${OUTPUT_DIR}/location_hierarchy.tsv"
-  LOCATION_HIERARCHY_REFERENCE="source-data/location_hierarchy.tsv"
-  LOCATION_HIERARCHY_ADDITIONS="${OUTPUT_DIR}/location-hierarchy-additions.tsv"
-
-  KEY="gisaid_epi_isl"
 
   ./bin/transform-gisaid "${INPUT_DIR}/gisaid.ndjson" \
     --output-metadata "${OUTPUT_DIR}/metadata.tsv" \
@@ -63,6 +112,29 @@ main() {
     <(sort "${LOCATION_HIERARCHY_REFERENCE}") \
     <(sort "${LOCATION_HIERARCHY_NEW}") \
     >"${LOCATION_HIERARCHY_ADDITIONS}"
+}
+
+upload-outputs() {
+  ./bin/upload-to-s3 "${OUTPUT_DIR}/metadata.tsv" "${S3_BUCKET}/metadata.tsv.gz"
+  ./bin/upload-to-s3 "${OUTPUT_DIR}/additional_info.tsv" "${S3_BUCKET}/additional_info.tsv.gz"
+  ./bin/upload-to-s3 "${OUTPUT_DIR}/flagged_metadata.txt" "${S3_BUCKET}/flagged_metadata.txt.gz"
+  ./bin/upload-to-s3 "${OUTPUT_DIR}/sequences.fasta" "${S3_BUCKET}/sequences.fasta.gz"
+}
+
+print-help() {
+  # Print the help comments at the top of this file ($0)
+  local line
+  while read -r line; do
+    if [[ $line =~ ^#! ]]; then
+      continue
+    elif [[ $line =~ ^# ]]; then
+      line="${line/##/}"
+      line="${line/# /}"
+      echo "$line"
+    else
+      break
+    fi
+  done <"$0"
 }
 
 main "$@"

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+trap "exit" INT
+
+set -x
+
+INPUT_DIR="data/gisaid/inputs"
+OUTPUT_DIR="data/gisaid/outputs"
+
+main() {
+  cd "$(dirname "$0")/.."
+
+  mkdir -p "${INPUT_DIR}"
+  mkdir -p "${OUTPUT_DIR}"
+
+  METADATA_OLD="${INPUT_DIR}/metadata.tsv"
+  METADATA_NEW="${OUTPUT_DIR}/metadata.tsv"
+  METADATA_CHANGES="${OUTPUT_DIR}/metadata-changes.txt"
+  METADATA_ADDITIONS="${OUTPUT_DIR}/metadata-additions.tsv"
+
+  ADDITIONAL_INFO_OLD="${INPUT_DIR}/additional_info.tsv"
+  ADDITIONAL_INFO_NEW="${OUTPUT_DIR}/additional_info.tsv"
+  ADDITIONAL_INFO_CHANGES="${OUTPUT_DIR}/additional-info-changes.txt"
+
+  LOCATION_HIERARCHY_NEW="${INPUT_DIR}/location_hierarchy.tsv"
+  LOCATION_HIERARCHY_REFERENCE="source-data/location_hierarchy.tsv"
+  LOCATION_HIERARCHY_ADDITIONS="${OUTPUT_DIR}/location-hierarchy-additions.tsv"
+
+  KEY="gisaid_epi_isl"
+
+  ./bin/transform-gisaid "${INPUT_DIR}/gisaid.ndjson" \
+    --output-metadata "${OUTPUT_DIR}/metadata.tsv" \
+    --output-fasta "${OUTPUT_DIR}/sequences.fasta" \
+    --output-additional-info "${OUTPUT_DIR}/additional_info.tsv"
+
+  csv-diff \
+    "${METADATA_OLD}" \
+    "${METADATA_NEW}" \
+    --format tsv \
+    --key "$KEY" \
+    --singular sequence \
+    --plural sequences \
+    >"${METADATA_CHANGES}"
+
+  ./bin/metadata-additions "${METADATA_OLD}" "${METADATA_NEW}" "${KEY}" >"${METADATA_ADDITIONS}"
+
+  csv-diff \
+    <(awk 'BEGIN {FS="\t"}; { if ($3 != "" || $4 != "") { print }}' "${ADDITIONAL_INFO_OLD}") \
+    <(awk 'BEGIN {FS="\t"}; { if ($3 != "" || $4 != "") { print }}' "${ADDITIONAL_INFO_NEW}") \
+    --format tsv \
+    --key "${KEY}" \
+    --singular "additional info" \
+    --plural "additional info" \
+    >${ADDITIONAL_INFO_CHANGES}
+
+  ./bin/flag-metadata "${OUTPUT_DIR}/metadata.tsv" >"${OUTPUT_DIR}/flagged_metadata.txt"
+  ./bin/check-locations "${OUTPUT_DIR}/metadata.tsv" "${OUTPUT_DIR}/location_hierarchy.tsv" "gisaid_epi_isl"
+
+  comm -13 \
+    <(sort "${LOCATION_HIERARCHY_REFERENCE}") \
+    <(sort "${LOCATION_HIERARCHY_NEW}") \
+    >"${LOCATION_HIERARCHY_ADDITIONS}"
+}
+
+main "$@"


### PR DESCRIPTION
### Description of proposed changes    

This adds local, offline script for GISAID ingest.


### Related issue(s)  

This script is meant to be a temporary replacement for the currently non-functional ingest Github Action.


### Testing

The workflow should be roughly as follows:


1 .Download input files from S3 (these are the "rolling" results of the previous ingest):

```
./bin/local-ingest-gisaid --download-inputs
```

The following files will be downloaded:

```
data/gisaid/inputs/metadata.tsv
data/gisaid/inputs/additional_info.tsv
```

2. Download fresh GISAID data

Create a file `.env` in the directory one level above the project. For example, if your project is in  `~/work/ncov-ingest`, make a file `~/work/.env`. Define the following variables in it:

```
GISAID_URL=
GISAID_USERNAME=
GISAID_PASSWORD=
```
(make sure you don't loose or accidentally commit this sensitive information anywhere)

Run:

```
./bin/local-ingest-gisaid --download-gisaid
```

The following files will appear:

```
data/gisaid/tmp/gisaid.ndjson.bz2
data/gisaid/inputs/gisaid.ndjson
```

2.5. Optionally, remove or move the previous outputs:

```
rm -rf data/gisaid/outputs
# or
mv data/gisaid/outputs{,_}

```


3. Run ingest

```
./bin/local-ingest-gisaid --ingest
```

Note: that this part of the script does not use network or any cloud storage. It is currently does not send the Slack notifications either.

Note: additionally do downloaded inputs, files in `source-data/` are also used during ingest.

The results will be produced in `data/gisaid/outputs/`:

```
additional-info-changes.txt
additional_info.tsv
flagged_metadata.txt
location-hierarchy-additions.tsv
location_hierarchy.tsv
metadata-additions.tsv
metadata-changes.txt
metadata.tsv
sequences.fasta

```

4. Perform the usual cleanup and build shepherding. You don't have to commit and push changes to files in `source-data/` to GitHub for the local ingest to be operational. However, it is a good idea to share these changes with the world when you are done.

5. Re-run ingest (3) with cleaned data if needed. You can re-run as many times as you want. Your changes stay on your machine.

6. Upload the new results to S3 bucket:

```
./bin/local-ingest-gisaid --upload-outputs
```

The following files will be uploaded:

```
metadata.tsv
additional_info.tsv
flagged_metadata.txt
sequences.fasta
```

Now the ncov build can be triggered as usual.

Don't forget to update GitHub with the results of your work in (5)


