### PR TITLE
Add subclades

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ Enter this into the `slack_member_id` field of your alert configuration.
 
 ## Refreshing clades
 
-Clades assigned with Nextclade are currently cached in `nextclade.tsv` on S3 bucket and only incremental updates for new sequences are performed during the daily ingests. This clade cache goes stale with time. It is necessary to perform full update of `nextclade.tsv` file periodically, recomputing clades for all of the GISAID sequences (~200k as on November 2020) all over again, to account for changes in the data. Same goes for when updating Nextclade versions, as they may lead to changes in clade assignment logic. Massive amounts of compute is required and it is not currently feasible to do this computation on current infrastructure, so it should be done elsewhere. It takes approximately 2-3 hours on a 16 core/32 threads machine for 200k sequences.
+Clades assigned with Nextclade are currently cached in `nextclade.tsv` on S3 bucket and only incremental updates for new sequences are performed during the daily ingests. This clade cache goes stale with time. It is necessary to perform full update of `nextclade.tsv` file periodically, recomputing clades for all of the GISAID sequences all over again, to account for changes in the data. Same goes for when updating Nextclade versions, as they may lead to changes in clade assignment logic. Massive amounts of compute is required and it is not currently feasible to do this computation on current infrastructure, so it should be done elsewhere. As of November 2020, for 200k sequences, it takes approximately 2-3 hours on an on-prem Xeon machine with 16 cores/32 threads.
 
-Python 3.6+, Node.js >= 12 and yarn v1 are required.
-Use `./bin/gisaid-get-all-clades` to perform this update:
+Use `./bin/gisaid-get-all-clades` to perform this update.
+Python >= 3.6+, Node.js >= 12 (14 recommended) and yarn v1 are required.
 
 ```
 git clone https://github.com/nextstrain/ncov-ingest
@@ -81,7 +81,9 @@ The resulting `data/gisaid/nextclade.tsv` should be placed on S3 bucked, replaci
 ./bin/upload-to-s3 data/gisaid/nextclade.tsv s3://nextstrain-ncov-private/nextclade.tsv.gz
 ```
 
-It will be picked up by the next ingest. The best time for the update is between daily builds. There is usually no rush, even if the globally recomputed `nextclade.tsv` is lagging behind one or two days, it will be incrementally updated by the next daily ingest. 
+It will be picked up by the next ingest.
+
+The best time for the update is between daily builds. There is usually no rush, even if the globally recomputed `nextclade.tsv` is lagging behind one or two days, it will be incrementally updated by the next daily ingest.
 
 
 ## Required dependencies

--- a/bin/gisaid-get-all-clades
+++ b/bin/gisaid-get-all-clades
@@ -33,7 +33,7 @@ bzip2 -cdk "${TMP_DIR}/gisaid.ndjson.bz2" >"data/gisaid/gisaid.ndjson"
   --output-unix-newline
 
 ./bin/run-nextclade \
-  "data/gisaid/nextclade.sequences.fasta" \
+  "data/gisaid/sequences.fasta" \
   "data/gisaid/nextclade.tsv"
 
 ./bin/join-metadata-and-clades \

--- a/bin/gisaid-get-all-clades
+++ b/bin/gisaid-get-all-clades
@@ -20,6 +20,7 @@ mkdir -p "${TMP_DIR}"
 if [ -f "data/gisaid/gisaid.ndjson" ]; then
   echo "Note: 'data/gisaid/gisaid.ndjson' already exists. Reusing it and skipping download step."
   echo "Note: to start fresh, remove the following files: 'rm data/gisaid/{gisaid.ndjson,metadata.tsv,sequences.fasta}'"
+  echo ""
 else
   wget \
     --directory-prefix="${TMP_DIR}" \
@@ -33,6 +34,7 @@ fi
 
 if [ -f "data/gisaid/metadata.tsv" ] && [ -f "data/gisaid/sequences.fasta" ]; then
   echo "Note: 'data/gisaid/metadata.tsv' and 'data/gisaid/sequences.fasta' already exist. Reusing them and skipping transform step. Delete these files to start fresh."
+  echo ""
 else
   ./bin/transform-gisaid "data/gisaid/gisaid.ndjson" \
     --output-metadata "data/gisaid/metadata.tsv" \

