### PR TITLE
Upload GenBank files to s3://nextstrain-data/files/ncov/open/…

### DIFF
--- a/bin/ingest-genbank
+++ b/bin/ingest-genbank
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-: "${S3_SRC:=s3://nextstrain-data/ncov-ingest}"
+: "${S3_SRC:=s3://nextstrain-data/files/ncov/open}"
 : "${S3_DST:=$S3_SRC}"
 
 # Determine where to save data files based on if we're running as a result of a
@@ -21,12 +21,12 @@ case "${GITHUB_REF:-}" in
         # Save data files under a per-branch prefix
         silent=yes
         branch="${GITHUB_REF##refs/heads/}"
-        S3_DST="$S3_DST/branch/$branch"
+        S3_DST="${S3_DST/nextstrain-data/nextstrain-staging}/branch/$branch"
         ;;
     "")
         # Save data files under a tmp prefix
         silent=yes
-        S3_DST="$S3_DST/tmp"
+        S3_DST="${S3_DST/nextstrain-data/nextstrain-staging}/tmp"
         ;;
     *)
         echo "Skipping ingest for ref $GITHUB_REF"
@@ -88,13 +88,13 @@ fi
 
 
 if [[ "$branch" == master ]]; then
-    ./bin/notify-on-metadata-change data/genbank/metadata.tsv "$S3_SRC/genbank_metadata.tsv.gz" genbank_accession
+    ./bin/notify-on-metadata-change data/genbank/metadata.tsv "$S3_SRC/metadata.tsv.gz" genbank_accession
     ./bin/notify-on-problem-data data/genbank/problem_data.tsv
     ./bin/notify-on-location-hierarchy-addition data/genbank/location_hierarchy.tsv source-data/location_hierarchy.tsv
 fi
 
-./bin/upload-to-s3 ${silent:+--quiet} data/genbank/metadata.tsv "$S3_DST/genbank_metadata.tsv.gz"
-./bin/upload-to-s3 ${silent:+--quiet} data/genbank/sequences.fasta "$S3_DST/genbank_sequences.fasta.gz"
+./bin/upload-to-s3 ${silent:+--quiet} data/genbank/metadata.tsv "$S3_DST/metadata.tsv.gz"
+./bin/upload-to-s3 ${silent:+--quiet} data/genbank/sequences.fasta "$S3_DST/sequences.fasta.gz"
 ./bin/upload-to-s3 ${silent:+--quiet} data/genbank/nextclade.tsv "$S3_DST/nextclade.tsv.gz"
 
 ./bin/clean

--- a/bin/transform-genbank
+++ b/bin/transform-genbank
@@ -303,7 +303,7 @@ if __name__ == '__main__':
         description=__doc__,
         formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("genbank_data",
-        default="s3://nextstrain-data/ncov-ingest/genbank.ndjson.gz",
+        default="s3://nextstrain-data/files/ncov/open/genbank.ndjson.gz",
         nargs="?",
         help="Newline-delimited GenBank JSON data")
     parser.add_argument("--annotations",


### PR DESCRIPTION
For downloading by the ncov "open data" build.  We'll be consolidating and uploading additional files from the ncov build to the same location as well.

Removes "genbank_" prefix from filenames because in time we'll start ingesting other Open Data sources (e.g. COG-UK) into these same files.

## Todo

* [x] Figure out where we want `branch/` and `tmp/` prefixes to live, if not under `files/ncov/open/{branch,tmp}/…`.
* [x] Update [NextstrainNcovIngestUploader](https://console.aws.amazon.com/iam/home?region=us-east-1#/policies/arn:aws:iam::827581582529:policy/NextstrainNcovIngestUploader$jsonEditor) IAM policy for paths
* [x] Configure S3 lifecycle policies for new branch/tmp data, if necessary.

## Cleanup (after merge)

* [ ] Delete [NextstrainNcovPrivateUploader](https://console.aws.amazon.com/iam/home?region=us-west-2#/policies/arn:aws:iam::827581582529:policy/NextstrainNcovPrivateUploader$jsonEditor) and [NextstrainDataUploader](https://console.aws.amazon.com/iam/home?region=us-west-2#/policies/arn:aws:iam::827581582529:policy/NextstrainDataUploader$jsonEditor) IAM policies. They're only attached to the `nextstrain-ncov-ingest-uploader` user, which already now has a new combined policy attached covering what it needs for this PR.