### PR TITLE
upload-to-s3: Drop Content-Encoding from object metadata

### DIFF
--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -32,14 +32,13 @@ main() {
 
     if [[ $src_hash != "$dst_hash" ]]; then
         echo "Uploading $src → $dst"
-        content_encoding=$(content-encoding "$dst")
         if [[ "$dst" == *.gz ]]; then
             gzip -c "$src"
         elif  [[ "$dst" == *.xz ]]; then
             xz -2 -c "$src"
         else
             cat "$src"
-        fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash" "$(content-type "$dst")" ${content_encoding:+"$content_encoding"}
+        fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash" "$(content-type "$dst")"
 
         if [[ $quiet == 1 ]]; then
             echo "Quiet mode. No Slack notification sent."
@@ -55,18 +54,13 @@ main() {
 }
 
 content-type() {
-    case "${1%.[gx]z}" in
+    case "$1" in
         *.tsv)      echo --content-type=text/tab-separated-values;;
         *.csv)      echo --content-type=text/comma-separated-values;;
         *.ndjson)   echo --content-type=application/x-ndjson;;
+        *.gz)       echo --content-type=application/gzip;;
         *.xz)       echo --content-type=application/x-xz;;
         *)          echo --content-type=text/plain;;
-    esac
-}
-
-content-encoding() {
-    case "$1" in
-        *.gz) echo --content-encoding=gzip;;
     esac
 }
 


### PR DESCRIPTION
This avoids the field being sent as an HTTP header, which causes most
HTTP clients to automatically decompress the content.  The automatic
decompression is useful if piping directly to another process, but
pretty confusing when downloading because the filename still retains the
.gz extension but the file isn't compressed!  This confuses both
browser-based downloads and the Broad's mirroring of S3 to GCP Storage.

Additionally, as Ivan and others have noted, ~no HTTP clients support
Content-Encoding: xz, even though we were setting it and the bulk of our
files are xz-compressed now.