--- a/bin/gisaid-get-all-clades
+++ b/bin/gisaid-get-all-clades
@@ -7,13 +7,13 @@ trap "exit" INT
 
 TMP_DIR="data/gisaid/tmp"
 
-: "${GISAID_USERNAME:?The GISAID_USERNAME environment variable is required.}"
-: "${GISAID_PASSWORD:?The GISAID_PASSWORD environment variable is required.}"
-: "${GISAID_URL:?The GISAID_URL environment variable is required.}"
-
 # Load environment variables from these files, if exist
 [ -f ".env" ] && source ".env"
 [ -f "../.env" ] && source "../.env"
+
+: "${GISAID_USERNAME:?The GISAID_USERNAME environment variable is required.}"
+: "${GISAID_PASSWORD:?The GISAID_PASSWORD environment variable is required.}"
+: "${GISAID_URL:?The GISAID_URL environment variable is required.}"
 
 mkdir -p "${TMP_DIR}"
 
@@ -25,20 +25,17 @@ wget \
   "${GISAID_URL}" \
   -O "${TMP_DIR}/gisaid.ndjson.bz2"
 
-bzip2 -cdk "${TMP_DIR}/gisaid.ndjson.bz2" >"${GISAID_NDJSON}"
+bzip2 -cdk "${TMP_DIR}/gisaid.ndjson.bz2" >"data/gisaid/gisaid.ndjson"
 
-# Convert .ndjson into big `sequences.fasta` and `metadata.tsv`
 ./bin/transform-gisaid "data/gisaid/gisaid.ndjson" \
   --output-metadata "data/gisaid/metadata.tsv" \
   --output-fasta "data/gisaid/sequences.fasta" \
-  --output-additional-info "data/gisaid/additional_info.tsv"
+  --output-unix-newline
 
-# Run nextclade in parallel batches from `sequences.fasta`, produce `nextclade.clades.tsv`
 ./bin/run-nextclade \
-  "data/gisaid/sequences.fasta" \
+  "data/gisaid/nextclade.sequences.fasta" \
   "data/gisaid/nextclade.tsv"
 
-# Join `metadata.tsv` and `nextclade.clades.tsv`, produce `metadata2.tsv`
 ./bin/join-metadata-and-clades \
   "data/gisaid/metadata.tsv" \
   "data/gisaid/nextclade.tsv" \

--- a/bin/gisaid-get-all-clades
+++ b/bin/gisaid-get-all-clades
@@ -17,20 +17,28 @@ TMP_DIR="data/gisaid/tmp"
 
 mkdir -p "${TMP_DIR}"
 
-# Get .ndjson
-wget \
-  --directory-prefix="${TMP_DIR}" \
-  --http-user="${GISAID_USERNAME}" \
-  --http-password="${GISAID_PASSWORD}" \
-  "${GISAID_URL}" \
-  -O "${TMP_DIR}/gisaid.ndjson.bz2"
+if [ -f "data/gisaid/gisaid.ndjson" ]; then
+  echo "Note: 'data/gisaid/gisaid.ndjson' already exists. Reusing it and skipping download step."
+  echo "Note: to start fresh, remove the following files: 'rm data/gisaid/{gisaid.ndjson,metadata.tsv,sequences.fasta}'"
+else
+  wget \
+    --directory-prefix="${TMP_DIR}" \
+    --http-user="${GISAID_USERNAME}" \
+    --http-password="${GISAID_PASSWORD}" \
+    "${GISAID_URL}" \
+    -O "${TMP_DIR}/gisaid.ndjson.bz2"
 
-bzip2 -cdk "${TMP_DIR}/gisaid.ndjson.bz2" >"data/gisaid/gisaid.ndjson"
+  bzip2 -cdk "${TMP_DIR}/gisaid.ndjson.bz2" >"data/gisaid/gisaid.ndjson"
+fi
 
