### PR TITLE
fix: set clock deviation to nan (?) when there is no valid date

### DIFF
--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -102,7 +102,7 @@ def main():
     offset = result["Nextstrain_clade"].apply(lambda x: offset_by_clade.get(x, 2.0))
     # calculate divergence
     result["clock_deviation"] = np.array(div_array - ((t-reference_day)*rate_per_day + offset), dtype=int)
-    result["clock_deviation"][np.isnan(div_array)] = np.nan
+    result["clock_deviation"][np.isnan(div_array)|np.isnan(t)] = np.nan
 
     for col in list(column_map.values()) + ["clock_deviation"]:
         result[col] = result[col].fillna(VALUE_MISSING_DATA)


### PR DESCRIPTION
without  a valid date, no clock deviation can be calculated. this sets these values explicitly to `?` (our missing value sign)
