### PR TITLE
Upgrade Nextclade to 0.11.1 with new clades

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "@neherlab/nextclade": "0.10.0"
+    "@neherlab/nextclade": "0.11.0-alpha.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "@neherlab/nextclade": "0.11.0-alpha.1"
+    "@neherlab/nextclade": "0.11.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@neherlab/nextclade@0.11.0-alpha.1":
-  version "0.11.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@neherlab/nextclade/-/nextclade-0.11.0-alpha.1.tgz#8e7d14ae36048553b6d587de13b705e8f1d21856"
-  integrity sha512-a99Z6tuCH/n3GvfjoGSkfTGyFjMwWQkHQkT7c3blIRk45dI+JQFQ1wLOQNWsse/48WP5Hedplp/a75oyKsblVg==
+"@neherlab/nextclade@0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@neherlab/nextclade/-/nextclade-0.11.1.tgz#e966552bedb38dad9e8d23a5b1d7e3c8bdfaf567"
+  integrity sha512-0saRyNuvd8q+GRakCVMrokib+GP7JNAgjI15y/8E3OPwPtiJsGQxe0/516VDthGZllEsyTTPsAGOh2E8J/pwqQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@neherlab/nextclade@0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@neherlab/nextclade/-/nextclade-0.8.1.tgz#90a60c25921944bc77c630e6bd84edab4b2e5a77"
-  integrity sha512-WqJRO+K3LXywYdOCbvzPx82SnHLfMYnlKN2d5xwDEFbUWc4PHxfGZ6jTRnWvIHoruxTbrkJZRlFK/d/2hWn5YQ==
+"@neherlab/nextclade@0.11.0-alpha.1":
+  version "0.11.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@neherlab/nextclade/-/nextclade-0.11.0-alpha.1.tgz#8e7d14ae36048553b6d587de13b705e8f1d21856"
+  integrity sha512-a99Z6tuCH/n3GvfjoGSkfTGyFjMwWQkHQkT7c3blIRk45dI+JQFQ1wLOQNWsse/48WP5Hedplp/a75oyKsblVg==


### PR DESCRIPTION
### Description of proposed changes    

This brings the new upcoming clades, as described in 
https://virological.org/t/updated-nextstain-sars-cov-2-clade-naming-strategy/581

The Nextclade default tree was updated here: https://github.com/nextstrain/nextclade/pull/293


### Related issue(s)  

### Testing


### Thank you for contributing to Nextstrain!