-./bin/transform-gisaid "data/gisaid/gisaid.ndjson" \
-  --output-metadata "data/gisaid/metadata.tsv" \
-  --output-fasta "data/gisaid/sequences.fasta" \
-  --output-unix-newline
+if [ -f "data/gisaid/metadata.tsv" ] && [ -f "data/gisaid/sequences.fasta" ]; then
+  echo "Note: 'data/gisaid/metadata.tsv' and 'data/gisaid/sequences.fasta' already exist. Reusing them and skipping transform step. Delete these files to start fresh."
+else
+  ./bin/transform-gisaid "data/gisaid/gisaid.ndjson" \
+    --output-metadata "data/gisaid/metadata.tsv" \
+    --output-fasta "data/gisaid/sequences.fasta" \
+    --output-unix-newline
+fi
 
 ./bin/run-nextclade \
   "data/gisaid/sequences.fasta" \

--- a/bin/join-rows
+++ b/bin/join-rows
@@ -19,7 +19,11 @@ def main():
     args = parse_args()
 
     left = pd.read_csv(args.first_file, sep='\t', low_memory=False, na_filter = False)
-    right = pd.read_csv(args.second_file, sep='\t', low_memory=False, na_filter = False)
+
+    try:
+        right = pd.read_csv(args.second_file, sep='\t', low_memory=False, na_filter = False)
+    except FileNotFoundError:
+        right = pd.DataFrame().reindex_like(left)
 
     result = pd.concat([left, right], join='outer')
 

--- a/bin/run-nextclade
+++ b/bin/run-nextclade
@@ -20,8 +20,6 @@ set -o nounset
 set -o pipefail
 trap "exit" INT
 
-set -x
-
 INPUT_FASTA=${1}
 OUTPUT_TSV=${2}
 TMP_DIR_FASTA="tmp/fasta"

--- a/bin/run-nextclade
+++ b/bin/run-nextclade
@@ -27,7 +27,7 @@ TMP_DIR_CLADES="tmp/clades"
 INPUT_WILDCARD="${TMP_DIR_FASTA}/*.fasta"
 OUTPUT_WILDCARD="${TMP_DIR_CLADES}/*.tsv"
 
