### PR TITLE
Launch ncov builds using the up-and-coming new nextstrain/base image

### DIFF
--- a/bin/launch-build
+++ b/bin/launch-build
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 nextstrain build --aws-batch --cpus 96 --memory 180GiB --detach \
-    --image nextstrain/base:branch-python-base \
     "$@" \
     --profile nextstrain_profiles/nextstrain \
     --set-threads tree=16

--- a/bin/launch-build
+++ b/bin/launch-build
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 nextstrain build --aws-batch --cpus 96 --memory 180GiB --detach \
+    --image nextstrain/base:branch-python-base \
     "$@" \
     --profile nextstrain_profiles/nextstrain \
     --set-threads tree=16

--- a/bin/rebuild-staging
+++ b/bin/rebuild-staging
@@ -66,6 +66,22 @@ main() {
 
     echo "Notifying Slack about rebuild."
     "$bin"/notify-slack "A new staging build was submitted. Follow along in your local ncov repo with: "'```'"nextstrain build --aws-batch --attach $aws_batch_job_id ."'```'
+
+
+    echo "Launching a trial build for nextstrain/base:branch-python-base"
+
+    # Must use a config file because Snakemake's --config options seemingly
+    # don't override the profile's config files as they should.  Not sure why.
+    tee ncov/trial.yaml <<<"
+---
+S3_BUCKET: nextstrain-ncov-private/branch/new-build-base-image
+s3_staging_url: s3://nextstrain-staging/trial_
+"
+
+    "$bin"/launch-build \
+        --image nextstrain/base:branch-python-base \
+        ncov deploy_to_staging upload \
+        --configfile trial.yaml
 }
 
 # Returns 1 if both files match (have identical hashes). Else returns 0.


### PR DESCRIPTION
This helps us test the new image internally before making it the default.¹

I launched a quick test with:

    ./bin/launch-build --exec uname /var/empty

to make sure that builds can still start. ~Waiting on success as Batch hasn't scheduled the job onto a node yet.~ Update: it started fine and the job definition uses the expected image.

¹ https://github.com/nextstrain/docker-base/pull/21