### PR TITLE
Add nextstrain clades to metadata (version for running locally)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ ehthumbs.db
 Thumbs.db
 
 .env
+tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ ncov/
 Icon?
 ehthumbs.db
 Thumbs.db
+
+.env

--- a/bin/filter-fasta
+++ b/bin/filter-fasta
@@ -31,16 +31,13 @@ def main():
     args = parse_args()
 
     tsv = pd.read_csv(args.input_tsv, sep="\t")
-    tsv_ids = list(tsv['seqName'])
+    tsv_ids = set(tsv['seqName'])
 
-    result = []
     with open(args.input_fasta) as f_input:
-        for seq in SeqIO.parse(f_input, "fasta"):
-            if seq.id not in tsv_ids:
-                result.append(seq)
-
-    with open(args.output_fasta, "w") as f_output:
-        SeqIO.write(result, f_output, "fasta")
+        with open(args.output_fasta, "w") as f_output:
+            for seq in SeqIO.parse(f_input, "fasta"):
+                if seq.id not in tsv_ids:
+                    SeqIO.write(seq, f_output, "fasta")
 
 
 if __name__ == '__main__':

--- a/bin/filter-fasta
+++ b/bin/filter-fasta
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import argparse
+
+import pandas as pd
+from Bio import SeqIO
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="\
+Produces a FASTA FILE containing sequences present in the input FASTA file, \
+but missing the input TSV file. This is useful in order to find which sequences require additional treatment. \
+")
+    parser.add_argument(
+        "--input_fasta",
+        required=True,
+        help="Path to the input FASTA file.")
+    parser.add_argument(
+        "--input_tsv",
+        required=True,
+        help="Path to the input TSV file."
+    )
+    parser.add_argument(
+        "--output_fasta",
+        required=True,
+        help="Path to the output FASTA file."
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    tsv = pd.read_csv(args.input_tsv, sep="\t")
+    tsv_ids = list(tsv['seqName'])
+
+    result = []
+    with open(args.input_fasta) as f_input:
+        for seq in SeqIO.parse(f_input, "fasta"):
+            if seq.id not in tsv_ids:
+                result.append(seq)
+
+    with open(args.output_fasta, "w") as f_output:
+        SeqIO.write(result, f_output, "fasta")
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/gisaid-get-all-clades
+++ b/bin/gisaid-get-all-clades
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+trap "exit" INT
+
+# Get .ndjson
+./bin/local-ingest-gisaid --download-gisaid
+
+# Convert .ndjson into big `sequences.fasta` and `metadata.tsv`
+./bin/local-ingest-gisaid --transform
+
+# Run nextclade in parallel batches from `sequences.fasta`, produce `nextclade.clades.tsv`
+./bin/run-nextclade \
+  "data/gisaid/outputs/sequences.fasta" \
+  "data/gisaid/outputs/nextclade.clades.tsv"
+
+# Join `metadata.tsv` and `nextclade.clades.tsv`, produce `metadata2.tsv`
+./bin/join-metadata-and-clades \
+  "data/gisaid/outputs/metadata.tsv" \
+  "data/gisaid/outputs/nextclade.clades.tsv" \
+  -o "data/gisaid/outputs/metadata2.tsv"

--- a/bin/gisaid-get-all-clades
+++ b/bin/gisaid-get-all-clades
@@ -5,11 +5,11 @@ set -o nounset
 set -o pipefail
 trap "exit" INT
 
-# Get .ndjson
-./bin/local-ingest-gisaid --download-gisaid
-
-# Convert .ndjson into big `sequences.fasta` and `metadata.tsv`
-./bin/local-ingest-gisaid --transform
+## Get .ndjson
+#./bin/local-ingest-gisaid --download-gisaid
+#
+## Convert .ndjson into big `sequences.fasta` and `metadata.tsv`
+#./bin/local-ingest-gisaid --transform
 
 # Run nextclade in parallel batches from `sequences.fasta`, produce `nextclade.clades.tsv`
 ./bin/run-nextclade \

--- a/bin/ingest-gisaid
+++ b/bin/ingest-gisaid
@@ -64,8 +64,6 @@ main() {
 
     cd "$(dirname "$0")/.."
 
-    set -x
-
     if [[ "$fetch" == 1 ]]; then
         ./bin/fetch-from-gisaid > data/gisaid.ndjson
         if [[ "$branch" == master ]]; then

--- a/bin/join-csv-rows
+++ b/bin/join-csv-rows
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -o errexit
-set -o nounset
-set -o pipefail
-trap "exit" INT
-
-# Joins CSV/TSV rows from multiple files, preserving header only from the first file
-awk 'FNR==1 && NR!=1{next;}{print}' $@

--- a/bin/join-csv-rows
+++ b/bin/join-csv-rows
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+trap "exit" INT
+
+# Joins CSV/TSV rows from multiple files, preserving header only from the first file
+awk 'FNR==1 && NR!=1{next;}{print}' $@

--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -36,19 +36,19 @@ def parse_args():
 def main():
     args = parse_args()
 
-    metadata = pd.read_csv(args.first_file, index_col=False, sep='\t')
+    metadata = pd.read_csv(args.first_file, index_col=METADATA_JOIN_COLUMN_NAME, sep='\t', low_memory=False)
 
     # Read and rename clade column to be more descriptive
-    clades = pd.read_csv(args.second_file, index_col=False, sep='\t') \
+    clades = pd.read_csv(args.second_file, index_col=NEXTCLADE_JOIN_COLUMN_NAME, sep='\t', low_memory=False) \
         .rename(columns={INPUT_CLADE_COLUMN: OUTPUT_CLADE_COLUMN})
 
-    clades = clades[[NEXTCLADE_JOIN_COLUMN_NAME, OUTPUT_CLADE_COLUMN]]
+    clades = clades[[OUTPUT_CLADE_COLUMN]]
 
     # Concatenate on columns
     result = pd.merge(
         metadata, clades,
-        left_on=METADATA_JOIN_COLUMN_NAME,
-        right_on=NEXTCLADE_JOIN_COLUMN_NAME,
+        left_index=True,
+        right_index=True,
         how='left'
     )
 

--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -8,6 +8,7 @@ INPUT_CLADE_COLUMN = "clade"
 OUTPUT_CLADE_COLUMN = "Nextstrain_clade"
 INSERT_BEFORE_THIS_COLUMN = "pangolin_lineage"
 INDEX_COLUMN_NAME = 'strain'
+VALUE_CLADE_MISSING = '-'
 
 
 def reorder_columns(result: pd.DataFrame):
@@ -42,6 +43,8 @@ def main():
 
     # Concatenate on columns
     result = pd.concat([metadata, clades], axis=1)
+
+    result[OUTPUT_CLADE_COLUMN] = result[OUTPUT_CLADE_COLUMN].fillna(VALUE_CLADE_MISSING)
 
     # Move the new column so that it's next to other clade columns
     result = reorder_columns(result)

--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -42,7 +42,7 @@ def main():
     # Concatenate on columns
     result = pd.concat([metadata, clades], axis=1)
 
-    # Move tje new column so that it's next to other clade columns
+    # Move the new column so that it's next to other clade columns
     result = reorder_columns(result)
 
     result.to_csv(args.o)

--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -7,6 +7,7 @@ import pandas as pd
 INPUT_CLADE_COLUMN = "clade"
 OUTPUT_CLADE_COLUMN = "Nextstrain_clade"
 INSERT_BEFORE_THIS_COLUMN = "pangolin_lineage"
+INDEX_COLUMN_NAME = 'strain'
 
 
 def reorder_columns(result: pd.DataFrame):
@@ -33,7 +34,7 @@ def parse_args():
 def main():
     args = parse_args()
 
-    metadata = pd.read_csv(args.first_file, index_col='strain', sep='\t')
+    metadata = pd.read_csv(args.first_file, index_col=INDEX_COLUMN_NAME, sep='\t')
 
     # Read and rename clade column to be more descriptive
     clades = pd.read_csv(args.second_file, index_col=0, sep='\t') \
@@ -45,7 +46,7 @@ def main():
     # Move the new column so that it's next to other clade columns
     result = reorder_columns(result)
 
-    result.to_csv(args.o)
+    result.to_csv(args.o, index_label=INDEX_COLUMN_NAME)
 
 
 if __name__ == '__main__':

--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -41,6 +41,8 @@ def main():
     clades = pd.read_csv(args.second_file, index_col=0, sep='\t') \
         .rename(columns={INPUT_CLADE_COLUMN: OUTPUT_CLADE_COLUMN})
 
+    clades = clades[[OUTPUT_CLADE_COLUMN]]
+
     # Concatenate on columns
     result = pd.concat([metadata, clades], axis=1)
 

--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -7,7 +7,8 @@ import pandas as pd
 INPUT_CLADE_COLUMN = "clade"
 OUTPUT_CLADE_COLUMN = "Nextstrain_clade"
 INSERT_BEFORE_THIS_COLUMN = "pangolin_lineage"
-INDEX_COLUMN_NAME = 'strain'
+METADATA_JOIN_COLUMN_NAME = 'strain'
+NEXTCLADE_JOIN_COLUMN_NAME = 'seqName'
 VALUE_CLADE_MISSING = '-'
 
 
@@ -35,23 +36,28 @@ def parse_args():
 def main():
     args = parse_args()
 
-    metadata = pd.read_csv(args.first_file, index_col=INDEX_COLUMN_NAME, sep='\t')
+    metadata = pd.read_csv(args.first_file, index_col=False, sep='\t')
 
     # Read and rename clade column to be more descriptive
-    clades = pd.read_csv(args.second_file, index_col=0, sep='\t') \
+    clades = pd.read_csv(args.second_file, index_col=False, sep='\t') \
         .rename(columns={INPUT_CLADE_COLUMN: OUTPUT_CLADE_COLUMN})
 
-    clades = clades[[OUTPUT_CLADE_COLUMN]]
+    clades = clades[[NEXTCLADE_JOIN_COLUMN_NAME, OUTPUT_CLADE_COLUMN]]
 
     # Concatenate on columns
-    result = pd.concat([metadata, clades], axis=1)
+    result = pd.merge(
+        metadata, clades,
+        left_on=METADATA_JOIN_COLUMN_NAME,
+        right_on=NEXTCLADE_JOIN_COLUMN_NAME,
+        how='left'
+    )
 
     result[OUTPUT_CLADE_COLUMN] = result[OUTPUT_CLADE_COLUMN].fillna(VALUE_CLADE_MISSING)
 
     # Move the new column so that it's next to other clade columns
     result = reorder_columns(result)
 
-    result.to_csv(args.o, index_label=INDEX_COLUMN_NAME, sep='\t')
+    result.to_csv(args.o, index_label=METADATA_JOIN_COLUMN_NAME, sep='\t')
 
 
 if __name__ == '__main__':

--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -46,7 +46,7 @@ def main():
     # Move the new column so that it's next to other clade columns
     result = reorder_columns(result)
 
-    result.to_csv(args.o, index_label=INDEX_COLUMN_NAME)
+    result.to_csv(args.o, index_label=INDEX_COLUMN_NAME, sep='\t')
 
 
 if __name__ == '__main__':

--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+
+import pandas as pd
+
+INPUT_CLADE_COLUMN = "clade"
+OUTPUT_CLADE_COLUMN = "Nextstrain_clade"
+INSERT_BEFORE_THIS_COLUMN = "pangolin_lineage"
+
+
+def reorder_columns(result: pd.DataFrame):
+    """
+    Moves the new clade column after a specified column
+    """
+    columns = list(result.columns)
+    columns.remove(OUTPUT_CLADE_COLUMN)
+    insert_at = columns.index(INSERT_BEFORE_THIS_COLUMN)
+    columns.insert(insert_at, OUTPUT_CLADE_COLUMN)
+    return result[columns]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Joins metadata file with Nextclade clade output",
+    )
+    parser.add_argument("first_file")
+    parser.add_argument("second_file")
+    parser.add_argument("-o", default=sys.stdout)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    metadata = pd.read_csv(args.first_file, index_col='strain', sep='\t')
+
+    # Read and rename clade column to be more descriptive
+    clades = pd.read_csv(args.second_file, index_col=0, sep='\t') \
+        .rename(columns={INPUT_CLADE_COLUMN: OUTPUT_CLADE_COLUMN})
+
+    # Concatenate on columns
+    result = pd.concat([metadata, clades], axis=1)
+
+    # Move tje new column so that it's next to other clade columns
+    result = reorder_columns(result)
+
+    result.to_csv(args.o)
+
+
+main()

--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -48,4 +48,5 @@ def main():
     result.to_csv(args.o)
 
 
-main()
+if __name__ == '__main__':
+    main()

--- a/bin/join-rows
+++ b/bin/join-rows
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+
+import pandas as pd
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Joins rows of two TSV files, making sure to preserve all the columns and rows (full outer join)",
+    )
+    parser.add_argument("first_file")
+    parser.add_argument("second_file")
+    parser.add_argument("-o", default=sys.stdout)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    left = pd.read_csv(args.first_file, sep='\t', low_memory=False)
+    right = pd.read_csv(args.second_file, sep='\t', low_memory=False)
+
+    result = pd.concat([left, right], join='outer')
+
+    result.to_csv(args.o, index=False, sep='\t')
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -112,13 +112,13 @@ ingest() {
   nextclade.js \
     --input-fasta="${OUTPUT_DIR}/sequences.fasta" \
     --output-json="${OUTPUT_DIR}/nextclade.json" \
-    --output-csv="${OUTPUT_DIR}/nextclade.csv" \
-    --output-csv-clades-only="${OUTPUT_DIR}/nextclade.clades.csv" \
+    --output-tsv="${OUTPUT_DIR}/nextclade.csv" \
+    --output-tsv-clades-only="${OUTPUT_DIR}/nextclade.clades.tsv" \
     --output-tree="${OUTPUT_DIR}/nextclade.tree.json"
 
   ./bin/join-metadata-and-clades \
     "${OUTPUT_DIR}/metadata.tsv" \
-    "${OUTPUT_DIR}/nextclade.clades.csv" \
+    "${OUTPUT_DIR}/nextclade.clades.tsv" \
     -o "${OUTPUT_DIR}/metadata2.tsv"
 
   csv-diff \

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -100,7 +100,7 @@ download-gisaid() {
     "${GISAID_URL}" \
     -O "${TMP_DIR}/gisaid.ndjson.bz2"
 
-  bzip2 -cdk "${TMP_DIR}/gisaid.ndjson.bz2" > "${GISAID_NDJSON}"
+  bzip2 -cdk "${TMP_DIR}/gisaid.ndjson.bz2" >"${GISAID_NDJSON}"
 }
 
 transform() {
@@ -124,7 +124,7 @@ ingest() {
   ./bin/filter-fasta \
     --input_fasta="${OUTPUT_DIR}/sequences.fasta" \
     --input_tsv="${INPUT_DIR}/nextclade.tsv" \
-    --output_fasta="${OUTPUT_DIR}/nextclade.sequences.fasta" \
+    --output_fasta="${OUTPUT_DIR}/nextclade.sequences.fasta"
 
   # ... and assign clades to them
   ./bin/run-nextclade \

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -95,9 +95,10 @@ download-gisaid() {
     --directory-prefix="${TMP_DIR}" \
     --http-user="${GISAID_USERNAME}" \
     --http-password="${GISAID_PASSWORD}" \
-    "${GISAID_URL}"
+    "${GISAID_URL}" \
+    -O "${TMP_DIR}/gisaid.ndjson.bz2"
 
-  bzip2 -cdk "${TMP_DIR}/corona2020_fulldump.json.bz2" > "${GISAID_NDJSON}"
+  bzip2 -cdk "${TMP_DIR}/gisaid.ndjson.bz2" > "${GISAID_NDJSON}"
 }
 
 ingest() {

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -129,13 +129,8 @@ ingest() {
   # ... and assign clades to them
   ./bin/run-nextclade \
     "${OUTPUT_DIR}/nextclade.sequences.fasta" \
-    "${OUTPUT_DIR}/nextclade.clades.new.tsv" \
-
-  # Concatenate the new clades with the old ones
-  ./bin/join-csv-rows \
-  "${OUTPUT_DIR}/nextclade.clades.new.tsv" \
-  "${INPUT_DIR}/nextclade.clades.tsv" \
-  > "${OUTPUT_DIR}/nextclade.clades.tsv" \
+    "${INPUT_DIR}/nextclade.clades.tsv" \
+    "${OUTPUT_DIR}/nextclade.clades.tsv"
 
   # Join these clades into metadata
   ./bin/join-metadata-and-clades \

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -123,19 +123,19 @@ ingest() {
   # Find sequences in FASTA which don't have clades assigned yet
   ./bin/filter-fasta \
     --input_fasta="${OUTPUT_DIR}/sequences.fasta" \
-    --input_tsv="${INPUT_DIR}/nextclade.clades.tsv" \
+    --input_tsv="${INPUT_DIR}/nextclade.tsv" \
     --output_fasta="${OUTPUT_DIR}/nextclade.sequences.fasta" \
 
   # ... and assign clades to them
   ./bin/run-nextclade \
     "${OUTPUT_DIR}/nextclade.sequences.fasta" \
-    "${INPUT_DIR}/nextclade.clades.tsv" \
-    "${OUTPUT_DIR}/nextclade.clades.tsv"
+    "${INPUT_DIR}/nextclade.tsv" \
+    "${OUTPUT_DIR}/nextclade.tsv"
 
   # Join these clades into metadata
   ./bin/join-metadata-and-clades \
     "${OUTPUT_DIR}/metadata.tsv" \
-    "${OUTPUT_DIR}/nextclade.clades.tsv" \
+    "${OUTPUT_DIR}/nextclade.tsv" \
     -o "${OUTPUT_DIR}/metadata2.tsv"
 
   csv-diff \

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -21,8 +21,6 @@ set -o nounset
 set -o pipefail
 trap "exit" INT
 
-set -x
-
 TMP_DIR="data/gisaid/tmp"
 INPUT_DIR="data/gisaid/inputs"
 OUTPUT_DIR="data/gisaid/outputs"
@@ -133,17 +131,17 @@ ingest() {
     "${OUTPUT_DIR}/nextclade.sequences.fasta" \
     "${OUTPUT_DIR}/nextclade.clades.new.tsv" \
 
+  # Concatenate the new clades with the old ones
+  ./bin/join-csv-rows \
+  "${OUTPUT_DIR}/nextclade.clades.new.tsv" \
+  "${INPUT_DIR}/nextclade.clades.tsv" \
+  > "${OUTPUT_DIR}/nextclade.clades.tsv" \
+
   # Join these clades into metadata
   ./bin/join-metadata-and-clades \
     "${OUTPUT_DIR}/metadata.tsv" \
     "${OUTPUT_DIR}/nextclade.clades.tsv" \
     -o "${OUTPUT_DIR}/metadata2.tsv"
-
-  # And also join these clades to the overall mapping
-  ./bin/join-csv-rows \
-  "${OUTPUT_DIR}/nextclade.clades.new.tsv" \
-  "${INPUT_DIR}/nextclade.clades.tsv" \
-  > "${OUTPUT_DIR}/nextclade.clades.tsv" \
 
   csv-diff \
     "${METADATA_OLD}" \

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -25,7 +25,7 @@ main() {
   ADDITIONAL_INFO_NEW="${OUTPUT_DIR}/additional_info.tsv"
   ADDITIONAL_INFO_CHANGES="${OUTPUT_DIR}/additional-info-changes.txt"
 
-  LOCATION_HIERARCHY_NEW="${INPUT_DIR}/location_hierarchy.tsv"
+  LOCATION_HIERARCHY_NEW="${OUTPUT_DIR}/location_hierarchy.tsv"
   LOCATION_HIERARCHY_REFERENCE="source-data/location_hierarchy.tsv"
   LOCATION_HIERARCHY_ADDITIONS="${OUTPUT_DIR}/location-hierarchy-additions.tsv"
 

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -136,7 +136,7 @@ ingest() {
   ./bin/join-metadata-and-clades \
     "${OUTPUT_DIR}/metadata.tsv" \
     "${OUTPUT_DIR}/nextclade.tsv" \
-    -o "${OUTPUT_DIR}/metadata2.tsv"
+    -o "${OUTPUT_DIR}/metadata.tsv"
 
   csv-diff \
     "${METADATA_OLD}" \

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -23,8 +23,11 @@ trap "exit" INT
 
 set -x
 
+TMP_DIR="data/gisaid/tmp"
 INPUT_DIR="data/gisaid/inputs"
 OUTPUT_DIR="data/gisaid/outputs"
+
+GISAID_NDJSON="${INPUT_DIR}/gisaid.ndjson"
 
 METADATA_OLD="${INPUT_DIR}/metadata.tsv"
 METADATA_NEW="${OUTPUT_DIR}/metadata.tsv"
@@ -56,6 +59,10 @@ main() {
       download-inputs
       exit
       ;;
+    --download-gisaid)
+      download-gisaid
+      exit
+      ;;
     --ingest)
       ingest
       exit
@@ -75,6 +82,22 @@ download-inputs() {
 
   aws s3 cp "${S3_BUCKET}/additional_info.tsv.gz" - | gunzip -cq >"data/gisaid/inputs/additional_info.tsv"
   aws s3 cp "${S3_BUCKET}/metadata.tsv.gz" - | gunzip -cq >"data/gisaid/inputs/metadata.tsv"
+}
+
+download-gisaid() {
+  [ -f ".env" ] && source ".env"
+  [ -f "../.env" ] && source "../.env"
+
+  mkdir -p "${INPUT_DIR}"
+  mkdir -p "${TMP_DIR}"
+
+  wget \
+    --directory-prefix="${TMP_DIR}" \
+    --http-user="${GISAID_USERNAME}" \
+    --http-password="${GISAID_PASSWORD}" \
+    "${GISAID_URL}"
+
+  bzip2 -cdk "${TMP_DIR}/corona2020_fulldump.json.bz2" > "${GISAID_NDJSON}"
 }
 
 ingest() {

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -122,13 +122,18 @@ ingest() {
     --output-fasta "${OUTPUT_DIR}/sequences.fasta" \
     --output-additional-info "${OUTPUT_DIR}/additional_info.tsv"
 
-  nextclade.js \
-    --input-fasta="${OUTPUT_DIR}/sequences.fasta" \
-    --output-json="${OUTPUT_DIR}/nextclade.json" \
-    --output-tsv="${OUTPUT_DIR}/nextclade.csv" \
-    --output-tsv-clades-only="${OUTPUT_DIR}/nextclade.clades.tsv" \
-    --output-tree="${OUTPUT_DIR}/nextclade.tree.json"
+  # Find sequences in FASTA which don't have clades assigned yet
+  ./bin/filter-fasta \
+    --input_fasta="${OUTPUT_DIR}/sequences.fasta" \
+    --input_tsv="${INPUT_DIR}/nextclade.clades.tsv" \
+    --output_fasta="${OUTPUT_DIR}/nextclade.sequences.fasta" \
 
+  # ... and assign clades to them
+  ./bin/run-nextclade \
+    "${OUTPUT_DIR}/nextclade.sequences.fasta" \
+    "${OUTPUT_DIR}/nextclade.clades.tsv" \
+
+  # Join these clades into metadata
   ./bin/join-metadata-and-clades \
     "${OUTPUT_DIR}/metadata.tsv" \
     "${OUTPUT_DIR}/nextclade.clades.tsv" \

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -1,4 +1,20 @@
 #!/usr/bin/env bash
+# usage: local-ingest-gisaid [flags]
+#        local-ingest-gisaid --help
+#
+# flags:
+#
+#  --help             Print this help message
+#
+#  --download-inputs  Download required input files from AWS S3 bucket
+#                     (Note: required gisaid.ndjson file should be downloaded
+#                     separately)
+#
+#  --ingest           Run ingest scripts offline locally. This will take input
+#                     files, perform transformations and will write output files
+#
+#  --upload-outputs   Upload output files to AWS S3 bucket
+#
 
 set -o errexit
 set -o nounset
@@ -10,26 +26,59 @@ set -x
 INPUT_DIR="data/gisaid/inputs"
 OUTPUT_DIR="data/gisaid/outputs"
 
+METADATA_OLD="${INPUT_DIR}/metadata.tsv"
+METADATA_NEW="${OUTPUT_DIR}/metadata.tsv"
+METADATA_CHANGES="${OUTPUT_DIR}/metadata-changes.txt"
+METADATA_ADDITIONS="${OUTPUT_DIR}/metadata-additions.tsv"
+
+ADDITIONAL_INFO_OLD="${INPUT_DIR}/additional_info.tsv"
+ADDITIONAL_INFO_NEW="${OUTPUT_DIR}/additional_info.tsv"
+ADDITIONAL_INFO_CHANGES="${OUTPUT_DIR}/additional-info-changes.txt"
+
+LOCATION_HIERARCHY_NEW="${OUTPUT_DIR}/location_hierarchy.tsv"
+LOCATION_HIERARCHY_REFERENCE="source-data/location_hierarchy.tsv"
+LOCATION_HIERARCHY_ADDITIONS="${OUTPUT_DIR}/location-hierarchy-additions.tsv"
+
+S3_BUCKET="s3://nextstrain-ncov-private"
+
+KEY="gisaid_epi_isl"
+
 main() {
   cd "$(dirname "$0")/.."
 
+  for arg; do
+    case "$arg" in
+    -h | --help)
+      print-help
+      exit
+      ;;
+    --download-inputs)
+      download-inputs
+      exit
+      ;;
+    --ingest)
+      ingest
+      exit
+      ;;
+    --upload-outputs)
+      upload-outputs
+      exit
+      ;;
+    esac
+  done
+
+  print-help
+}
+
+download-inputs() {
   mkdir -p "${INPUT_DIR}"
+
+  aws s3 cp "${S3_BUCKET}/additional_info.tsv.gz" - | gunzip -cq >"data/gisaid/inputs/additional_info.tsv"
+  aws s3 cp "${S3_BUCKET}/metadata.tsv.gz" - | gunzip -cq >"data/gisaid/inputs/metadata.tsv"
+}
+
+ingest() {
   mkdir -p "${OUTPUT_DIR}"
-
-  METADATA_OLD="${INPUT_DIR}/metadata.tsv"
-  METADATA_NEW="${OUTPUT_DIR}/metadata.tsv"
-  METADATA_CHANGES="${OUTPUT_DIR}/metadata-changes.txt"
-  METADATA_ADDITIONS="${OUTPUT_DIR}/metadata-additions.tsv"
-
-  ADDITIONAL_INFO_OLD="${INPUT_DIR}/additional_info.tsv"
-  ADDITIONAL_INFO_NEW="${OUTPUT_DIR}/additional_info.tsv"
-  ADDITIONAL_INFO_CHANGES="${OUTPUT_DIR}/additional-info-changes.txt"
-
-  LOCATION_HIERARCHY_NEW="${OUTPUT_DIR}/location_hierarchy.tsv"
-  LOCATION_HIERARCHY_REFERENCE="source-data/location_hierarchy.tsv"
-  LOCATION_HIERARCHY_ADDITIONS="${OUTPUT_DIR}/location-hierarchy-additions.tsv"
-
-  KEY="gisaid_epi_isl"
 
   ./bin/transform-gisaid "${INPUT_DIR}/gisaid.ndjson" \
     --output-metadata "${OUTPUT_DIR}/metadata.tsv" \
@@ -63,6 +112,29 @@ main() {
     <(sort "${LOCATION_HIERARCHY_REFERENCE}") \
     <(sort "${LOCATION_HIERARCHY_NEW}") \
     >"${LOCATION_HIERARCHY_ADDITIONS}"
+}
+
+upload-outputs() {
+  ./bin/upload-to-s3 "${OUTPUT_DIR}/metadata.tsv" "${S3_BUCKET}/metadata.tsv.gz"
+  ./bin/upload-to-s3 "${OUTPUT_DIR}/additional_info.tsv" "${S3_BUCKET}/additional_info.tsv.gz"
+  ./bin/upload-to-s3 "${OUTPUT_DIR}/flagged_metadata.txt" "${S3_BUCKET}/flagged_metadata.txt.gz"
+  ./bin/upload-to-s3 "${OUTPUT_DIR}/sequences.fasta" "${S3_BUCKET}/sequences.fasta.gz"
+}
+
+print-help() {
+  # Print the help comments at the top of this file ($0)
+  local line
+  while read -r line; do
+    if [[ $line =~ ^#! ]]; then
+      continue
+    elif [[ $line =~ ^# ]]; then
+      line="${line/##/}"
+      line="${line/# /}"
+      echo "$line"
+    else
+      break
+    fi
+  done <"$0"
 }
 
 main "$@"

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -131,13 +131,19 @@ ingest() {
   # ... and assign clades to them
   ./bin/run-nextclade \
     "${OUTPUT_DIR}/nextclade.sequences.fasta" \
-    "${OUTPUT_DIR}/nextclade.clades.tsv" \
+    "${OUTPUT_DIR}/nextclade.clades.new.tsv" \
 
   # Join these clades into metadata
   ./bin/join-metadata-and-clades \
     "${OUTPUT_DIR}/metadata.tsv" \
     "${OUTPUT_DIR}/nextclade.clades.tsv" \
     -o "${OUTPUT_DIR}/metadata2.tsv"
+
+  # And also join these clades to the overall mapping
+  ./bin/join-csv-rows \
+  "${OUTPUT_DIR}/nextclade.clades.new.tsv" \
+  "${INPUT_DIR}/nextclade.clades.tsv" \
+  > "${OUTPUT_DIR}/nextclade.clades.tsv" \
 
   csv-diff \
     "${METADATA_OLD}" \

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+trap "exit" INT
+
+set -x
+
+INPUT_DIR="data/gisaid/inputs"
+OUTPUT_DIR="data/gisaid/outputs"
+
+main() {
+  cd "$(dirname "$0")/.."
+
+  mkdir -p "${INPUT_DIR}"
+  mkdir -p "${OUTPUT_DIR}"
+
+  METADATA_OLD="${INPUT_DIR}/metadata.tsv"
+  METADATA_NEW="${OUTPUT_DIR}/metadata.tsv"
+  METADATA_CHANGES="${OUTPUT_DIR}/metadata-changes.txt"
+  METADATA_ADDITIONS="${OUTPUT_DIR}/metadata-additions.tsv"
+
+  ADDITIONAL_INFO_OLD="${INPUT_DIR}/additional_info.tsv"
+  ADDITIONAL_INFO_NEW="${OUTPUT_DIR}/additional_info.tsv"
+  ADDITIONAL_INFO_CHANGES="${OUTPUT_DIR}/additional-info-changes.txt"
+
+  LOCATION_HIERARCHY_NEW="${INPUT_DIR}/location_hierarchy.tsv"
+  LOCATION_HIERARCHY_REFERENCE="source-data/location_hierarchy.tsv"
+  LOCATION_HIERARCHY_ADDITIONS="${OUTPUT_DIR}/location-hierarchy-additions.tsv"
+
+  KEY="gisaid_epi_isl"
+
+  ./bin/transform-gisaid "${INPUT_DIR}/gisaid.ndjson" \
+    --output-metadata "${OUTPUT_DIR}/metadata.tsv" \
+    --output-fasta "${OUTPUT_DIR}/sequences.fasta" \
+    --output-additional-info "${OUTPUT_DIR}/additional_info.tsv"
+
+  csv-diff \
+    "${METADATA_OLD}" \
+    "${METADATA_NEW}" \
+    --format tsv \
+    --key "$KEY" \
+    --singular sequence \
+    --plural sequences \
+    >"${METADATA_CHANGES}"
+
+  ./bin/metadata-additions "${METADATA_OLD}" "${METADATA_NEW}" "${KEY}" >"${METADATA_ADDITIONS}"
+
+  csv-diff \
+    <(awk 'BEGIN {FS="\t"}; { if ($3 != "" || $4 != "") { print }}' "${ADDITIONAL_INFO_OLD}") \
+    <(awk 'BEGIN {FS="\t"}; { if ($3 != "" || $4 != "") { print }}' "${ADDITIONAL_INFO_NEW}") \
+    --format tsv \
+    --key "${KEY}" \
+    --singular "additional info" \
+    --plural "additional info" \
+    >${ADDITIONAL_INFO_CHANGES}
+
+  ./bin/flag-metadata "${OUTPUT_DIR}/metadata.tsv" >"${OUTPUT_DIR}/flagged_metadata.txt"
+  ./bin/check-locations "${OUTPUT_DIR}/metadata.tsv" "${OUTPUT_DIR}/location_hierarchy.tsv" "gisaid_epi_isl"
+
+  comm -13 \
+    <(sort "${LOCATION_HIERARCHY_REFERENCE}") \
+    <(sort "${LOCATION_HIERARCHY_NEW}") \
+    >"${LOCATION_HIERARCHY_ADDITIONS}"
+}
+
+main "$@"

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -109,6 +109,18 @@ ingest() {
     --output-fasta "${OUTPUT_DIR}/sequences.fasta" \
     --output-additional-info "${OUTPUT_DIR}/additional_info.tsv"
 
+  nextclade.js \
+    --input-fasta="${OUTPUT_DIR}/sequences.fasta" \
+    --output-json="${OUTPUT_DIR}/nextclade.json" \
+    --output-csv="${OUTPUT_DIR}/nextclade.csv" \
+    --output-csv-clades-only="${OUTPUT_DIR}/nextclade.clades.csv" \
+    --output-tree="${OUTPUT_DIR}/nextclade.tree.json"
+
+  ./bin/join-metadata-and-clades \
+    "${OUTPUT_DIR}/metadata.tsv" \
+    "${OUTPUT_DIR}/nextclade.clades.csv" \
+    -o "${OUTPUT_DIR}/metadata2.tsv"
+
   csv-diff \
     "${METADATA_OLD}" \
     "${METADATA_NEW}" \

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -63,6 +63,10 @@ main() {
       download-gisaid
       exit
       ;;
+    --transform)
+      transform
+      exit
+      ;;
     --ingest)
       ingest
       exit
@@ -99,6 +103,15 @@ download-gisaid() {
     -O "${TMP_DIR}/gisaid.ndjson.bz2"
 
   bzip2 -cdk "${TMP_DIR}/gisaid.ndjson.bz2" > "${GISAID_NDJSON}"
+}
+
+transform() {
+  mkdir -p "${OUTPUT_DIR}"
+
+  ./bin/transform-gisaid "${INPUT_DIR}/gisaid.ndjson" \
+    --output-metadata "${OUTPUT_DIR}/metadata.tsv" \
+    --output-fasta "${OUTPUT_DIR}/sequences.fasta" \
+    --output-additional-info "${OUTPUT_DIR}/additional_info.tsv"
 }
 
 ingest() {

--- a/bin/run-nextclade
+++ b/bin/run-nextclade
@@ -54,6 +54,11 @@ for input in ${INPUT_WILDCARD}; do
     --output-tsv-clades-only="${output_filename}" &
 done
 
+# Wait until all processes finish
+for job in $(jobs -p); do
+  wait $job
+done
+
 # Concatenate output batches together
 ./bin/join-csv-rows ${OUTPUT_WILDCARD} >${OUTPUT_TSV}
 

--- a/bin/run-nextclade
+++ b/bin/run-nextclade
@@ -28,7 +28,7 @@ TMP_DIR_CLADES="tmp/clades"
 INPUT_WILDCARD="${TMP_DIR_FASTA}/*.fasta"
 OUTPUT_WILDCARD="${TMP_DIR_CLADES}/*.tsv"
 
-BATCH_SIZE=4
+BATCH_SIZE=200
 
 # Default number of processes, if not provided.
 # Usually equals to the sum of numbers of logical cores ("threads") on all CPUs

--- a/bin/run-nextclade
+++ b/bin/run-nextclade
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Allows running nextclade on a large input fasta file:
+#   - splits fasta file into batches of a given size (Node.js is limited to max 2G file size)
+#   - runs batches in a parallel pool, given number of processes (nextclade CLI is currently serial)
+#   - concatenates inputs from all batches
+
+# TODO: This functionality might be ported to nextclade native
+# (with streaming .fasta reader and webworkers/multiprocessing)
+
+set -o errexit
+set -o nounset
+set -o pipefail
+trap "exit" INT
+
+INPUT_FASTA=${1}
+OUTPUT_TSV=${2}
+TMP_DIR_FASTA="tmp/fasta"
+TMP_DIR_CLADES="tmp/clades"
+INPUT_WILDCARD="${TMP_DIR_FASTA}/*.fasta"
+OUTPUT_WILDCARD="${TMP_DIR_CLADES}/*.tsv"
+
+# Default number of processes, if not provided.
+# Usually equals to the number of threads on all CPUs combined.
+N_PROCESSES_DEFAULT=$(getconf _NPROCESSORS_ONLN)
+
+# Alternatively, use number of processes provided as the third argument
+N_PROCESSES=${3:-"${N_PROCESSES_DEFAULT}"}
+
+# Split fasta file to multiple batches
+mkdir -p "${TMP_DIR_FASTA}"
+./bin/split-fasta \
+  "${INPUT_FASTA}" \
+  --batch_size=100 \
+  --output_dir="${TMP_DIR_FASTA}"
+
+# Run batches in parallel
+echo "Using {N_PROCESSES} parallel processes"
+mkdir -p "${TMP_DIR_CLADES}"
+N_JOBS_CURRENT="\j"
+for input in ${INPUT_WILDCARD}; do
+  input_basename="$(basename "${input}")"
+  output_basename="${input_basename%.fasta}.tsv"
+  output_filename="${TMP_DIR_CLADES}/${output_basename}"
+  echo ${output_filename}
+
+  while ((${N_JOBS_CURRENT@P} >= N_PROCESSES)); do
+    wait -n
+  done
+
+  echo "Processing ${input}"
+
+  nextclade.js \
+    --input-fasta="${input}" \
+    --output-tsv-clades-only="${output_filename}" &
+done
+
+# Concatenate output batches together
+./bin/join-csv-rows ${OUTPUT_WILDCARD} >${OUTPUT_TSV}
+
+rm -rf "${TMP_DIR_FASTA}" "${TMP_DIR_CLADES}"

--- a/bin/run-nextclade
+++ b/bin/run-nextclade
@@ -14,7 +14,8 @@ set -o pipefail
 trap "exit" INT
 
 INPUT_FASTA=${1}
-OUTPUT_TSV=${2}
+INPUT_TSV=${2}
+OUTPUT_TSV=${3}
 TMP_DIR_FASTA="tmp/fasta"
 TMP_DIR_CLADES="tmp/clades"
 INPUT_WILDCARD="${TMP_DIR_FASTA}/*.fasta"
@@ -25,13 +26,13 @@ OUTPUT_WILDCARD="${TMP_DIR_CLADES}/*.tsv"
 N_PROCESSES_DEFAULT=$(getconf _NPROCESSORS_ONLN)
 
 # Alternatively, use number of processes provided as the third argument
-N_PROCESSES=${3:-"${N_PROCESSES_DEFAULT}"}
+N_PROCESSES=${4:-"${N_PROCESSES_DEFAULT}"}
 
 # Split fasta file to multiple batches
 mkdir -p "${TMP_DIR_FASTA}"
 ./bin/split-fasta \
   "${INPUT_FASTA}" \
-  --batch_size=100 \
+  --batch_size=20 \
   --output_dir="${TMP_DIR_FASTA}"
 
 # Run batches in parallel
@@ -59,7 +60,11 @@ for job in $(jobs -p); do
   wait $job
 done
 
+cp "${INPUT_TSV}" "${OUTPUT_TSV}"
+
 # Concatenate output batches together
-./bin/join-csv-rows ${OUTPUT_WILDCARD} >${OUTPUT_TSV}
+for output in ${OUTPUT_WILDCARD}; do
+  tail -n +2 "$output" >>"${OUTPUT_TSV}"
+done
 
 rm -rf "${TMP_DIR_FASTA}" "${TMP_DIR_CLADES}"

--- a/bin/run-nextclade
+++ b/bin/run-nextclade
@@ -64,7 +64,7 @@ cp "${INPUT_TSV}" "${OUTPUT_TSV}"
 
 # Concatenate output batches together
 for output in ${OUTPUT_WILDCARD}; do
-  tail -n +2 "$output" >>"${OUTPUT_TSV}"
+  ./bin/join-rows $output "${OUTPUT_TSV}" -o "${OUTPUT_TSV}"
 done
 
 #rm -rf "${TMP_DIR_FASTA}" "${TMP_DIR_CLADES}"

--- a/bin/run-nextclade
+++ b/bin/run-nextclade
@@ -52,7 +52,7 @@ for input in ${INPUT_WILDCARD}; do
 
   nextclade.js \
     --input-fasta="${input}" \
-    --output-tsv-clades-only="${output_filename}" &
+    --output-tsv="${output_filename}" &
 done
 
 # Wait until all processes finish

--- a/bin/run-nextclade
+++ b/bin/run-nextclade
@@ -35,14 +35,13 @@ mkdir -p "${TMP_DIR_FASTA}"
   --output_dir="${TMP_DIR_FASTA}"
 
 # Run batches in parallel
-echo "Using {N_PROCESSES} parallel processes"
+echo "Using ${N_PROCESSES} parallel processes"
 mkdir -p "${TMP_DIR_CLADES}"
 N_JOBS_CURRENT="\j"
 for input in ${INPUT_WILDCARD}; do
   input_basename="$(basename "${input}")"
   output_basename="${input_basename%.fasta}.tsv"
   output_filename="${TMP_DIR_CLADES}/${output_basename}"
-  echo ${output_filename}
 
   while ((${N_JOBS_CURRENT@P} >= N_PROCESSES)); do
     wait -n

--- a/bin/run-nextclade
+++ b/bin/run-nextclade
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 
-# Allows running nextclade on a large input fasta file:
-#   - splits fasta file into batches of a given size (Node.js is limited to max 2G file size)
-#   - runs batches in a parallel pool, given number of processes (nextclade CLI is currently serial)
-#   - concatenates inputs from all batches
-
-# TODO: This functionality might be ported to nextclade native
-# (with streaming .fasta reader and webworkers/multiprocessing)
+# HACK: Allows running nextclade on a large input fasta file:
+#
+#   - Splits fasta file into batches of a given size (Node.js is limited to max
+#     GBytes file size)
+#
+#   - Runs batches one at a time. Nextclade uses a thread pool to schedule the
+#     analysis of sequences in parallel, on per-sequence basis.
+#
+#   - Concatenates outputs from all batches
+#
+# TODO: This this script will be redundant when Nextclade implements a proper
+#  streaming fasta reader, thus lifting the 2 GBytes limit. This will
+#  effectively move batching inside Nextclade
+#
 
 set -o errexit
 set -o nounset
@@ -21,8 +28,11 @@ TMP_DIR_CLADES="tmp/clades"
 INPUT_WILDCARD="${TMP_DIR_FASTA}/*.fasta"
 OUTPUT_WILDCARD="${TMP_DIR_CLADES}/*.tsv"
 
+BATCH_SIZE=4
+
 # Default number of processes, if not provided.
-# Usually equals to the number of threads on all CPUs combined.
+# Usually equals to the sum of numbers of logical cores ("threads") on all CPUs
+# in the system combined, including "hyperthreads".
 N_PROCESSES_DEFAULT=$(getconf _NPROCESSORS_ONLN)
 
 # Alternatively, use number of processes provided as the third argument
@@ -32,32 +42,22 @@ N_PROCESSES=${4:-"${N_PROCESSES_DEFAULT}"}
 mkdir -p "${TMP_DIR_FASTA}"
 ./bin/split-fasta \
   "${INPUT_FASTA}" \
-  --batch_size=20 \
+  --batch_size=${BATCH_SIZE} \
   --output_dir="${TMP_DIR_FASTA}"
 
 # Run batches in parallel
 echo "Using ${N_PROCESSES} parallel processes"
 mkdir -p "${TMP_DIR_CLADES}"
-N_JOBS_CURRENT="\j"
 for input in ${INPUT_WILDCARD}; do
   input_basename="$(basename "${input}")"
   output_basename="${input_basename%.fasta}.tsv"
   output_filename="${TMP_DIR_CLADES}/${output_basename}"
 
-  while ((${N_JOBS_CURRENT@P} >= N_PROCESSES)); do
-    wait -n
-  done
-
   echo "Processing ${input}"
-
   nextclade.js \
+    --jobs="${N_PROCESSES}" \
     --input-fasta="${input}" \
-    --output-tsv="${output_filename}" &
-done
-
-# Wait until all processes finish
-for job in $(jobs -p); do
-  wait $job
+    --output-tsv="${output_filename}"
 done
 
 cp "${INPUT_TSV}" "${OUTPUT_TSV}"
@@ -67,4 +67,4 @@ for output in ${OUTPUT_WILDCARD}; do
   tail -n +2 "$output" >>"${OUTPUT_TSV}"
 done
 
-rm -rf "${TMP_DIR_FASTA}" "${TMP_DIR_CLADES}"
+#rm -rf "${TMP_DIR_FASTA}" "${TMP_DIR_CLADES}"

--- a/bin/split-fasta
+++ b/bin/split-fasta
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+import argparse
+import os
+
+from Bio import SeqIO
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Splits a fasta file into batch of given size")
+    parser.add_argument("input_file", help="Path to the input fasta file.")
+    parser.add_argument(
+        "--batch_size", "-c",
+        required=True,
+        help="Size of each batch. Note that the last batch might be smaller than that."
+    )
+    parser.add_argument(
+        "--output_dir", "-o",
+        required=True,
+        help="Output directory. Batches will be named as `{output_dir}/{basename(input_file)}.batch-{i:05}.fasta`, where `i:05` is the index of a batch zeri-padded to length of 5."
+    )
+    return parser.parse_args()
+
+
+# From https://biopython.org/wiki/Split_large_file
+def batch_iterator(iterator, batch_size):
+    """Returns lists of length batch_size.
+
+    This can be used on any iterator, for example to batch up
+    SeqRecord objects from Bio.SeqIO.parse(...), or to batch
+    Alignment objects from Bio.AlignIO.parse(...), or simply
+    lines from a file handle.
+
+    This is a generator function, and it returns lists of the
+    entries from the supplied iterator.  Each list will have
+    batch_size entries, although the final list may be shorter.
+    """
+    entry = True  # Make sure we loop once
+    while entry:
+        batch = []
+        while len(batch) < batch_size:
+            try:
+                entry = next(iterator)
+            except StopIteration:
+                entry = None
+            if entry is None:
+                # End of file
+                break
+            batch.append(entry)
+        if batch:
+            yield batch
+
+
+def main():
+    file_format = "fasta"
+    args = parse_args()
+    input_filename = os.path.basename(args.input_file)
+    batch_size = int(args.batch_size)
+
+    with open(args.input_file) as f_input:
+        record_iter = SeqIO.parse(f_input, file_format)
+        for i, batch in enumerate(batch_iterator(record_iter, batch_size)):
+            filename = os.path.join(args.output_dir, f"{input_filename}.batch-{i:05}.fasta")
+            with open(filename, "w") as f_output:
+                count = SeqIO.write(batch, f_output, file_format)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Description of proposed changes    

During GISAID ingest, it is proposed to produce a version of `metadata.tsv` file which contains an additional column "Nextstrain_clade", containing clade deduced using Nextclade CLI tool.

Thus, the "nextmeta" published on GISAID will contain not only Pangolin lineages and GISAID clades, but also Nextstrain clades.

---

<sub>
Work in progress: Currently only has implementation for local runs.
</sub>

---

<sub>
TODO: run for a few days in addition to the current vanilla ingest and compare the results. Port to GitHub-action-based script.
</sub>

---

In order to make this happen, this PR introduces 2 distinct tasks:

##### One-time preparation task ("full run"):

Ensures that all currently existing GISAID sequences (~100k) are processed and have a clade assigned. It's too compute-intensive for GitHub actions and must be done locally, on premises or on a high-performance cloud instance. Runs in a few hours on a laptop, in background or overnight.

The same task can be used for periodic mass-synchronization of clades, to account for metadata and sequence changes on GISAID.

Implementation details:
 - have fresh `sequences.fasta`, `metadata.tsv`
 - split `sequences.fasta` into batches: `sequences.fasta.batch-xxxxx.tsv`
 - for each batch (in parallel): run `nextclade.js`, get `sequences.fasta.batch-xxxxx.tsv`, containing clades
 - concatenate results into `nextclade.clades.tsv`
 - join `metadata.tsv` and `nextclade.clades.tsv`, such that `metadata2.tsv` has an additional column "Nextstrain_clade"



##### Daily task:

Runs as a part of daily ingest. Takes only sequences that have no clades, assigns clades, merges them into the new metadata. Should take no more than a minute or a few for a usual daily batch of sequences.

Implementation details:

 - during ingest, have fresh `metadata.tsv`, `sequences.fasta`, and old `nextclade.clades.tsv`
 - filter `sequences.fasta`: get a list of sequences that are in `sequences.fasta`, but are not in `nextclade.clades.tsv`, save them to `nextclade.sequences.fasta`
 - run nextclade on `nextclade.sequences.fasta`, get `nextclade.clades.new.tsv`
 - add `nextclade.clades.new.tsv` to `nextclade.clades.tsv`
 - join `metadata.tsv` and `nextclade.clades.tsv`
 - TODO: the final implementation for GitHub actions should persist `nextclade.clades.tsv` on S3


##### Additional considerations and decisions:

 - Name of the new column. Currently "Nextstrain_clade".
 
 - How and how often to run "full runs".

 - Whether we need to implement matching by GISAID ID. Currently matching of clade to metadata is done by sequence name. These names might change on GISAID. A more reliable mapping can be implemented by using GISAID-specific stable identifier. Nextclade has no access to metadata and only operates on sequence names. So this might not be currently possible to do reliably without processing sequences one by one, which might be very slow.
  Additionally, matching by name may produce inaccurate results if names are not unique and sequences with the same name are supposed to be in different clades.

 - Clades is only a tiny portion of Nextclade's output. We may consider more things to be saved, either for internal use or for publishing.


### Related issue(s)  
N/A

### Testing

This is based on local ingest branch (see #89)

 - setup local ingest environment as described in #89 

 - the script currently assumes that the `master` version of `nextclade.js` is available globally. That's the only version that has the new `--output-tsv-clades-only` flag. You can build it as described in [README](https://github.com/nextstrain/nextclade/blob/master/packages/cli/README.md#build) and it appears in packages/cli/dist. Then I just symlinked it to one of my directories in `PATH` (`~/bin`).
   It will be available on npm after we finalize this business here, so that simple `npm install -g @neherlab/nextclade` will do then.

 - for "full run":

    ```bash
    nice -19 ionice -c3 ./bin/gisaid-get-all-clades
    ```
    (scales with the number of available threads)

 - observe `data/gisaid/outputs/metadata2.tsv` which contains clades for all sequences (excluding the ones that failed to align during nextclade step)

 - observe `data/gisaid/outputs/nextclade.clades.tsv` with clade mapping (and no other metadata)

 - move `data/gisaid/outputs/nextclade.clades.tsv` to `data/gisaid/inputs/nextclade.clades.tsv`
   (simulating the transition to the next day - inputs of the today are the outputs of yesterday)

 - for daily ingest:
   run as described in #89 (the new steps are added to the `--ingest` part)

 - observe `data/gisaid/outputs/metadata2.tsv` which contains clades for all sequences, including today's

### Thank you for contributing to Nextstrain!

🙏


@rneher @emmahodcroft Could you please expand on motivation and other considerations for this feature?
