### PR TITLE
Improve transform genbank

### DIFF
--- a/bin/transform-genbank
+++ b/bin/transform-genbank
@@ -2,6 +2,7 @@
 """
 Parse the GenBank JSON load into a metadata tsv and a FASTA file.
 """
+import os
 import argparse
 import csv
 import sys
@@ -18,8 +19,17 @@ from utils.transform import (
     write_fasta_file,
 
 )
-from utils.transformpipeline.transforms import UserProvidedGeoLocationSubstitutionRules 
-
+from utils.transformpipeline import LINE_NUMBER_KEY
+from utils.transformpipeline.datasource import LineToJsonDataSource
+from utils.transformpipeline.filters import SequenceLengthFilter, LineNumberFilter
+from utils.transformpipeline.transforms import (
+    DropSequenceData,
+    RenameAndAddColumns,
+    StandardizeData,
+    StandardizeGenbankStrainNames,
+    UserProvidedAnnotations,
+    UserProvidedGeoLocationSubstitutionRules,
+)
 
 assert 'sequence' not in METADATA_COLUMNS, "Sequences should not appear in metadata!"
 
@@ -314,6 +324,8 @@ if __name__ == '__main__':
     parser.add_argument("--problem-data",
         default=base / "data/genbank/problem_data.tsv",
         help="Output location of generated tsv of problem records missing geography region or a valid strain name")
+    parser.add_argument("--sorted-fasta", action="store_true",
+        help="Sort the fasta file in the same order as the metadata file.  WARNING: Enabling this option can consume a lot of memory.")
     parser.add_argument("--geo-location-rules",
         default = str( base / "source-data/gisaid_geoLocationRules.tsv" ) ,
         help="Optional manually curated rules to correct geographical location.\n"
@@ -322,14 +334,102 @@ if __name__ == '__main__':
         "Lines or parts of lines starting with '#' are treated as comments.\n"
         "e.g.\n\t"
         "Europe/Spain/Catalunya/Mataró\tEurope/Spain/Catalunya/Mataro\n\t")
-
+    parser.add_argument(
+        "--output-unix-newline",
+        dest="newline",
+        action="store_const",
+        const="\n",
+        default=os.linesep,
+        help="When specified, always use unix newlines in output files."
+    )
     args = parser.parse_args()
 
-    genbank_data = pd.read_json(args.genbank_data,
-                                lines=True,
-                                compression='infer')
-    genbank_data = preprocess(genbank_data)
-    genbank_data = standardize_strain_names(genbank_data)
+
+    #parsing curated annotations
+    annotations = UserProvidedAnnotations()
+    if args.annotations:
+        # Use the curated annotations tsv to update any column values
+        with open(args.annotations, "r") as gisaid_fh:
+            csvreader = csv.reader(gisaid_fh, delimiter='\t')
+            for row in csvreader:
+                if row[0].lstrip()[0] == '#':
+                    continue
+                elif len(row) != 3:
+                    print("WARNING: couldn't decode annotation line " + "\t".join(row))
+                    continue
+                strainId, key, value = row
+                annotations.add_user_annotation(
+                    strainId,
+                    key,
+                    # remove the comment and the extra ws from the value
+                    value.split('#')[0].rstrip(),
+                )
+
+
+    accessions = UserProvidedAnnotations()
+    if args.accessions:
+        with open(args.accessions, "r") as accessions_fh:
+            for row in csv.DictReader(accessions_fh, delimiter='\t'):
+                accessions.add_user_annotation(
+                    row["genbank_accession"],
+                    "gisaid_epi_isl",
+                    row["gisaid_epi_isl"],
+                )
+
+    geoRules = UserProvidedGeoLocationSubstitutionRules()
+    if args.geo_location_rules :
+        # use curated rules to subtitute known spurious locations with correct ones
+        with open(args.geo_location_rules,'r') as geo_location_rules_fh :
+            for line in geo_location_rules_fh:
+                geoRules.readFromLine( line )
+
+
+    with open(args.genbank_data, "r") as genbank_fh :
+
+        pipeline = (
+            LineToJsonDataSource(genbank_fh)
+            | RenameAndAddColumns(column_map = { 'collected': 'date',
+                                                 'submitted': 'date_submitted'})
+            | StandardizeData()
+            | SequenceLengthFilter(15000)
+        )
+
+        if not args.sorted_fasta:
+            pipeline = pipeline | DropSequenceData()
+
+        pipeline = pipeline | StandardizeGenbankStrainNames()
+
+        sorted_metadata = sorted(
+            pipeline,
+            key=lambda obj: (
+                obj['strain'],
+                -obj['length'],
+                obj['genbank_accession'],
+                obj[LINE_NUMBER_KEY]
+            )
+        )
+        #print( type( sorted_metadata ) )
+        #print( sorted_metadata )
+
+    # this should be moved further down
+    # dedup by strain and compile a list of relevant line numbers.
+    seen_strains = set()
+    line_numbers = set()
+    updated_strain_names_by_line_no = {}
+    for entry in sorted_metadata:
+        if entry['strain'] in seen_strains:
+            continue
+
+        seen_strains.add(entry['strain'])
+        line_numbers.add(entry[LINE_NUMBER_KEY])
+        updated_strain_names_by_line_no[entry[LINE_NUMBER_KEY]] = entry['strain']
+
+    #genbank_data = pd.read_json(args.genbank_data,
+    #                            lines=True,
+    #                            compression='infer')
+    #genbank_data = preprocess(genbank_data)
+    #genbank_data = standardize_strain_names(genbank_data)
+    genbank_data = pd.DataFrame( sorted_metadata )
     genbank_data = parse_geographic_columns(genbank_data)
     genbank_data = parse_authors(genbank_data)
 
