### PR TITLE
Generalizing rules script

### DIFF
--- a/bin/detect-generalizable-geoRules
+++ b/bin/detect-generalizable-geoRules
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+import sys
+import csv
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "lib"))
+from utils.transform import (
+    METADATA_COLUMNS,
+)
+
+from utils.transformpipeline.transforms import UserProvidedGeoLocationSubstitutionRules
+import argparse
+from collections import defaultdict
+
+if __name__ == '__main__':
+    
+
+    parser = argparse.ArgumentParser(
+        description="Parse a file containing substitutions rules for geographic locations and assess if the rules are compatible.",
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+    parser.add_argument("--geo-location-rules", required = True,
+        help="Optional manually curated rules to correct geographical location.\n"
+            "The TSV file should have no header and exactly 8 columns which contain:\n\t"
+            "1. the raw region\n\t"
+            "2. the raw country\n\t"
+            "3. the raw division\n\t"
+            "4. the raw location\n\t"
+            "5. the transformed region\n\t"
+            "6. the transformed country\n\t"
+            "7. the transformed division\n\t"
+            "8. the transformed location\n\t"
+        "Lines or parts of lines starting with '#' are treated as comments.\n"
+        "e.g.\n\t"
+        "Europe Spain   Catalunya   Mataró  Europe  Spain   Catalunya   Mataro\n\t")
+
+
+    args = parser.parse_args()
+
+    geoRules = UserProvidedGeoLocationSubstitutionRules()
+    if args.geo_location_rules :
+        # use curated rules to subtitute known spurious locations with correct ones
+        with open(args.geo_location_rules,'r') as geo_location_rules_fh :
+            csvreader = csv.reader(geo_location_rules_fh, delimiter='\t')
+            for row in csvreader:
+                if row[0].lstrip()[0] == '#':
+                    continue
+                elif len(row) != 8:
+                    print("WARNING: couldn't decode annotation line " + "\t".join(row))
+                    continue
+                row[-1] = row[-1].partition('#')[0].rstrip()
+                raw , annot = tuple( row[:4] ) , tuple( row[4:8] )
+                # remove the comment and the extra ws from the value
+
+                geoRules.add_user_rule(
+                    raw,
+                    annot
+                )
+
+    print('rules read')
+
+    potentiallyGeneral = {}
+    potentiallyGeneralList = defaultdict(list)
+    problemGeneralization = set()
+
+
+    for region , countries in geoRules.entries.items():
+        for country , divisions in countries.items():
+            for division , locations in divisions.items():
+                for location , arrival in locations.items() :
+                    
+                    raw=tuple([region,country,division,location])
+
+                    # We want to detect cases such as 
+                    # a/b/c/d -> a/b/C/d
+                    # in which case we could generalize to a/b/c/* -> a/b/C/*
+                    # NB : in general we want to keep the upper levels in the substitution pattern
+
+                    # finding which fields are candidate to generalization
+                    generalizable = []
+                    for i in [3,2,1,0]:
+                        if raw[i] == arrival[i] and raw[i]!='*':
+                            generalizable.append(i)
+                        else :
+                            break
+
+                    if len(generalizable) > 0 :
+
+                        generalizedRaw = list(raw)
+                        generalizedArrival = list(arrival)
+                        for i in generalizable:
+                            generalizedRaw[i] = '*'
+                            generalizedArrival[i] = '*'
+
+                        generalizedRaw = tuple(generalizedRaw)
+                        generalizedArrival = tuple(generalizedArrival)
+
+
+                        # checking if this generalizable rule is already in conflict with another 
+                        if generalizedRaw in potentiallyGeneral and potentiallyGeneral[generalizedRaw] != generalizedArrival:
+                            problemGeneralization.add( generalizedRaw )
+
+                        # adding this generalized rule to the set
+                        potentiallyGeneral[generalizedRaw] = generalizedArrival
+                        potentiallyGeneralList[generalizedRaw].append( (raw , arrival) )
+
+    print('Generalization assessed.' , len(potentiallyGeneral) - len(problemGeneralization) , 'potential candidates.' )
+
+    sep1='\t'
+    sep2='\t'
+
+    for generalizedRaw,generalizedArrival in potentiallyGeneral.items():
+
+        if generalizedRaw in problemGeneralization: # ignore problem cases where generalization would create conflicts
+            continue
+
+        print('#***')
+        print('#Generalizes',len(potentiallyGeneralList[generalizedRaw]),"rules")
+        print(sep1.join(generalizedRaw),sep1.join(generalizedArrival) , "#GENERAL", sep=sep2 )
+        for generalized in potentiallyGeneralList[generalizedRaw]:
+
+            print('#SPECIFIC',sep1.join(generalized[0]),sep1.join(generalized[1]) , sep=sep2 )
+
+
+

--- a/bin/detect-generalizable-geoRules
+++ b/bin/detect-generalizable-geoRules
@@ -41,16 +41,24 @@ if __name__ == '__main__':
     if args.geo_location_rules :
         # use curated rules to subtitute known spurious locations with correct ones
         with open(args.geo_location_rules,'r') as geo_location_rules_fh :
-            csvreader = csv.reader(geo_location_rules_fh, delimiter='\t')
-            for row in csvreader:
-                if row[0].lstrip()[0] == '#':
+            
+            for line in geo_location_rules_fh :
+
+                if line.lstrip()[0] == '#':
                     continue
-                elif len(row) != 8:
+
+                row = line.strip('\n').split('\t')
+
+                raw,annot = None,None
+                if len(row) == 8:
+                    row[-1] = row[-1].partition('#')[0].rstrip()
+                    raw , annot = tuple( row[:4] ) , tuple( row[4:8] )
+                elif len(row) == 2:
+                    row[-1] = row[-1].partition('#')[0].rstrip()
+                    raw , annot = tuple( row[0].split('/') ) , tuple( row[1].split('/') )
+                else:
                     print("WARNING: couldn't decode annotation line " + "\t".join(row))
                     continue
-                row[-1] = row[-1].partition('#')[0].rstrip()
-                raw , annot = tuple( row[:4] ) , tuple( row[4:8] )
-                # remove the comment and the extra ws from the value
 
                 geoRules.add_user_rule(
                     raw,

--- a/bin/detect-generalizable-geoRules
+++ b/bin/detect-generalizable-geoRules
@@ -20,19 +20,12 @@ if __name__ == '__main__':
         formatter_class=argparse.RawTextHelpFormatter
     )
     parser.add_argument("--geo-location-rules", required = True,
-        help="Optional manually curated rules to correct geographical location.\n"
-            "The TSV file should have no header and exactly 8 columns which contain:\n\t"
-            "1. the raw region\n\t"
-            "2. the raw country\n\t"
-            "3. the raw division\n\t"
-            "4. the raw location\n\t"
-            "5. the transformed region\n\t"
-            "6. the transformed country\n\t"
-            "7. the transformed division\n\t"
-            "8. the transformed location\n\t"
+        help="manually curated rules to correct geographical location.\n"
+            "The TSV file should have no header and exactly 2 columns in the following format:\n\t"
+            "region/country/division/location<tab>region/country/division/location"
         "Lines or parts of lines starting with '#' are treated as comments.\n"
         "e.g.\n\t"
-        "Europe Spain   Catalunya   Mataró  Europe  Spain   Catalunya   Mataro\n\t")
+        "Europe/Spain/Catalunya/Mataró\tEurope/Spain/Catalunya/Mataro\n\t")
 
 
     args = parser.parse_args()
