### PR TITLE
Tone down the Slack notification on new/changed data

### DIFF
--- a/bin/notify-on-record-change
+++ b/bin/notify-on-record-change
@@ -23,7 +23,7 @@ printf "%'4d added records\n" "$added_records"
 
 if [[ $added_records -gt 0 ]]; then
     echo "Notifying Slack about added records (n=$added_records)"
-    "$bin"/notify-slack ":rotating_light: <!channel> New nCoV records (n=$added_records) found on $source_name."
+    "$bin"/notify-slack "📈 New nCoV records (n=$added_records) found on $source_name."
 
 elif [[ $added_records -lt 0 ]]; then
     echo "New file has fewer records‽"


### PR DESCRIPTION
While new data was high urgency at the beginning of this pandemic and
cause for immediate rebuilds, our build shepherds have long-settled into
a regular cadence where new data is processed on our own schedule
instead of as interrupts.  Mentioning `@channel` also masks "real"
mentions of individuals in the channel, which makes it harder to get the
attention of people tagged into conversations.