@@ -340,6 +440,24 @@ if __name__ == '__main__':
     genbank_data = update_metadata(genbank_data)
     genbank_data = find_and_drop_problem_records(genbank_data)
 
-    write_fasta_file(genbank_data, args.output_fasta)
+    if args.sorted_fasta:
+        write_fasta_file(genbank_data, args.output_fasta)
+
     genbank_data = genbank_data[METADATA_COLUMNS]
     genbank_data.to_csv(args.output_metadata, sep='\t', na_rep='', index=False)
+
+
+    if not args.sorted_fasta:
+        
+        with open(args.genbank_data, "r") as genbank_IN , open(args.output_fasta, "wt", newline=args.newline) as fasta_OUT:
+                for entry in (
+                        LineToJsonDataSource(genbank_IN)
+                        | RenameAndAddColumns(column_map = { 'collected': 'date',
+                                                 'submitted': 'date_submitted'})
+                        | StandardizeData()
+                        | LineNumberFilter(line_numbers)
+                ):
+                    strain_name = updated_strain_names_by_line_no[entry[LINE_NUMBER_KEY]]
+                    print( '>' , strain_name , sep='' , file= fasta_OUT)
+                    print( entry['sequence'] , file= fasta_OUT)
+                    

--- a/bin/transform-genbank
+++ b/bin/transform-genbank
@@ -446,22 +446,6 @@ if __name__ == '__main__':
         line_numbers.add(entry[LINE_NUMBER_KEY])
         updated_strain_names_by_line_no[entry[LINE_NUMBER_KEY]] = entry['strain']
 
-    #genbank_data = pd.read_json(args.genbank_data,
-    #                            lines=True,
-    #                            compression='infer')
-    #genbank_data = preprocess(genbank_data)
-    #genbank_data = standardize_strain_names(genbank_data)
-    #genbank_data = parse_geographic_columns(genbank_data)
-    #genbank_data = parse_authors(genbank_data)
-
-
-
-    ##geoRules additions
-    #genbank_data = apply_geoRules( genbank_data , rulesFile = args.geo_location_rules )
-    ##
-
-    #genbank_data = update_metadata(genbank_data)
-    #genbank_data = find_and_drop_problem_records(genbank_data)
 
     with open( args.output_metadata , 'wt' ) as metadata_OUT:
         dict_writer_kwargs = {'lineterminator': args.newline} 
@@ -488,14 +472,6 @@ if __name__ == '__main__':
                     print( '>' , strain_name , sep='' , file= fasta_OUT)
                     print( entry['sequence'] , file= fasta_OUT)                
 
-
-    #genbank_data = pd.DataFrame( sorted_metadata )
-
-    #if args.sorted_fasta:
-    #    write_fasta_file(genbank_data, args.output_fasta)
-
-    #genbank_data = genbank_data[METADATA_COLUMNS]
-    #genbank_data.to_csv(args.output_metadata, sep='\t', na_rep='', index=False)
 
 
     if not args.sorted_fasta:

