### PR TITLE
Support for gzipped fasta files throughout workflow

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ pandas = ">=1.0.1"
 s3fs = "*"
 biopython = "*"
 regex = "*"
+python-magic = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -207,6 +207,14 @@
             ],
             "version": "==2.8.1"
         },
+        "python-magic": {
+            "hashes": [
+                "sha256:356efa93c8899047d1eb7d3eb91e871ba2f5b1376edbaf4cc305e3c872207355",
+                "sha256:b757db2a5289ea3f1ced9e60f072965243ea43a2221430048fd8cacab17be0ce"
+            ],
+            "index": "pypi",
+            "version": "==0.4.18"
+        },
         "pytz": {
             "hashes": [
                 "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed",

--- a/bin/notify-on-record-change
+++ b/bin/notify-on-record-change
@@ -13,8 +13,12 @@ source_name=${3:?A record source name is required as the third argument.}
 # if the file is not already present, just exit
 "$bin"/s3-object-exists "$dst" || exit 0
 
-src_record_count="$(wc -l < "$src")"
-dst_record_count="$(wc -l < <(aws s3 cp --no-progress "$dst" - | gunzip -cfq))"
+if [[ "$src" == *.gz ]]; then
+    src_record_count="$(gunzip -c "$src" | wc -l)"
+else
+    src_record_count="$(wc -l "$src")"
+fi
+dst_record_count="$(aws s3 cp --no-progress "$dst" - | gunzip -cfq | wc -l)"
 added_records="$(( src_record_count - dst_record_count ))"
 
 printf "%'4d %s\n" "$src_record_count" "$src"

--- a/bin/transform-gisaid
+++ b/bin/transform-gisaid
@@ -2,11 +2,16 @@
 """
 Parse the GISAID NDJSON load into a metadata tsv and a FASTA file.
 """
-import os
 import argparse
+import contextlib
 import csv
+import gzip
+import io
+import os
 import sys
 from pathlib import Path
+
+from magic import from_buffer
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
 from utils.transform import (
@@ -42,6 +47,27 @@ assert 'sequence' not in METADATA_COLUMNS, "Sequences should not appear in metad
 assert 'sequence' not in ADDITIONAL_INFO_COLUMNS, "Sequences should not appear in additional info!"
 
 
+@contextlib.contextmanager
+def open_read_maybe_gz(filepath):
+    with open(filepath, "rb") as stream:
+        # peek to see if it's a gzip file
+        file_type = from_buffer(stream.peek())
+        if file_type.find("gzip") != -1:
+            yield gzip.open(stream, "rt")
+        else:
+            yield io.TextIOWrapper(stream)
+
+
+@contextlib.contextmanager
+def open_write_maybe_gz(filepath, newline=None):
+    with open(filepath, "wb") as stream:
+        if filepath.lower().endswith(".gz"):
+            with gzip.GzipFile(fileobj=stream, mode="wb") as stream:
+                yield io.TextIOWrapper(stream, newline=newline)
+        else:
+            yield io.TextIOWrapper(stream, newline=newline)
+
+
 if __name__ == '__main__':
     base = Path(__file__).resolve().parent.parent
 
@@ -50,7 +76,7 @@ if __name__ == '__main__':
         formatter_class=argparse.RawTextHelpFormatter
     )
     parser.add_argument("gisaid_data",
-        default="s3://nextstrain-ncov-private/gisaid.ndjson.gz",
+        default="data/gisaid.ndjson.gz",
         help="Newline-delimited GISAID JSON data")
     parser.add_argument("--annotations",
         default=base / "source-data/gisaid_annotations.tsv",
@@ -106,7 +132,7 @@ if __name__ == '__main__':
                     value.split('#')[0].rstrip(),
                 )
 
-    with open(args.gisaid_data, "r") as gisaid_fh:
+    with open_read_maybe_gz(args.gisaid_data) as gisaid_fh:
         pipeline = (
             LineToJsonDataSource(gisaid_fh)
             | RenameAndAddColumns()
@@ -152,7 +178,7 @@ if __name__ == '__main__':
         seen_strains.add(entry['strain'])
         line_numbers.add(entry[LINE_NUMBER_KEY])
 
-    with open(args.output_fasta, "wt", newline=args.newline) as fasta_fh:
+    with open_write_maybe_gz(args.output_fasta, newline=args.newline) as fasta_fh:
         with open(args.output_additional_info, "wt", newline="") as additional_info_fh, \
              open(args.output_metadata, "wt", newline="") as metadata_fh:
             dict_writer_kwargs = {'lineterminator': args.newline}
@@ -190,7 +216,7 @@ if __name__ == '__main__':
                         updated_strain_names_by_line_no[entry[LINE_NUMBER_KEY]] = entry['strain']
 
         if not args.sorted_fasta:
-            with open(args.gisaid_data, "r") as gisaid_fh:
+            with open_read_maybe_gz(args.gisaid_data) as gisaid_fh:
                 for entry in (
                         LineToJsonDataSource(gisaid_fh)
                         | RenameAndAddColumns()

--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -19,12 +19,22 @@ main() {
     local src="${1:?A source file is required as the first argument.}"
     local dst="${2:?A destination s3:// URL is required as the second argument.}"
 
+    local src_hash
+    if [[ "$src" == *.gz ]]; then
+        src_hash="$(gunzip -c "$src" | "$bin/sha256sum")"
+    else
+        src_hash="$("$bin/sha256sum" < "$src")"
+    fi
     local s3path="${dst#s3://}"
     local bucket="${s3path%%/*}"
     local key="${s3path#*/}"
 
     local src_hash dst_hash no_hash=0000000000000000000000000000000000000000000000000000000000000000
-    src_hash="$("$bin/sha256sum" < "$src")"
+    if [[ "$src" == *.gz ]]; then
+        src_hash="$(gunzip -c "$src" | "$bin/sha256sum")"
+    else
+        src_hash="$("$bin/sha256sum" < "$src")"
+    fi
     dst_hash="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text || echo "$no_hash")"
 
     echo "$src_hash $src"
@@ -32,8 +42,12 @@ main() {
 
     if [[ $src_hash != "$dst_hash" ]]; then
         echo "Uploading $src → $dst"
-        if [[ "$dst" == *.gz ]]; then
+        if [[ "$dst" == *.gz ]] && [[ "$src" != *.gz ]]; then
+            # src is not a gzip file but the dst is, so we need to compress it.
             gzip -c "$src"
+        elif [[ "$dst" != *.gz ]] && [[ "$src" == *.gz ]]; then
+            # src is not a zip file but the dst is not, so we need to decompress it.
+            gunzip -c "$src"
         else
             cat "$src"
         fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash" "$(content-type "$dst")" "$(content-encoding "$dst")"


### PR DESCRIPTION
### Description of proposed changes    
1. Upload and delta change scripts understand .gz files.  Checksums are still performed on uncompressed data.  This works out well, because we compress at most once, and uncompressing is cheap.
2. `bin/transform-gisaid` will inspect the input to see if it's gzipped.  If so, it unzips it.
3. `bin/transform-gisaid` will use the output filename to decide whether or not to compress it on the fly.

### Testing
Launched a build where we keep most files compressed.  We had an earlier version of the workflow without the nextclade integration, but when rebased, it'll likely be problematic.  However, this workflow can still operate on uncompressed data, so it is backwards compatible.
