### PR TITLE
bin/transform-gisaid address #103 strain name bug

### DIFF
--- a/bin/transform-gisaid
+++ b/bin/transform-gisaid
@@ -174,6 +174,7 @@ if __name__ == '__main__':
             )
             metadata_csv.writeheader()
 
+            updated_strain_names_by_line_no = {}
             for entry in sorted_metadata:
                 if entry[LINE_NUMBER_KEY] in line_numbers:
                     additional_info_csv.writerow(entry)
@@ -182,6 +183,8 @@ if __name__ == '__main__':
                     if args.sorted_fasta:
                         fasta_fh.write(f">{entry['strain']}\n")
                         fasta_fh.write(f"{entry['sequence']}\n")
+                    else:
+                        updated_strain_names_by_line_no[entry[LINE_NUMBER_KEY]] = entry['strain']
 
         if not args.sorted_fasta:
             with open(args.gisaid_data, "r") as gisaid_fh:
@@ -192,5 +195,6 @@ if __name__ == '__main__':
                         | SequenceLengthFilter(15000)
                         | LineNumberFilter(line_numbers)
                 ):
-                    fasta_fh.write(f">{entry['strain']}\n")
+                    strain_name = updated_strain_names_by_line_no[entry[LINE_NUMBER_KEY]]
+                    fasta_fh.write(f">{strain_name}\n")
                     fasta_fh.write(f"{entry['sequence']}\n")


### PR DESCRIPTION
this is an attempt to fix a #103 
where the strain names output
by bin/transform were not consistent
across metadata and fasta output files.
Since this was only an issue when
--sorted-fasta was not passed, this
addresses the issue by adding logic
to use strain names from the transformed
metadata list (to match the metadata output)
when writing out an unsorted fasta.

### Testing
Tested locally with bin/local-ingest-gisaid --transform which resulted in a clean diff (instructions for diff to illustrate the bug are in #103).
Also tested memory usage (only once) using `/usr/bin/time -l pipenv run bin/local-ingest-gisaid --transform` which showed  only a ~28MB increase when running transform (as in bin/local-ingest-gisaid) with this commit compared to running without. This seems to avoid the larger scale (~5.5GB) increase of using --sorted-fasta.