### PR TITLE
flag-metadata: Flag collection dates prior to March 2020

### DIFF
--- a/bin/flag-metadata
+++ b/bin/flag-metadata
@@ -22,8 +22,9 @@ if __name__ == '__main__':
         help="Location of generated metadata tsv. Defaults to `data/gisaid/metadata.tsv`")
     args = parser.parse_args()
 
-    metadata = pd.read_csv(args.metadata, sep="\t")
+    metadata = pd.read_csv(args.metadata, sep="\t", dtype="string")
     metadata.loc[metadata.date > str(date.today()), 'reason'] = '# Collection date in the future'
+    metadata.loc[(metadata.date < "2020-03-01") & (metadata.date.str.len() == 10), 'reason'] = '# Collection date prior to March 2020'
     flagged_strains = metadata.loc[metadata.reason.notnull()]
 
     print(flagged_strains[['strain', 'reason']].to_csv(header=False, index=False, sep='\t'))


### PR DESCRIPTION
While there are many valid sequences with such dates already in this
dataset, vanishingly few _new_ sequences are likely to appear with such
dates.  They're more likely to be typos for early 2021 dates, so the
build shepherds want notice of them.

This will change the steady state of flagged_metadata.txt from empty to
several thousand lines, but that should be ok, I think.