### PR TITLE
run genbank ingest on push shared location rules

### DIFF
--- a/.github/workflows/ingest-genbank-master.yml
+++ b/.github/workflows/ingest-genbank-master.yml
@@ -8,6 +8,7 @@ on:
       - '**'
     paths:
       - source-data/genbank_annotations.tsv
+      - source-data/gisaid_geoLocationRules.tsv
 
   # Manually triggered using `./bin/trigger genbank/ingest` (or `ingest`, which
   # includes GISAID)


### PR DESCRIPTION
Since we use `source-data/gisaid_geoLocationRules.tsv` to correct genbank location metadata as well as gisaid, it makes sense to me to run genbank ingest when it is updated the same way we do for gisaid ingest.