### PR TITLE
Update to use pango_lineage 

### DIFF
--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -6,7 +6,7 @@ import pandas as pd
 
 INPUT_CLADE_COLUMN = "clade"
 OUTPUT_CLADE_COLUMN = "Nextstrain_clade"
-INSERT_BEFORE_THIS_COLUMN = "pangolin_lineage"
+INSERT_BEFORE_THIS_COLUMN = "pango_lineage"
 METADATA_JOIN_COLUMN_NAME = 'strain'
 NEXTCLADE_JOIN_COLUMN_NAME = 'seqName'
 VALUE_CLADE_MISSING = '-'

--- a/bin/transform-genbank
+++ b/bin/transform-genbank
@@ -164,7 +164,7 @@ def generate_hardcoded_metadata(genbank_data: pd.DataFrame) -> pd.DataFrame:
     hardcoded_metadata['segment']           = 'genome'
     hardcoded_metadata['age']               = '?'
     hardcoded_metadata['sex']               = '?'
-    hardcoded_metadata['pangolin_lineage']  = '?'
+    hardcoded_metadata['pango_lineage']  = '?'
     hardcoded_metadata['GISAID_clade']      = '?'
     hardcoded_metadata['originating_lab']   = '?'
     hardcoded_metadata['submitting_lab']    = '?'

--- a/lib/utils/transform.py
+++ b/lib/utils/transform.py
@@ -9,7 +9,7 @@ from typing import List, Optional, Set, Union
 METADATA_COLUMNS = [  # Ordering of columns in the existing metadata.tsv in the ncov repo
     'strain', 'virus', 'gisaid_epi_isl', 'genbank_accession', 'date', 'region',
     'country', 'division', 'location', 'region_exposure', 'country_exposure',
-    'division_exposure', 'segment', 'length', 'host', 'age', 'sex', 'pangolin_lineage', 'GISAID_clade',
+    'division_exposure', 'segment', 'length', 'host', 'age', 'sex', 'pango_lineage', 'GISAID_clade',
     'originating_lab', 'submitting_lab', 'authors', 'url', 'title', 'paper_url',
     'date_submitted', 'purpose_of_sequencing'
 ]

--- a/lib/utils/transformpipeline/transforms.py
+++ b/lib/utils/transformpipeline/transforms.py
@@ -179,7 +179,7 @@ class RenameAndAddColumns(Transformer):
         'covv_authors': 'authors',
         'covv_patient_age': 'age',
         'covv_gender': 'sex',
-        'covv_lineage': 'pangolin_lineage',
+        'covv_lineage': 'pango_lineage',
         'covv_clade': 'GISAID_clade',
         'covv_add_host_info': 'additional_host_info',
         'covv_add_location': 'additional_location_info',


### PR DESCRIPTION
### Description of proposed changes    
What comes in from GISAID is `covv_lineage`. We previously renamed this to `pangolin_lineage`, but in `ncov` PR [568](https://github.com/nextstrain/ncov/pull/568) we decided to rename this to `pango_lineage` to reflect the updated naming of this nomenclature scheme.

However, this currently isn't working, because in the rest of the pipeline we are still calling it `pangolin_lineage` starting with this renaming in `ncov-ingest`.

This PR changes the rename to `pango_lineage` and hopefully catches all other instances where this is referred to by name. (I found all instances through simple `grep` so if that may not have been sufficient please double-check I caught them all!)

Would appreciate extra eyes on this as I haven't tested it.

### Testing
UNTESTED
