### PR TITLE
Automatically retry fetches from GISAID and GenBank

### DIFF
--- a/bin/ingest-genbank
+++ b/bin/ingest-genbank
@@ -68,7 +68,22 @@ main() {
     set -x
 
     if [[ "$fetch" == 1 ]]; then
-        ./bin/fetch-from-genbank > data/genbank.ndjson
+        local attempt=0 max_attempts=5
+
+        while [[ $((++attempt)) -le $max_attempts ]]; do
+            echo "Fetch attempt $attempt"
+            if ./bin/fetch-from-genbank > data/genbank.ndjson; then
+                break
+            else
+                echo "...FAILED"
+                rm data/genbank.ndjson
+                sleep 10
+            fi
+        done
+        if [[ ! -f data/genbank.ndjson ]]; then
+            echo "Failed to fetch"
+            exit 1
+        fi
         if [[ "$branch" == master ]]; then
             ./bin/notify-on-record-change data/genbank.ndjson "$S3_SRC/genbank.ndjson.xz" "GenBank"
         fi

--- a/bin/ingest-gisaid
+++ b/bin/ingest-gisaid
@@ -65,7 +65,22 @@ main() {
     cd "$(dirname "$0")/.."
 
     if [[ "$fetch" == 1 ]]; then
-        ./bin/fetch-from-gisaid > data/gisaid.ndjson
+        local attempt=0 max_attempts=5
+
+        while [[ $((++attempt)) -le $max_attempts ]]; do
+            echo "Fetch attempt $attempt"
+            if ./bin/fetch-from-gisaid > data/gisaid.ndjson; then
+                break
+            else
+                echo "...FAILED"
+                rm data/gisaid.ndjson
+                sleep 10
+            fi
+        done
+        if [[ ! -f data/gisaid.ndjson ]]; then
+            echo "Failed to fetch"
+            exit 1
+        fi
         if [[ "$branch" == master ]]; then
             ./bin/notify-on-record-change data/gisaid.ndjson "$S3_SRC/gisaid.ndjson.xz" "GISAID"
         fi


### PR DESCRIPTION
Try to recover from transient network/connection failures we sometimes
see.  Most of these are protocol errors or connections unexpected closed
by the remote peer.  We can't use curl's --retry option because it
doesn't apply to the kinds of errors we see and its --retry-all-errors
option would produce duplicate/corrupted data since we process it as a
stream and write to disk.

This retry logic is rather crude but should be fine for now.  At some
point when this pipeline uses a workflow engine like Snakemake,
presumably we can make use of builtin retry logic.

~Try to recover from transient network/connection failures we sometimes
see. Most of these are protocol errors or connections unexpected closed
by the remote peer. The documention is unclear and only mentions
timeouts and HTTP 5xx, but I _think_ curl will treat protocol issues as
transient failures for the purposes of --retry.~

~This will make up to 10 total requests (1 original + up to 9 retries).
curl's default backoff delay time for retries starts at 1s and doubles
for every subsequent attempt: 1 2 4 8 16 32 64 128 256. If this proves
to be unsuitable for our purposes, we can further tune retry behaviour
with curl's other --retry-* options.~
