### PR TITLE
Add Nextclade 1.0.0 to docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,11 @@ COPY package.json yarn.lock /nextstrain/ncov-ingest/
 RUN cd /nextstrain/ncov-ingest && yarn install --non-interactive
 ENV PATH="/nextstrain/ncov-ingest/node_modules/.bin:$PATH"
 
+# Install Nextclade C++
+RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-Linux-x86_64 \
+         -o /usr/local/bin/nextclade \
+ && chmod a+rx /usr/local/bin/nextclade
+
 # Put any bin/ dir in the cwd on the path for more convenient invocation of
 # ncov-ingest's programs.
 ENV PATH="./bin:$PATH"


### PR DESCRIPTION
### Description of proposed changes    
This adds Nextclade 1.0.0 (the new C++-based version) to the ncov-ingest docker container. This is needed in order to be able to run the changes in #170, as the same docker container image is shared across all of the branches. 

NOTE: the `nextclade.js` and `nextclade` commands will still resolve Nextclade 0.14.1 located in `/nextstrain/ncov-ingest/node_modules/.bin/`, as it goes first in the `$PATH`. In order to call Nextclade 1.0.0, you need the full path, which is `/usr/local/bin/nextclade`

### Related issue(s)  
Related to #170 

### Testing
-