-BATCH_SIZE=200
+BATCH_SIZE=${BATCH_SIZE:=200}
 
 # Default number of processes, if not provided.
 # Usually equals to the sum of numbers of logical cores ("threads") on all CPUs

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "@neherlab/nextclade": "0.8.0-alpha.1"
+    "@neherlab/nextclade": "0.8.0-alpha.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "@neherlab/nextclade": "0.8.0-alpha.5"
+    "@neherlab/nextclade": "0.8.0-alpha.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "@neherlab/nextclade": "0.8.0-1"
+    "@neherlab/nextclade": "0.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "@neherlab/nextclade": "0.8.0-alpha.4"
+    "@neherlab/nextclade": "0.8.0-alpha.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "@neherlab/nextclade": "0.8.0-alpha.6"
+    "@neherlab/nextclade": "0.8.0-1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@neherlab/nextclade@0.8.0-alpha.1":
-  version "0.8.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@neherlab/nextclade/-/nextclade-0.8.0-alpha.1.tgz#5df06f0d0caa164535244869820ceb03e9c7a33a"
-  integrity sha512-yRsz4eLS60xINYhV639QmK18+1qyhN1jA7Her0aYz8Tsx364grhxCus8FkBhsq/mashm2zdoUR6xQPN4Of2Mwg==
+"@neherlab/nextclade@0.8.0-alpha.4":
+  version "0.8.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@neherlab/nextclade/-/nextclade-0.8.0-alpha.4.tgz#acbdd12b7cf6314ce74a43207fa3458ef7c25852"
+  integrity sha512-rD+mkM+UkVy150SeQ4ubU3bZYZDdANT3NJAnffapoSqg1Q3Hn6vGT/ngN7vGwUyn71FlXYvEifKqht+cSRwrJQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@neherlab/nextclade@0.8.0-1":
-  version "0.8.0-1"
-  resolved "https://registry.yarnpkg.com/@neherlab/nextclade/-/nextclade-0.8.0-1.tgz#32b596aa8b276ce937570ccdc052aa3612108839"
-  integrity sha512-FI2gB1L0V7X1+o+Qb1IMQBJLp6I+ndgbkGyTgHzox/NgDLfnk1FoVvHEcF5EVxY03GsYwlJkwUlT0bxmbNEntQ==
+"@neherlab/nextclade@0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@neherlab/nextclade/-/nextclade-0.8.1.tgz#90a60c25921944bc77c630e6bd84edab4b2e5a77"
+  integrity sha512-WqJRO+K3LXywYdOCbvzPx82SnHLfMYnlKN2d5xwDEFbUWc4PHxfGZ6jTRnWvIHoruxTbrkJZRlFK/d/2hWn5YQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@neherlab/nextclade@0.8.0-alpha.4":
-  version "0.8.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/@neherlab/nextclade/-/nextclade-0.8.0-alpha.4.tgz#acbdd12b7cf6314ce74a43207fa3458ef7c25852"
-  integrity sha512-rD+mkM+UkVy150SeQ4ubU3bZYZDdANT3NJAnffapoSqg1Q3Hn6vGT/ngN7vGwUyn71FlXYvEifKqht+cSRwrJQ==
+"@neherlab/nextclade@0.8.0-alpha.5":
+  version "0.8.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/@neherlab/nextclade/-/nextclade-0.8.0-alpha.5.tgz#6076a5a0ffa3c44b4a2444511259cee292dee809"
+  integrity sha512-RtvFGwVqNKe7zKrzhNJkEWT8tZYqVapaqDt9R6vIUpMVXzjhvJOaVVlj2zq+xaJ8HPQ+c4tJLKa6q3SihQ6iBA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@neherlab/nextclade@0.8.0-alpha.6":
-  version "0.8.0-alpha.6"
-  resolved "https://registry.yarnpkg.com/@neherlab/nextclade/-/nextclade-0.8.0-alpha.6.tgz#d32e68f3bee12b762921b61715ae7cf84045d908"
-  integrity sha512-+6tdeAZ/Bt+z+JJFhn8Zu8OstQXYz2ZGWl5yEM+qlvySnUhIR0dPDzNTZxOTuJ7cN2S9XXCT2l2KOkyw/hvTaQ==
+"@neherlab/nextclade@0.8.0-1":
+  version "0.8.0-1"
+  resolved "https://registry.yarnpkg.com/@neherlab/nextclade/-/nextclade-0.8.0-1.tgz#32b596aa8b276ce937570ccdc052aa3612108839"
+  integrity sha512-FI2gB1L0V7X1+o+Qb1IMQBJLp6I+ndgbkGyTgHzox/NgDLfnk1FoVvHEcF5EVxY03GsYwlJkwUlT0bxmbNEntQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@neherlab/nextclade@0.8.0-alpha.5":
-  version "0.8.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@neherlab/nextclade/-/nextclade-0.8.0-alpha.5.tgz#6076a5a0ffa3c44b4a2444511259cee292dee809"
-  integrity sha512-RtvFGwVqNKe7zKrzhNJkEWT8tZYqVapaqDt9R6vIUpMVXzjhvJOaVVlj2zq+xaJ8HPQ+c4tJLKa6q3SihQ6iBA==
+"@neherlab/nextclade@0.8.0-alpha.6":
+  version "0.8.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/@neherlab/nextclade/-/nextclade-0.8.0-alpha.6.tgz#d32e68f3bee12b762921b61715ae7cf84045d908"
+  integrity sha512-+6tdeAZ/Bt+z+JJFhn8Zu8OstQXYz2ZGWl5yEM+qlvySnUhIR0dPDzNTZxOTuJ7cN2S9XXCT2l2KOkyw/hvTaQ==


### PR DESCRIPTION
### Description of proposed changes    
What is the goal of this pull request? What does this pull request change?

This upgrades nextclade to v0.8.0-alpha5, which introduces new European subclades, notably 20A.EU1 and 20A.EU2. This means that `nextclade.tsv` and `metadata.tsv` will contain these new clades instead of 20A, for some of the 20A sequences.

After approved, before merging and before next daily ingest, we need to replace the `nextclade.tsv` on S3 with recomputed one, containing new clades for all sequences processed in the past.

The old and new `nextclade.tsv` and `metadata.tsv` are provided in Slack channel.

Additionally, this PR cleans up the global recompute script (which allows to obtain these updated files).

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Related to https://github.com/nextstrain/nextclade/pull/239

### Testing
What steps should be taken to test the changes you've proposed?  
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?  

Compare new and old `nextclade.tsv` and `metadata.tsv` and see if it makes sense.

The comparison

### Thank you for contributing to Nextstrain!