@@ -114,7 +107,7 @@ if __name__ == '__main__':
 
     print('Generalization assessed.' , len(potentiallyGeneral) - len(problemGeneralization) , 'potential candidates.' )
 
-    sep1='\t'
+    sep1='/'
     sep2='\t'
 
     for generalizedRaw,generalizedArrival in potentiallyGeneral.items():


### PR DESCRIPTION
### Description of proposed changes    

This PR adds a script that scans a set of pre-existing geographic substitution rules and tries to find rules that may be generalized.

It is designed to help ingest shepherd manage the substitution rules and is made to be ran once in a while.


### Testing

This script is disconnected from all other processes.
No test is needed expect with the script itself.

### Usage

./bin/detect-generalizable-geoRules --geo-location-rules source-data/gisaid_geoLocationRules.tsv 

Output will look like : 
```
rules read
Generalization assessed. 86 potential candidates.
#***
#Generalizes 3 rules
A/B/c/*	A/B/C/*	#GENERAL
#SPECIFIC	A/B/c/d	A/B/C/d
#SPECIFIC	A/B/c/e	A/B/C/e
#SPECIFIC	A/B/c/f	A/B/C/f
#***
#Generalizes 24 rules
X/Y/z/*	X/Y/Z/*	#GENERAL
#SPECIFIC	X/Y/z/1	X/Y/Z/1
#SPECIFIC	X/Y/z/2	X/Y/Z/2
...
```

So that each candidates general rule can be evaluated, and then added (or not) to the rule file.
Subsequent removal of the specific rules, now rendered redundant by the new general rules, should then be done using `bin/check-gisaid-geoRules`.


<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
