### PR TITLE
Auto-deploy our core builds to production instead of staging

### DIFF
--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -1,4 +1,4 @@
-name: Rebuild nextstrain.org/staging/ncov
+name: Rebuild nextstrain.org/ncov
 
 on:
   # Manually triggered using bin/trigger rebuild
@@ -18,7 +18,7 @@ jobs:
       run: ./bin/setup-github-workflow
 
     - name: rebuild
-      run: ./bin/rebuild-staging
+      run: ./bin/rebuild
       env:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/bin/rebuild
+++ b/bin/rebuild
@@ -55,7 +55,7 @@ main() {
 
     output=$(
         "$bin"/launch-build \
-            ncov deploy_to_staging upload \
+            ncov deploy upload \
             --config slack_token="$SLACK_TOKEN"
     )
 
@@ -65,7 +65,7 @@ main() {
     aws_batch_job_id=$(grep "AWS Batch Job ID" <<<"$output" | cut -d ' ' -f 5)
 
     echo "Notifying Slack about rebuild."
-    "$bin"/notify-slack "A new staging build was submitted. Follow along in your local ncov repo with: "'```'"nextstrain build --aws-batch --attach $aws_batch_job_id ."'```'
+    "$bin"/notify-slack "A new build was submitted. Follow along in your local ncov repo with: "'```'"nextstrain build --aws-batch --attach $aws_batch_job_id ."'```'
 }
 
 # Returns 1 if both files match (have identical hashes). Else returns 0.


### PR DESCRIPTION
Discussion in Slack¹ led to consensus to switch. The reasoning is that
nearly all the time the build shepherd's are just copying files between
staging and production. Any occasional bad build can be fixed by rolling
back to yesterday's build (from the dated JSON files).

Mirrors [corresponding change](https://github.com/nextstrain/ncov/pull/629) in ncov workflow.

¹ https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1620422859124500