### PR TITLE
fetch-from-genbank: Increase CSV field size limit

### DIFF
--- a/bin/fetch-from-genbank
+++ b/bin/fetch-from-genbank
@@ -85,6 +85,9 @@ response.raise_for_status()
 
 response_content = response.iter_lines(decode_unicode = True)
 
+# 10 MiB; default is 128 KiB
+csv.field_size_limit(10 * 1024 * 1024)
+
 for row in csv.DictReader(response_content):
     json.dump(row, stdout, allow_nan = False, indent = None, separators = ',:')
     print()


### PR DESCRIPTION
Runs were failing because a GenBank-provided data field started
exceeding the default limit of 128 KiB.¹  5 MiB is an arbitrarily larger
amount.

¹ https://github.com/python/cpython/blob/7148293d/Modules/_csv.c#L1686-L1687