--- a/bin/transform-genbank
+++ b/bin/transform-genbank
@@ -23,6 +23,8 @@ from utils.transformpipeline import LINE_NUMBER_KEY
 from utils.transformpipeline.datasource import LineToJsonDataSource
 from utils.transformpipeline.filters import SequenceLengthFilter, LineNumberFilter
 from utils.transformpipeline.transforms import (
+    AbbreviateAuthors,
+    AddHardcodedMetadataGenbank,
     DropSequenceData,
     ParseGeographicColumnsGenbank,
     RenameAndAddColumns,
@@ -399,7 +401,13 @@ if __name__ == '__main__':
             pipeline = pipeline | DropSequenceData()
 
         pipeline = ( pipeline | StandardizeGenbankStrainNames()
-                            | ParseGeographicColumnsGenbank( base / 'source-data/us-state-codes.tsv' )
+                              | ParseGeographicColumnsGenbank( base / 'source-data/us-state-codes.tsv' )
+                              | AbbreviateAuthors()
+                              | AddHardcodedMetadataGenbank()
+                              | ApplyUserGeoLocationSubstitutionRules(geoRules)
+                              | MergeUserAnnotatedMetadata(annotations)
+                              | MergeUserAnnotatedMetadata(accessions)
+                              | FillDefaultLocationData()
         )
 
         sorted_metadata = sorted(
@@ -433,16 +441,17 @@ if __name__ == '__main__':
     #genbank_data = preprocess(genbank_data)
     #genbank_data = standardize_strain_names(genbank_data)
     #genbank_data = parse_geographic_columns(genbank_data)
-    genbank_data = pd.DataFrame( sorted_metadata )
+    #genbank_data = parse_authors(genbank_data)
 
 
-    genbank_data = parse_authors(genbank_data)
 
     ##geoRules additions
-    genbank_data = apply_geoRules( genbank_data , rulesFile = args.geo_location_rules )
+    #genbank_data = apply_geoRules( genbank_data , rulesFile = args.geo_location_rules )
     ##
 
-    genbank_data = update_metadata(genbank_data)
+    #genbank_data = update_metadata(genbank_data)
+
+    genbank_data = pd.DataFrame( sorted_metadata )
     genbank_data = find_and_drop_problem_records(genbank_data)
 
     if args.sorted_fasta:

--- a/bin/transform-genbank
+++ b/bin/transform-genbank
@@ -24,8 +24,11 @@ from utils.transformpipeline.datasource import LineToJsonDataSource
 from utils.transformpipeline.filters import SequenceLengthFilter, LineNumberFilter
 from utils.transformpipeline.transforms import (
     AbbreviateAuthors,
+    ApplyUserGeoLocationSubstitutionRules,
     AddHardcodedMetadataGenbank,
     DropSequenceData,
+    FillDefaultLocationData,
+    MergeUserAnnotatedMetadata,
     ParseGeographicColumnsGenbank,
     RenameAndAddColumns,
     StandardizeData,
@@ -378,7 +381,7 @@ if __name__ == '__main__':
                     "gisaid_epi_isl",
                     row["gisaid_epi_isl"],
                 )
-
+    
     geoRules = UserProvidedGeoLocationSubstitutionRules()
     if args.geo_location_rules :
         # use curated rules to subtitute known spurious locations with correct ones
@@ -405,8 +408,8 @@ if __name__ == '__main__':
                               | AbbreviateAuthors()
                               | AddHardcodedMetadataGenbank()
                               | ApplyUserGeoLocationSubstitutionRules(geoRules)
-                              | MergeUserAnnotatedMetadata(annotations)
-                              | MergeUserAnnotatedMetadata(accessions)
+                              | MergeUserAnnotatedMetadata(annotations, idKey = 'genbank_accession' )
+                              | MergeUserAnnotatedMetadata(accessions, idKey = 'genbank_accession_rev' )
                               | FillDefaultLocationData()
         )
 
@@ -428,6 +431,8 @@ if __name__ == '__main__':
     line_numbers = set()
     updated_strain_names_by_line_no = {}
     for entry in sorted_metadata:
+        if entry['genbank_accession'] == 'MT295464' :
+            print(entry)
         if entry['strain'] in seen_strains:
             continue
 
@@ -460,6 +465,8 @@ if __name__ == '__main__':
     genbank_data = genbank_data[METADATA_COLUMNS]
     genbank_data.to_csv(args.output_metadata, sep='\t', na_rep='', index=False)
 
+    print('metadata written')
+    exit(1)
 
     if not args.sorted_fasta:
         

--- a/bin/transform-genbank
+++ b/bin/transform-genbank
@@ -24,6 +24,7 @@ from utils.transformpipeline.datasource import LineToJsonDataSource
 from utils.transformpipeline.filters import SequenceLengthFilter, LineNumberFilter
 from utils.transformpipeline.transforms import (
     DropSequenceData,
+    ParseGeographicColumnsGenbank,
     RenameAndAddColumns,
     StandardizeData,
     StandardizeGenbankStrainNames,
@@ -397,7 +398,9 @@ if __name__ == '__main__':
         if not args.sorted_fasta:
             pipeline = pipeline | DropSequenceData()
 
-        pipeline = pipeline | StandardizeGenbankStrainNames()
+        pipeline = ( pipeline | StandardizeGenbankStrainNames()
+                            | ParseGeographicColumnsGenbank( base / 'source-data/us-state-codes.tsv' )
+        )
 
         sorted_metadata = sorted(
             pipeline,
@@ -429,8 +432,10 @@ if __name__ == '__main__':
     #                            compression='infer')
     #genbank_data = preprocess(genbank_data)
     #genbank_data = standardize_strain_names(genbank_data)
+    #genbank_data = parse_geographic_columns(genbank_data)
     genbank_data = pd.DataFrame( sorted_metadata )
-    genbank_data = parse_geographic_columns(genbank_data)
+
+
     genbank_data = parse_authors(genbank_data)
 
     ##geoRules additions

--- a/bin/transform-genbank
+++ b/bin/transform-genbank
@@ -21,7 +21,7 @@ from utils.transform import (
 )
 from utils.transformpipeline import LINE_NUMBER_KEY
 from utils.transformpipeline.datasource import LineToJsonDataSource
-from utils.transformpipeline.filters import SequenceLengthFilter, LineNumberFilter
+from utils.transformpipeline.filters import SequenceLengthFilter, LineNumberFilter, GenbankProblematicFilter
 from utils.transformpipeline.transforms import (
     AbbreviateAuthors,
     ApplyUserGeoLocationSubstitutionRules,
@@ -33,6 +33,7 @@ from utils.transformpipeline.transforms import (
     RenameAndAddColumns,
     StandardizeData,
     StandardizeGenbankStrainNames,
+    Tracker,
     UserProvidedAnnotations,
     UserProvidedGeoLocationSubstitutionRules,
 )
@@ -411,6 +412,12 @@ if __name__ == '__main__':
                               | MergeUserAnnotatedMetadata(annotations, idKey = 'genbank_accession' )
                               | MergeUserAnnotatedMetadata(accessions, idKey = 'genbank_accession_rev' )
                               | FillDefaultLocationData()
+                              | GenbankProblematicFilter( args.problem_data,
+                                                          ['genbank_accession', 'strain', 'region', 'country', 'url'],
+                                                          restval = '?' , 
+                                                          extrasaction ='ignore' , 
+                                                          delimiter  = '\t', 
+                                                          dict_writer_kwargs  = {'lineterminator': args.newline} )
         )
 
         sorted_metadata = sorted(
@@ -431,8 +438,7 @@ if __name__ == '__main__':
     line_numbers = set()
     updated_strain_names_by_line_no = {}
     for entry in sorted_metadata:
-        if entry['genbank_accession'] == 'MT295464' :
-            print(entry)
+
         if entry['strain'] in seen_strains:
             continue
 
@@ -455,18 +461,42 @@ if __name__ == '__main__':
     ##
 
     #genbank_data = update_metadata(genbank_data)
+    #genbank_data = find_and_drop_problem_records(genbank_data)
 
-    genbank_data = pd.DataFrame( sorted_metadata )
-    genbank_data = find_and_drop_problem_records(genbank_data)
+    with open( args.output_metadata , 'wt' ) as metadata_OUT:
+        dict_writer_kwargs = {'lineterminator': args.newline} 
 
+        metadata_csv = csv.DictWriter(
+            metadata_OUT,
+            METADATA_COLUMNS,
+            restval="",
+            extrasaction='ignore',
+            delimiter='\t',
+            **dict_writer_kwargs
+        )
+        metadata_csv.writeheader()
+
+        for entry in sorted_metadata :
+            if entry[LINE_NUMBER_KEY] in line_numbers:
+                metadata_csv.writerow(entry)
+    
     if args.sorted_fasta:
-        write_fasta_file(genbank_data, args.output_fasta)
+        with open( args.output_fasta , 'wt' ) as fasta_OUT:
+            for entry in sorted_metadata :
+                if entry[LINE_NUMBER_KEY] in line_numbers:
+                    strain_name = updated_strain_names_by_line_no[entry[LINE_NUMBER_KEY]]
+                    print( '>' , strain_name , sep='' , file= fasta_OUT)
+                    print( entry['sequence'] , file= fasta_OUT)                
 
-    genbank_data = genbank_data[METADATA_COLUMNS]
-    genbank_data.to_csv(args.output_metadata, sep='\t', na_rep='', index=False)
 
-    print('metadata written')
-    exit(1)
+    #genbank_data = pd.DataFrame( sorted_metadata )
+
+    #if args.sorted_fasta:
+    #    write_fasta_file(genbank_data, args.output_fasta)
+
+    #genbank_data = genbank_data[METADATA_COLUMNS]
+    #genbank_data.to_csv(args.output_metadata, sep='\t', na_rep='', index=False)
+
 
     if not args.sorted_fasta:
         

--- a/lib/utils/transformpipeline/filters.py
+++ b/lib/utils/transformpipeline/filters.py
@@ -1,4 +1,6 @@
-from typing import Container
+from typing import Container , List, Dict
+import csv 
+import re 
 
 from . import LINE_NUMBER_KEY
 from ._base import Filter
@@ -18,3 +20,58 @@ class LineNumberFilter(Filter):
 
     def test_value(self, inp: dict) -> bool:
         return inp[LINE_NUMBER_KEY] in self.line_numbers
+
+
+class GenbankProblematicFilter(Filter):
+    """
+    Find records that are missing geographic regions or have the wrong
+    name structure and print them out for manual curation. Drop the problem
+    records and duplicate records and return the modified DataFrame.
+    """
+    def __init__(self, fileName: str , 
+                 columns : List[str] , 
+                 restval : str = '?' , 
+                 extrasaction : str ='ignore' , 
+                 delimiter : str = ',', 
+                 dict_writer_kwargs : Dict[str,str] = {} ):
+
+        self.printProblem = fileName !=''
+        if self.printProblem:
+            self.OUT = open( fileName , 'wt')
+
+            self.writer = csv.DictWriter(
+                self.OUT,
+                columns,
+                restval=restval,
+                extrasaction=extrasaction,
+                delimiter=delimiter,
+                **dict_writer_kwargs
+            )
+            self.writer.writeheader()
+
+    def __del__(self):
+        if self.printProblem:
+            self.OUT.close()
+
+
+    def test_value(self, inp: dict) -> bool:
+
+        strain_name_regex = re.compile(  r'([\w]*/)?[\w]*/[-_\.\w]*/[\d]{4}' )
+
+        OK = True
+
+        if inp['region'] == '':
+            OK = False
+        elif inp['country'] == '':
+            OK = False
+        # All strain names should have structure {}/{}/{year} or {}/{}/{}/{year}
+        # with the exception of 'Wuhan-Hu-1/2019'
+        elif ( strain_name_regex.match( inp['strain'] ) is None ) and ( inp['strain'] != 'Wuhan-Hu-1/2019' ) :
+            OK = False
+
+        if not OK and self.printProblem :
+            self.writer.writerow(inp)
+
+        return OK
+ 
+

--- a/lib/utils/transformpipeline/transforms.py
+++ b/lib/utils/transformpipeline/transforms.py
@@ -345,7 +345,11 @@ class AbbreviateAuthors(Transformer):
         if entry['authors'] == "":
             entry['authors'] = '?'
         else:
-            entry['authors'] = re.split(r'(?:\s*[,，;；]\s*|\s+(?:and|&)\s+)', entry['authors'])[0] + " et al"
+            entry['authors'] = re.split(r'(?:\s*[,，;；]\s*|\s+(?:and|&)\s+)', entry['authors'])[0]
+
+            if not entry['authors'].strip('. ').endswith(" et al"): # if it does not already finishes with " et al.", add it 
+                entry['authors'] += ' et al'
+
         return entry
 
 

--- a/lib/utils/transformpipeline/transforms.py
+++ b/lib/utils/transformpipeline/transforms.py
@@ -414,6 +414,7 @@ class MergeUserAnnotatedMetadata(Transformer):
         for key, value in annotations:
             if key in entry and entry[key] == value :
                 print('REDUNDANT ANNOTATED METADATA :', entry[ self.idKey ] , key , value)
+
             entry[key] = value
         return entry
 
@@ -502,7 +503,7 @@ class StandardizeGenbankStrainNames(Transformer):
         # Compile list of regex to be used for strain name standardization
         # Order is important here! Keep the known prefixes first!
         regex_replacement = [
-            (r'(^SAR[S]{0,1}[-\s]CoV[-]{0,1}2/|^2019[-\s]nCoV[-_\s/]|^BetaCoV/|^nCoV-|^hCoV-19/)',''),
+            (r'(^SAR[S]{0,1}[-\s]{0,1}CoV[-]{0,1}2/|^2019[-\s]nCoV[-_\s/]|^BetaCoV/|^nCoV-|^hCoV-19/)',''),
             (r'(human/|homo sapien/|Homosapiens{0,1}/)',''),
             (r'^USA-', 'USA/'),
             (r'^USACT-', 'USA/CT-'),
@@ -608,3 +609,15 @@ class AddHardcodedMetadataGenbank(Transformer):
         return entry
 
         
+class Tracker(Transformer):
+    """
+    here to print a number of entries when seen
+    """
+    def __init__(self , interestIds : set , interestField : str):
+        self.interestIds = interestIds
+        self.interestField = interestField
+
+    def transform_value(self, entry : dict) -> dict :
+        if entry[ self.interestField ] in self.interestIds:
+            print(entry)
+        return entry

--- a/lib/utils/transformpipeline/transforms.py
+++ b/lib/utils/transformpipeline/transforms.py
@@ -550,7 +550,7 @@ class ParseGeographicColumnsGenbank(Transformer):
             sl = geographic_data[1].split(',')
             
             division = sl[0].strip()
-            if len(sl) == 1:
+            if len(sl) > 1:
                 location = sl[1].strip()
         elif len(geographic_data) > 2:
             assert False, f"Found unknown format for geographic data: {value}"
@@ -559,25 +559,47 @@ class ParseGeographicColumnsGenbank(Transformer):
         # Special parsing for US locations because the format varies
         if country == 'USA' and not division is None:
             # Switch location & division if location is a US state
-            if location and any(location.strip() in s for s in us_states.items()):
+            if location and any(location.strip() in s for s in self.us_states.items()):
                 state = location
                 location = division
                 division = state
             # Convert US state codes to full names
-            if us_states.get(division.strip().upper()):
-                division = us_states[division.strip().upper()]
+            if self.us_states.get(division.strip().upper()):
+                division = self.us_states[division.strip().upper()]
     
     
         location = location.strip().lower().title() if location else None
         division = division.strip().lower().title() if division else None
     
 
-        print(entry , '->' , geographic_data , country,
-                                                division,
-                                                location)
+        #print(entry , '->' , geographic_data , country, division, location)
         entry['country']     = country
         entry['division']    = division
         entry['location']    = location
 
 
         return entry
+
+class AddHardcodedMetadataGenbank(Transformer):
+    """
+    Adds a key-value for strain ID plus additional key-values containing harcoded
+    metadata.
+    """
+    def transform_value(self, entry: dict) -> dict:
+
+        entry['virus']             = 'ncov'
+        entry['gisaid_epi_isl']    = '?'
+        entry['segment']           = 'genome'
+        entry['age']               = '?'
+        entry['sex']               = '?'
+        entry['pango_lineage']  = '?'
+        entry['GISAID_clade']      = '?'
+        entry['originating_lab']   = '?'
+        entry['submitting_lab']    = '?'
+        entry['paper_url']         = '?'
+        entry['purpose_of_sequencing']         = '?'
+    
+        entry['url'] = entry['genbank_accession'].apply(lambda x: f"https://www.ncbi.nlm.nih.gov/nuccore/{x}")
+        return entry
+
+        


### PR DESCRIPTION
### Description of proposed changes    

Update of the transform-genbank script to reduce its imprint in memory as well as run time. 
The code now uses as much element as possible from the transform-gisaid script to promote maintainability.

On my computer, the script has gone from ~5Gb in RAM and a 20min execution time to less than 500Mb and under a minute.

The resulting metadata and fasta files are unchanged, except for one case of duplicates whose relative priority have changed (strain USA/Wuhan-Hu-1/2020).

The transform-gisaid script behaviour is impacted : the authors field default is now "?" instead of " et al" (a single record is affected AFAIK) and the spurious cases where the author field ended with "et al et al" are handled.


### Testing

ingest-genbank and ingest-gisaid should be run to ensure the metadata and sequence obtained have not been altered


<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
