### PR TITLE
Faster transform-gisaid

### DIFF
--- a/bin/ingest-gisaid
+++ b/bin/ingest-gisaid
@@ -76,9 +76,11 @@ main() {
         aws s3 cp --no-progress "$S3_DST/gisaid.ndjson.gz" - | gunzip -cfq > data/gisaid.ndjson
     fi
 
+    flagged_annotations="$(mktemp -t flagged-annotations-XXXXXX)"
+    trap "rm -f '$flagged_annotations'" EXIT
     ./bin/transform-gisaid data/gisaid.ndjson \
-      --output-metadata data/gisaid/metadata.tsv \
-      --output-fasta data/gisaid/sequences.fasta
+        --output-metadata data/gisaid/metadata.tsv \
+        --output-fasta data/gisaid/sequences.fasta > "$flagged_annotations"
 
     ./bin/flag-metadata data/gisaid/metadata.tsv > data/gisaid/flagged_metadata.txt
     ./bin/check-locations data/gisaid/metadata.tsv \
@@ -86,6 +88,7 @@ main() {
         gisaid_epi_isl
 
     if [[ "$branch" == master ]]; then
+        ./bin/notify-slack --upload "flagged-annotations" < "$flagged_annotations"
         ./bin/notify-on-metadata-change data/gisaid/metadata.tsv "$S3_SRC/metadata.tsv.gz" gisaid_epi_isl
         ./bin/notify-on-additional-info-change data/gisaid/additional_info.tsv "$S3_SRC/additional_info.tsv.gz"
         ./bin/notify-on-flagged-metadata-change data/gisaid/flagged_metadata.txt "$S3_SRC/flagged_metadata.txt.gz"

--- a/bin/transform-gisaid
+++ b/bin/transform-gisaid
@@ -1,19 +1,33 @@
 #!/usr/bin/env python3
 """
-Parse the GISAID JSON load into a metadata tsv and a FASTA file.
+Parse the GISAID NDJSON load into a metadata tsv and a FASTA file.
 """
 import argparse
+import csv
 import sys
+from collections import defaultdict
 from pathlib import Path
-import pandas as pd
+from typing import Any, Dict, List, Tuple
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
 from utils.transform import (
     METADATA_COLUMNS,
-    standardize_dataframe,
-    fill_default_geo_metadata,
-    write_fasta_file,
-    titlecase,
+)
+from utils.transformpipeline import LINE_NUMBER_KEY
+from utils.transformpipeline.datasource import LineToJsonDataSource
+from utils.transformpipeline.filters import LineNumberFilter, SequenceLengthFilter
+from utils.transformpipeline.transforms import (
+    AbbreviateAuthors,
+    AddHardcodedMetadata,
+    DropSequenceData,
+    ExpandLocation,
+    FillDefaultLocationData,
+    FixLabs,
+    MergeUserAnnotatedMetadata,
+    ParsePatientAge,
+    ParseSex,
+    RenameAndAddColumns,
+    StandardizeData,
 )
 
 # Preserve the ordering of these columns for ease when generating Slack
@@ -23,196 +37,9 @@ ADDITIONAL_INFO_COLUMNS = [
     'additional_location_info'
 ]
 
+
 assert 'sequence' not in METADATA_COLUMNS, "Sequences should not appear in metadata!"
 assert 'sequence' not in ADDITIONAL_INFO_COLUMNS, "Sequences should not appear in additional info!"
-
-def preprocess(gisaid_data: pd.DataFrame) -> pd.DataFrame:
-    """
-    Renames columns and abbreviate strain name in a given *gisaid_data*
-    DataFrame, returning the modified DataFrame.
-    """
-    mapper = {
-        'covv_virus_name'       : 'strain',
-        'covv_accession_id'     : 'gisaid_epi_isl',
-        'covv_collection_date'  : 'date',
-        'covv_host'             : 'host',
-        'covv_orig_lab'         : 'originating_lab',
-        'covv_subm_lab'         : 'submitting_lab',
-        'covv_authors'          : 'authors',
-        'covv_patient_age'      : 'age',
-        'covv_gender'           : 'sex',
-        'covv_lineage'          : 'pangolin_lineage',
-        'covv_clade'            : 'GISAID_clade',
-        'covv_add_host_info'    : 'additional_host_info',
-        'covv_add_location'     : 'additional_location_info',
-        'covv_subm_date'        : 'date_submitted',
-        'covv_location'         : 'location',
-    }
-
-    # Calculate sequence length.  GISAID provides a "sequence_length" column,
-    # but it sometimes inexplicably goes missing.
-    gisaid_data['sequence'] = gisaid_data['sequence'].str.replace('\n', '')
-    gisaid_data['length'] = gisaid_data['sequence'].str.len().astype("Int64")
-
-    # Standardize column names, dtypes and drop entries with length less than 15kb
-    gisaid_data = standardize_dataframe(gisaid_data, mapper)
-
-    # Abbreviate strain names by removing the prefix. Strip spaces, too.
-    gisaid_data['strain'] = gisaid_data['strain'] \
-        .str.replace(r'^[hn]CoV-19/', '', n=1, case=False) \
-        .str.replace(r'\s', '')
-
-    # Drop duplicates, prefer longest and earliest sequence (assuming accessions
-    # are chronological)
-    gisaid_data.sort_values(['strain', 'length', 'gisaid_epi_isl'],
-        ascending=[True, False, True], inplace=True)
-
-    gisaid_data.drop_duplicates('strain', inplace=True)
-
-    # Sort by strain name
-    gisaid_data.sort_values(by=['strain'], inplace=True)
-
-    return gisaid_data
-
-def parse_geographic_columns(gisaid_data: pd.DataFrame) -> pd.DataFrame:
-    """
-    Expands the string found in the column named `location` in the given
-    *df*, creating four new columns. Returns the modified ``pd.DataFrame``.
-    """
-    geographic_data = gisaid_data['location'].str.split(r'\s*/\s*', expand=True)
-    location_columns = ['region', 'country', 'division', 'location']
-
-    # Manually curate set of tokens that should not be cast to title case
-    articles = {
-        'and', 'de', 'del', 'des', 'di', 'do', 'en', 'l', 'la', 'las', 'le', 'los',
-        'nad', 'of', 'op', 'sur', 'the', 'y'
-    }
-    abbrev = {'USA', 'DC'}
-
-    for index, column in enumerate(location_columns):
-        gisaid_data[column] = geographic_data[index] \
-            .str.replace('_', ' ') \
-            .str.strip() \
-            .apply(lambda text: titlecase(text, articles, abbrev))
-
-    return gisaid_data
-
-def parse_originating_lab(gisaid_data: pd.DataFrame) -> pd.DataFrame:
-    """
-    Parses originating lab
-    """
-    # Strip and normalize whitespace
-    gisaid_data['originating_lab'] = gisaid_data['originating_lab'].str.replace(r'\s+', ' ')
-    # Fix common spelling mistakes
-    gisaid_data['originating_lab'] = gisaid_data['originating_lab'].str.replace('Contorl', 'Control')
-    gisaid_data['originating_lab'] = gisaid_data['originating_lab'].str.replace('Dieases', 'Disease')
-    return gisaid_data
-
-def parse_submitting_lab(gisaid_data: pd.DataFrame) -> pd.DataFrame:
-    """
-    Parses submitting lab
-    """
-    # Strip and normalize whitespace
-    gisaid_data['submitting_lab'] = gisaid_data['submitting_lab'].str.replace(r'\s+', ' ')
-    # Fix common spelling mistakes
-    gisaid_data['submitting_lab'] = gisaid_data['submitting_lab'].str.replace('Contorl', 'Control')
-    gisaid_data['submitting_lab'] = gisaid_data['submitting_lab'].str.replace('Dieases', 'Disease')
-    return gisaid_data
-
-def parse_authors(gisaid_data: pd.DataFrame) -> pd.DataFrame:
-    """
-    Abbreviates the column named `authors` to be "<first author> et al" rather
-    than a full list.
-
-    This is a "best effort" approach and still mangles a bunch of things.
-    Without structured author list data, improvements to the automatic parsing
-    meet diminishing returns quickly.  Further improvements should be
-    considered using manual annotations of an author map (separate from our
-    existing corrections/annotations).
-    """
-    # Strip and normalize whitespace
-    gisaid_data['authors'] = gisaid_data['authors'].str.replace(r'\s+', ' ')
-    # Split to first author as best we can for now.  Both commas and semicolons
-    # (and their full-width forms) appear to be used interchangeably without a
-    # difference of meaning.
-    gisaid_data['authors'] = gisaid_data['authors'].str.split(r'(?:\s*[,，;；]\s*|\s+(?:and|&)\s+)').str[0]
-    # Add et al
-    gisaid_data['authors'] = gisaid_data['authors'].astype(str) + ' et al'
-    return gisaid_data
-
-def parse_age(gisaid_data: pd.DataFrame) -> pd.DataFrame:
-    """
-    Parse patient age.
-    """
-    # Convert "60s" or "50's" to "?"
-    gisaid_data['age'] = gisaid_data['age'].str.replace(r"^\d+\'?[A-Za-z]", '?')
-    # Convert to just number
-    gisaid_data['age'] = gisaid_data['age'].str.replace(r"^(\d+) years$", lambda m: m.group(1))
-    # Convert months to years
-    gisaid_data['age'] = gisaid_data['age'].str.replace(r"^(\d+) months", lambda m: str(int(m.group(1))/12.0))
-    # Cleanup unknowns
-    gisaid_data['age'] = gisaid_data['age'].str.replace(r"^0$", '?')
-    # Catch all non-numeric values
-    gisaid_data['age'] = pd.to_numeric(gisaid_data['age'], errors='coerce').fillna('?')
-    # Convert numeric values to int
-    gisaid_data['age'] = gisaid_data['age'].apply(lambda x: x if x=='?' else int(x))
-    return gisaid_data
-
-def parse_sex(gisaid_data: pd.DataFrame) -> pd.DataFrame:
-    """
-    Parse patient sex.
-    """
-    # Casing and abbreviations
-    gisaid_data['sex'] = gisaid_data['sex'].str.replace(r"^male$", 'Male')
-    gisaid_data['sex'] = gisaid_data['sex'].str.replace(r"^M$", 'Male')
-    gisaid_data['sex'] = gisaid_data['sex'].str.replace(r"^female$", 'Female')
-    gisaid_data['sex'] = gisaid_data['sex'].str.replace(r"^F$", 'Female')
-    # Fix spelling
-    gisaid_data['sex'] = gisaid_data['sex'].str.replace(r"^Femal$", 'Female')
-    # Cleanup unknowns
-    gisaid_data['sex'] = gisaid_data['sex'].str.replace(r"^unknown$", '?')
-    gisaid_data['sex'] = gisaid_data['sex'].str.replace(r"^N/A$", '?')
-    gisaid_data['sex'] = gisaid_data['sex'].str.replace(r"^NA$", '?')
-    gisaid_data['sex'] = gisaid_data['sex'].str.replace(r"^not applicable$", '?')
-    return gisaid_data
-
-def generate_hardcoded_metadata(hardcoded_metadata: pd.DataFrame) -> pd.DataFrame:
-    """
-    Returns a ``pd.DataFrame`` with a column for strain ID plus additional
-    columns containing harcoded metadata.
-    """
-    hardcoded_metadata = pd.DataFrame(gisaid_data['strain'])
-    hardcoded_metadata['virus']             = 'ncov'
-    hardcoded_metadata['genbank_accession'] = '?'
-    hardcoded_metadata['url']               = 'https://www.gisaid.org'
-    # TODO verify these are all actually true
-    hardcoded_metadata['segment']           = 'genome'
-    hardcoded_metadata['title']             = '?'
-    hardcoded_metadata['paper_url']         = '?'
-
-    return hardcoded_metadata
-
-
-def update_metadata(curated_gisaid_data: pd.DataFrame) -> pd.DataFrame:
-    """ """
-    # Add hardcoded metadata which is *almost* always true
-    hardcoded_metadata = generate_hardcoded_metadata(curated_gisaid_data)
-    curated_gisaid_data.update(hardcoded_metadata)
-    curated_gisaid_data = curated_gisaid_data.merge(hardcoded_metadata)
-
-    if args.annotations:
-        # Use the curated annotations tsv to update any column values
-        user_provided_annotations = pd.read_csv(args.annotations, header=None, sep='\t', comment="#")
-        for index, (strain, epi_isl, key, value) in user_provided_annotations.iterrows():
-            # Strip any whitespace remaining from inline comments after the final column.
-            if isinstance(value, str):
-                value = value.rstrip()
-            curated_gisaid_data.loc[curated_gisaid_data['gisaid_epi_isl'] == epi_isl, key] = value
-
-    # Fill in blank geographic columns with exisiting geographic data
-    curated_gisaid_data = fill_default_geo_metadata(curated_gisaid_data)
-
-    return curated_gisaid_data
 
 
 if __name__ == '__main__':
@@ -224,7 +51,6 @@ if __name__ == '__main__':
     )
     parser.add_argument("gisaid_data",
         default="s3://nextstrain-ncov-private/gisaid.ndjson.gz",
-        nargs="?",
         help="Newline-delimited GISAID JSON data")
     parser.add_argument("--annotations",
         default=base / "source-data/gisaid_annotations.tsv",
@@ -249,25 +75,123 @@ if __name__ == '__main__':
     parser.add_argument("--output-additional-info",
         default=base / "data/gisaid/additional_info.tsv",
         help="Output location of additional info tsv. Defaults to `data/gisaid/additional_info.tsv`")
+    parser.add_argument("--sorted-fasta", action="store_true",
+        help="Sort the fasta file in the same order as the metadata file.  WARNING: Enabling this option can consume a lot of memory.")
+    parser.add_argument(
+        "--output-unix-newline",
+        dest="newline",
+        action="store_const",
+        const="\n",
+        default=None,
+        help="When specified, always use unix newlines in output files."
+    )
     args = parser.parse_args()
 
+    annotations: Dict[str, List[Tuple[str, Any]]] = defaultdict(list)
+    if args.annotations:
+        # Use the curated annotations tsv to update any column values
+        with open(args.annotations, "r") as gisaid_fh:
+            csvreader = csv.reader(gisaid_fh, delimiter='\t')
+            for row in csvreader:
+                if len(row) != 4:
+                    # ensure that it's a comment
+                    if row[0].lstrip()[0] != '#':
+                        print("WARNING: couldn't decode annotation line " + "\t".join(row))
+                    continue
+                strain, epi_isl, key, value = row
+                annotations[epi_isl].append((
+                    key,
+                    # remove the comment and the extra ws from the value
+                    value.split('#')[0].rstrip(),
+                ))
 
-    gisaid_data = pd.read_json(args.gisaid_data, lines=True, compression='infer')
-    gisaid_data = preprocess(gisaid_data)
-    write_fasta_file(gisaid_data, args.output_fasta)
+    with open(args.gisaid_data, "r") as gisaid_fh:
+        pipeline = (
+            LineToJsonDataSource(gisaid_fh)
+            | RenameAndAddColumns()
+            | StandardizeData()
+            | SequenceLengthFilter(15000)
+        )
 
-    gisaid_data = parse_geographic_columns(gisaid_data)
-    gisaid_data = parse_originating_lab(gisaid_data)
-    gisaid_data = parse_submitting_lab(gisaid_data)
-    gisaid_data = parse_authors(gisaid_data)
-    gisaid_data = parse_age(gisaid_data)
-    gisaid_data = parse_sex(gisaid_data)
-    gisaid_data = update_metadata(gisaid_data)
+        if not args.sorted_fasta:
+            pipeline = pipeline | DropSequenceData()
 
-    # Export additional info
-    gisaid_data[ADDITIONAL_INFO_COLUMNS] \
-        .to_csv(args.output_additional_info, sep='\t', na_rep='?', index=False)
+        pipeline = (
+            pipeline
+            | ExpandLocation()
+            | FixLabs()
+            | AbbreviateAuthors()
+            | ParsePatientAge()
+            | ParseSex()
+            | AddHardcodedMetadata()
+            | MergeUserAnnotatedMetadata(annotations)
+            | FillDefaultLocationData()
+        )
 
-    # Reorder columns consistent with the existing metadata on GitHub
-    gisaid_data = gisaid_data[METADATA_COLUMNS]
-    gisaid_data.to_csv(args.output_metadata, sep='\t', na_rep='', index=False)
+        sorted_metadata = sorted(
+            pipeline,
+            key=lambda obj: (
+                obj['strain'],
+                -obj['length'],
+                obj['gisaid_epi_isl'],
+                obj[LINE_NUMBER_KEY]
+            )
+        )
+
+    # dedup by strain and compile a list of relevant line numbers.
+    seen_strains = set()
+    line_numbers = set()
+    for entry in sorted_metadata:
+        if entry['strain'] in seen_strains:
+            continue
+
+        seen_strains.add(entry['strain'])
+        line_numbers.add(entry[LINE_NUMBER_KEY])
+
+    with open(args.output_fasta, "wt", newline=args.newline) as fasta_fh:
+        with open(args.output_additional_info, "wt", newline="") as additional_info_fh, \
+             open(args.output_metadata, "wt", newline="") as metadata_fh:
+            dict_writer_kwargs = {}
+            if args.newline is not None:
+                dict_writer_kwargs['lineterminator'] = args.newline
+
+            # set up the CSV output files
+            additional_info_csv = csv.DictWriter(
+                additional_info_fh,
+                ADDITIONAL_INFO_COLUMNS,
+                restval="?",
+                extrasaction='ignore',
+                delimiter='\t',
+                **dict_writer_kwargs
+            )
+            additional_info_csv.writeheader()
+            metadata_csv = csv.DictWriter(
+                metadata_fh,
+                METADATA_COLUMNS,
+                restval="?",
+                extrasaction='ignore',
+                delimiter='\t',
+                **dict_writer_kwargs
+            )
+            metadata_csv.writeheader()
+
+            for entry in sorted_metadata:
+                if entry[LINE_NUMBER_KEY] in line_numbers:
+                    additional_info_csv.writerow(entry)
+                    metadata_csv.writerow(entry)
+
+                    if args.sorted_fasta:
+                        fasta_fh.write(f">{entry['strain']}\n")
+                        fasta_fh.write(f"{entry['sequence']}\n")
+
+        if not args.sorted_fasta:
+            with open(args.gisaid_data, "r") as gisaid_fh:
+                for entry in (
+                        LineToJsonDataSource(gisaid_fh)
+                        | RenameAndAddColumns()
+                        | StandardizeData()
+                        | SequenceLengthFilter(15000)
+                        | LineNumberFilter(line_numbers)
+                ):
+                    fasta_fh.write(f">{entry['strain']}\n")
+                    fasta_fh.write(f"{entry['sequence']}\n")

--- a/lib/utils/transformpipeline/__init__.py
+++ b/lib/utils/transformpipeline/__init__.py
@@ -1,0 +1,1 @@
+LINE_NUMBER_KEY = "__pipeline_lineno"

--- a/lib/utils/transformpipeline/_base.py
+++ b/lib/utils/transformpipeline/_base.py
@@ -1,0 +1,115 @@
+"""
+The classes in this module allow modular definitions of transformations and filters when
+processing a stream of data.  Most of the complexity is to allow for the simple
+representation of such streams.  An example might be:
+
+RenameColumns() | CalculateLength() | FilterBasedOnLength()
+
+A more vanilla implementation might be simpler, but is less intuitive to use:
+
+FilterBasedOnLength().process(CalculateLength().process(RenameColumns().process()))
+"""
+
+
+from abc import abstractmethod
+from typing import cast, Iterable, Iterator
+
+
+class PipelineException(Exception):
+    pass
+
+
+class DataSourceIterator(Iterator[dict]):
+    """A data source iterator represents the read marker for a stream
+    (i.e., an Iterable) of dicts."""
+    @abstractmethod
+    def raise_exception(self, exc: Exception) -> bool:
+        """Returns true if an exception should be raised."""
+        pass
+
+
+class DataSource(Iterable[dict]):
+    """A data source represents a stream (i.e., an Iterable) of dicts."""
+    def __or__(self, other):
+        return ChainedPipelineComponent(self, other)
+
+    @abstractmethod
+    def __iter__(self) -> DataSourceIterator:
+        pass
+
+
+class PipelineComponent:
+    """A pipeline component transforms an input stream of dicts to an output stream of
+    dicts.   Each pipeline component represents a step in the processing of gisaid data.
+    """
+    @abstractmethod
+    def process(self, iterator: Iterator[dict]) -> dict:
+        pass
+
+
+class ChainedPipelineComponentIterator(DataSourceIterator):
+    def __init__(
+            self,
+            data_source: DataSource,
+            pipe_component: PipelineComponent,
+    ):
+        self.data_source_iterator = cast(DataSourceIterator, iter(data_source))
+        self.pipe_component = pipe_component
+
+    def __next__(self) -> dict:
+        try:
+            return self.pipe_component.process(self.data_source_iterator)
+        except StopIteration:
+            raise
+        except PipelineException:
+            raise
+        except Exception as ex:
+            if self.data_source_iterator.raise_exception(ex):
+                raise
+
+    def raise_exception(self, exc: Exception) -> bool:
+        return self.data_source_iterator.raise_exception(exc)
+
+
+class ChainedPipelineComponent(DataSource):
+    """A chained pipeline component represents a data source and a pipeline component.
+    This itself is a data source that can be fed into the next pipeline component.
+    """
+    def __init__(
+            self,
+            data_source: DataSource,
+            pipe_component: PipelineComponent,
+    ):
+        self.data_source = data_source
+        self.pipe_component = pipe_component
+
+    def __iter__(self) -> DataSourceIterator:
+        return ChainedPipelineComponentIterator(self.data_source, self.pipe_component)
+
+
+class Transformer(PipelineComponent):
+    """A transformer is a pipeline component that transforms each value in the input
+    stream.  Implementations should implement `transform_value`, which takes a single
+    value in the stream an outputs the value."""
+    def process(self, iterator: Iterator[dict]) -> dict:
+        return self.transform_value(next(iterator))
+
+    @abstractmethod
+    def transform_value(self, entry: dict) -> dict:
+        pass
+
+
+class Filter(PipelineComponent):
+    """A filter is a pipeline component that tests whether each value in the input
+    stream should be in the output stream.  Implementations should implement
+    `test_value`, which should return True if the value should be in the output stream.
+    """
+    def process(self, iterator: Iterator[dict]) -> dict:
+        while True:
+            entry = next(iterator)
+            if self.test_value(entry):
+                return entry
+
+    @abstractmethod
+    def test_value(self, entry: dict) -> bool:
+        pass

--- a/lib/utils/transformpipeline/datasource.py
+++ b/lib/utils/transformpipeline/datasource.py
@@ -1,0 +1,28 @@
+import json
+from typing import Iterable
+
+from ._base import DataSource, DataSourceIterator, PipelineException
+
+
+class LineToJsonIterator(DataSourceIterator):
+    def __init__(self, lines: Iterable[str]):
+        self.lines_iter = iter(lines)
+        self.last_line = None
+        self.lines_exceptions_raised = set()
+
+    def __next__(self) -> dict:
+        self.last_line = next(self.lines_iter)
+        return json.loads(self.last_line)
+
+    def raise_exception(self, exc: Exception) -> bool:
+        raise PipelineException(f"Error parsing line:\n{self.last_line}")
+
+
+class LineToJsonDataSource(DataSource):
+    """This data source takes an iterable of json lines (i.e., ndjson) and produces
+    an iterator of parsed objects."""
+    def __init__(self, lines: Iterable[str]):
+        self.lines = lines
+
+    def __iter__(self) -> DataSourceIterator:
+        return LineToJsonIterator(self.lines)

--- a/lib/utils/transformpipeline/filters.py
+++ b/lib/utils/transformpipeline/filters.py
@@ -1,0 +1,20 @@
+from typing import Container
+
+from . import LINE_NUMBER_KEY
+from ._base import Filter
+
+
+class SequenceLengthFilter(Filter):
+    def __init__(self, min_length: int):
+        self.min_length = min_length
+
+    def test_value(self, inp: dict) -> bool:
+        return inp['length'] >= self.min_length
+
+
+class LineNumberFilter(Filter):
+    def __init__(self, line_numbers: Container[int]):
+        self.line_numbers = line_numbers
+
+    def test_value(self, inp: dict) -> bool:
+        return inp[LINE_NUMBER_KEY] in self.line_numbers

--- a/lib/utils/transformpipeline/transforms.py
+++ b/lib/utils/transformpipeline/transforms.py
@@ -1,0 +1,244 @@
+import re
+import unicodedata
+from typing import Any, Dict, Sequence, Tuple
+
+from utils.transform import format_date, titlecase
+from . import LINE_NUMBER_KEY
+from ._base import Transformer
+
+
+class RenameAndAddColumns(Transformer):
+    """This transformer applies the column renames as dictated by COLUMN_MAP."""
+
+    COLUMN_MAP = {
+        'covv_virus_name': 'strain',
+        'covv_accession_id': 'gisaid_epi_isl',
+        'covv_collection_date': 'date',
+        'covv_host': 'host',
+        'covv_orig_lab': 'originating_lab',
+        'covv_subm_lab': 'submitting_lab',
+        'covv_authors': 'authors',
+        'covv_patient_age': 'age',
+        'covv_gender': 'sex',
+        'covv_lineage': 'pangolin_lineage',
+        'covv_clade': 'GISAID_clade',
+        'covv_add_host_info': 'additional_host_info',
+        'covv_add_location': 'additional_location_info',
+        'covv_subm_date': 'date_submitted',
+        'covv_location': 'location',
+    }
+
+    def transform_value(self, entry: dict) -> dict:
+        for in_col, out_col in RenameAndAddColumns.COLUMN_MAP.items():
+            if in_col not in entry:
+                entry[out_col] = ""
+            else:
+                entry[out_col] = entry.pop(in_col)
+        return entry
+
+
+class StandardizeData(Transformer):
+    """This transformer standardizes the data format:
+
+    1. Removes newlines from the sequence and measures its length.
+    2. Strip whitespace and convert to Unicode Normalization Form C for all strings.
+    3. Standardize date formats.
+    4. Abbreviate and remove whitespace from strain names3
+    5. Add a line number.
+    """
+
+    def __init__(self):
+        self.line_count = 1
+
+    def transform_value(self, entry: dict) -> dict:
+        entry['sequence'] = entry['sequence'].replace('\n', '')
+        entry['length'] = len(entry['sequence'])
+
+        # Normalize all string data to Unicode Normalization Form C, for
+        # consistent, predictable string comparisons.
+        str_kvs = {
+            key: unicodedata.normalize('NFC', value).strip()
+            for key, value in entry.items()
+            if isinstance(value, str)
+        }
+        entry.update(str_kvs)
+
+        # Standardize date format to ISO 8601 date
+        date_columns = {'date', 'date_submitted'}
+        date_formats = {'%Y-%m-%d', '%Y-%m-%dT%H:%M:%SZ'}
+        for column in date_columns:
+            entry[column] = format_date(entry[column], date_formats)
+
+        # Abbreviate strain names by removing the prefix. Strip spaces, too.
+        entry['strain'] = re.sub(
+            r'(^[hn]CoV-19/)|\s+', '', entry['strain'], flags=re.IGNORECASE)
+
+        entry[LINE_NUMBER_KEY] = self.line_count
+        self.line_count += 1
+
+        return entry
+
+
+class DropSequenceData(Transformer):
+    """This transformer drops the sequence data.  This is necessary to read the entire
+    stream into memory to sort and deduplicate."""
+    def transform_value(self, entry: dict) -> dict:
+        entry.pop('sequence')
+        return entry
+
+
+class ExpandLocation(Transformer):
+    """
+    Expands the string found under the key `location`, creating four new values.
+    """
+    # Manually curate set of tokens that should not be cast to title case
+    ARTICLES = {
+        'and', 'de', 'del', 'des', 'di', 'do', 'en', 'l', 'la', 'las', 'le', 'los',
+        'nad', 'of', 'op', 'sur', 'the', 'y'
+    }
+    ABBREV = {'USA', 'DC'}
+    LOCATION_COLUMNS = ['region', 'country', 'division', 'location']
+
+    def transform_value(self, entry: dict) -> dict:
+        geographic_data = entry['location'].split(
+            '/',
+            maxsplit=len(ExpandLocation.LOCATION_COLUMNS))
+        geographic_data += [""] * (
+                len(ExpandLocation.LOCATION_COLUMNS) - len(geographic_data))
+
+        for index, column in enumerate(ExpandLocation.LOCATION_COLUMNS):
+            entry[column] = titlecase(
+                geographic_data[index]
+                .replace('_', ' ')
+                .strip(),
+                ExpandLocation.ARTICLES,
+                ExpandLocation.ABBREV,
+            )
+
+        return entry
+
+
+class FixLabs(Transformer):
+    """
+    Clean up and fix common spelling mistakes for labs.
+    """
+
+    def transform_value(self, entry: dict) -> dict:
+        for lab_key in ('originating_lab', 'submitting_lab'):
+            entry[lab_key] = FixLabs._cleanup_value(entry[lab_key])
+        return entry
+
+    @staticmethod
+    def _cleanup_value(val: str) -> str:
+        return (
+            re.sub(r'\s+', ' ', val)
+                .replace("Contorl", "Control")
+                .replace("Dieases", "Disease")
+        )
+
+
+class AbbreviateAuthors(Transformer):
+    """
+    Abbreviates the column named `authors` to be "<first author> et al" rather
+    than a full list.
+
+    This is a "best effort" approach and still mangles a bunch of things.
+    Without structured author list data, improvements to the automatic parsing
+    meet diminishing returns quickly.  Further improvements should be
+    considered using manual annotations of an author map (separate from our
+    existing corrections/annotations).
+    """
+    def transform_value(self, entry: dict) -> dict:
+        # Strip and normalize whitespace
+        entry['authors'] = re.sub(r'\s+', ' ', entry['authors'])
+        entry['authors'] = re.split(r'(?:\s*[,，;；]\s*|\s+(?:and|&)\s+)', entry['authors'])[0] + " et al"
+        return entry
+
+
+class ParsePatientAge(Transformer):
+    """
+    Parse patient age.
+    """
+    def transform_value(self, entry: dict) -> dict:
+        # Convert "60s" or "50's" to "?"
+        entry['age'] = re.sub(r'^\d+\'?[A-Za-z]', "?", entry['age'])
+        # Convert to just digit
+        entry['age'] = re.sub(r'^(\d+) years$', r'\1', entry['age'])
+        # Convert months to years
+        match = re.match(r'^(\d+) months', entry['age'])
+        if match:
+            entry['age'] = str(int(match.group(1)) / 12.0)
+        # Cleanup unknowns
+        entry['age'] = re.sub(r'^0$', '?', entry['age'])
+        # Convert numeric values to int and convert non-numeric values to "?"
+        try:
+            entry['age'] = int(float(entry['age']))
+        except ValueError:
+            entry['age'] = "?"
+        return entry
+
+
+class ParseSex(Transformer):
+    """
+    Parse patient sex.
+    """
+    def transform_value(self, entry: dict) -> dict:
+        # Casing, abbreviations, and spelling
+        entry['sex'] = re.sub(r"^(male|M)$", "Male", entry['sex'])
+        entry['sex'] = re.sub(r"^(female|F|Femal)$", "Female", entry['sex'])
+        # Cleanup unknowns
+        entry['sex'] = re.sub(r"^(unknown|N/A|NA|not applicable)$", "?", entry['sex'])
+        return entry
+
+
+class AddHardcodedMetadata(Transformer):
+    """
+    Adds a key-value for strain ID plus additional key-values containing harcoded
+    metadata.
+    """
+    def transform_value(self, entry: dict) -> dict:
+        entry['virus'] = 'ncov'
+        entry['genbank_accession'] = '?'
+        entry['url'] = 'https://www.gisaid.org'
+        # TODO verify these are all actually true
+        entry['segment'] = 'genome'
+        entry['title'] = '?'
+        entry['paper_url'] = '?'
+
+        return entry
+
+
+class MergeUserAnnotatedMetadata(Transformer):
+    """Use the curated annotations tsv to update any column values."""
+    def __init__(self, annotations: Dict[str, Sequence[Tuple[str, Any]]]):
+        self.annotations = annotations
+
+    def transform_value(self, entry: dict) -> dict:
+        annotations = self.annotations.get(entry['gisaid_epi_isl'], [])
+        for key, value in annotations:
+            entry[key] = value
+        return entry
+
+
+class FillDefaultLocationData(Transformer):
+    """
+    Fill in default geographic metadata based on existing metadata if they have not been
+    added by annotations.
+    """
+    def transform_value(self, entry: dict) -> dict:
+        # if division is blank, replace with country data, to avoid unexpected effects
+        # when subsampling by division (where an empty division is counted as a
+        # 'division' group)
+        if len(entry['division']) == 0:
+            entry['division'] = entry['country']
+
+        # Set `region_exposure` equal to `region` if it wasn't added by annotations
+        entry.setdefault('region_exposure', entry['region'])
+
+        # Set `country_exposure` equal to `country` if it wasn't added by annotations
+        entry.setdefault('country_exposure', entry['country'])
+
+        # Set `division_exposure` equal to `division` if it wasn't added by annotations
+        entry.setdefault('division_exposure', entry['division'])
+
+        return entry


### PR DESCRIPTION
Processing in transform-gisaid is represented as a pipeline of steps.  Each step either manipulates the data (`Transform`) or filters the data (`Filter`).  At the start of each pipeline is a `DataSource`.

To test this, I processed the same gisaid dataset with both the old script and the new script.  The key differences in the output are:

1. The new script does _not_, by default, sort the sequences before outputting.  It does perform the same deduplication process however.  To sort the sequence data, use the option `--sorted-fasta`.
2. The new script interprets errors in `source-data/gisaid_annotations.tsv` differently than the old script.  It ignores all rows that do not have four columns.  As a result, some annotations are not processed.

Additionally, there is the option `--output-unix-newline`, which forces all output (fasta files and metadata csv files) to use unix newlines.

Fixes https://github.com/nextstrain/ncov-ingest/issues/77

-------
originally opened as #88 by @ttung 