### PR TITLE
Trigger preprocessing pipelines after fetch-and-ingest

### DIFF
--- a/.github/workflows/fetch-and-ingest-genbank-master.yml
+++ b/.github/workflows/fetch-and-ingest-genbank-master.yml
@@ -31,7 +31,8 @@ jobs:
           AWS_DEFAULT_REGION \
           GITHUB_REF \
           SLACK_TOKEN \
-          SLACK_CHANNELS
+          SLACK_CHANNELS \
+          PAT_GITHUB_DISPATCH
 
         nextstrain build \
           --aws-batch \
@@ -48,3 +49,4 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
         SLACK_CHANNELS: ncov-genbank-updates
+        PAT_GITHUB_DISPATCH: ${{ secrets.PAT_GITHUB_DISPATCH }}

--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -32,7 +32,8 @@ jobs:
           GISAID_USERNAME_AND_PASSWORD \
           GITHUB_REF \
           SLACK_TOKEN \
-          SLACK_CHANNELS
+          SLACK_CHANNELS \
+          PAT_GITHUB_DISPATCH
 
         nextstrain build \
           --aws-batch \
@@ -51,3 +52,4 @@ jobs:
         GISAID_USERNAME_AND_PASSWORD: ${{ secrets.GISAID_USERNAME_AND_PASSWORD }}
         SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
         SLACK_CHANNELS: ncov-gisaid-updates
+        PAT_GITHUB_DISPATCH: ${{ secrets.PAT_GITHUB_DISPATCH }}

--- a/bin/ingest-genbank
+++ b/bin/ingest-genbank
@@ -170,6 +170,17 @@ main() {
     ./bin/upload-to-s3 ${silent:+--quiet} data/genbank/duplicate_biosample.txt "$S3_DST/duplicate_biosample.txt.gz"
 
     ./bin/clean
+
+    if [[ "$fetch" == 1 && "$branch" == master ]]; then
+        echo "Triggering ncov preprocessing GitHub action via repository dispatch."
+        curl -fsS https://api.github.com/repos/nextstrain/ncov/dispatches \
+          -H 'Accept: application/vnd.github.v3+json' \
+          -H 'Content-Type: application/json' \
+          -H "authorization: Bearer ${PAT_GITHUB_DISPATCH}" \
+          -d '{"event_type":"preprocess-open"}'
+    else
+        echo "Skipping running of ncov preprocessing workflow as the current branch is not master or we are running an ingest only (not a fetch-and-ingest)."
+    fi
 }
 
 print-help() {

--- a/bin/ingest-gisaid
+++ b/bin/ingest-gisaid
@@ -96,6 +96,9 @@ main() {
         --output-fasta data/gisaid/sequences.fasta \
         --output-unix-newline > "$flagged_annotations"
 
+    # Remove gisaid.ndjson to save disk space.
+    rm data/gisaid.ndjson
+
     # Download old clades
     (   aws s3 cp --no-progress "$S3_DST/nextclade.tsv.gz" - \
      || aws s3 cp --no-progress "$S3_SRC/nextclade.tsv.gz" -) \

--- a/bin/ingest-gisaid
+++ b/bin/ingest-gisaid
@@ -157,6 +157,17 @@ main() {
     ./bin/upload-to-s3 ${silent:+--quiet} data/gisaid/sequences.fasta "$S3_DST/sequences.fasta.xz"
 
     ./bin/clean
+
+    if [[ "$fetch" == 1 && "$branch" == master ]]; then
+        echo "Triggering ncov preprocessing GitHub action via repository dispatch."
+        curl -fsS https://api.github.com/repos/nextstrain/ncov/dispatches \
+          -H 'Accept: application/vnd.github.v3+json' \
+          -H 'Content-Type: application/json' \
+          -H "authorization: Bearer ${PAT_GITHUB_DISPATCH}" \
+          -d '{"event_type":"preprocess-gisaid"}'
+    else
+        echo "Skipping running of ncov preprocessing workflow as the current branch is not master or we are running an ingest only (not a fetch-and-ingest)."
+    fi
 }
 
 print-help() {


### PR DESCRIPTION
Our intention is to have the preprocessing (alignment) pipeline
run following fetch-and-ingest, which currently happens daily.

The API call is similar to that in `./bin/trigger` and follows [these docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#example-2-calling-the-rest-api)


### Testing
???

