### PR TITLE
fix: keep "n/a" values in metadata

### DIFF
--- a/bin/filter-fasta
+++ b/bin/filter-fasta
@@ -30,7 +30,7 @@ but missing the input TSV file. This is useful in order to find which sequences 
 def main():
     args = parse_args()
 
-    tsv = pd.read_csv(args.input_tsv, sep="\t")
+    tsv = pd.read_csv(args.input_tsv, sep="\t", low_memory=False)
     tsv_ids = set(tsv['seqName'])
 
     with open(args.input_fasta) as f_input:

--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -36,10 +36,10 @@ def parse_args():
 def main():
     args = parse_args()
 
-    metadata = pd.read_csv(args.first_file, index_col=METADATA_JOIN_COLUMN_NAME, sep='\t', low_memory=False)
+    metadata = pd.read_csv(args.first_file, index_col=METADATA_JOIN_COLUMN_NAME, sep='\t', low_memory=False, na_filter = False)
 
     # Read and rename clade column to be more descriptive
-    clades = pd.read_csv(args.second_file, index_col=NEXTCLADE_JOIN_COLUMN_NAME, sep='\t', low_memory=False) \
+    clades = pd.read_csv(args.second_file, index_col=NEXTCLADE_JOIN_COLUMN_NAME, sep='\t', low_memory=False, na_filter = False) \
         .rename(columns={INPUT_CLADE_COLUMN: OUTPUT_CLADE_COLUMN})
 
     clades = clades[[OUTPUT_CLADE_COLUMN]]

--- a/bin/join-rows
+++ b/bin/join-rows
@@ -18,8 +18,8 @@ def parse_args():
 def main():
     args = parse_args()
 
-    left = pd.read_csv(args.first_file, sep='\t', low_memory=False)
-    right = pd.read_csv(args.second_file, sep='\t', low_memory=False)
+    left = pd.read_csv(args.first_file, sep='\t', low_memory=False, na_filter = False)
+    right = pd.read_csv(args.second_file, sep='\t', low_memory=False, na_filter = False)
 
     result = pd.concat([left, right], join='outer')
 


### PR DESCRIPTION
### Description of proposed changes    
By default, Pandas parses `NA`, `n/a` and similar values as `NaN` when reading a TSV file and then writes an empty cell when saving.

This PR disables this behavior, so that the values above are interpreted as strings and are preserved in the output as is.


### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
A followup of #100

### Testing
Run and compare to metadata before #100.
Only new column should be added. Any other difference is a bug.

### Thank you for contributing to Nextstrain!
