### PR TITLE
Fix how we process comment lines

### DIFF
--- a/bin/transform-gisaid
+++ b/bin/transform-gisaid
@@ -94,10 +94,10 @@ if __name__ == '__main__':
         with open(args.annotations, "r") as gisaid_fh:
             csvreader = csv.reader(gisaid_fh, delimiter='\t')
             for row in csvreader:
-                if len(row) != 4:
-                    # ensure that it's a comment
-                    if row[0].lstrip()[0] != '#':
-                        print("WARNING: couldn't decode annotation line " + "\t".join(row))
+                if row[0].lstrip()[0] == '#':
+                    continue
+                elif len(row) != 4:
+                    print("WARNING: couldn't decode annotation line " + "\t".join(row))
                     continue
                 strain, epi_isl, key, value = row
                 annotations[epi_isl].append((


### PR DESCRIPTION
### Description of proposed changes
We were only detecting comment lines if it didn't resolve into four columns.  This changes the ordering -- first detect whether it is a comment, and only then do we continue processing.

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #95
