### PR TITLE
Add frame shifts and stop codons columns to metadata.tsv

### DIFF
--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -24,6 +24,8 @@ column_map = {
     "qc.mixedSites.status": "QC_mixed_sites",
     "qc.privateMutations.status": "QC_rare_mutations",
     "qc.snpClusters.status": "QC_snp_clusters",
+    "qc.frameShifts.frameShifts": "QC_frame_shifts",
+    "qc.stopCodons.stopCodons": "QC_stop_codons",
 }
 
 preferred_types = {


### PR DESCRIPTION
### Description of proposed changes    

Add frame shifts and stop codons columns to metadata.tsv. These come from

```
qc.frameShifts.frameShifts
qc.stopCodons.stopCodons
```

columns of Nextclade TSV output.

Before merging that, we need to recompute metadata.tsv from scratch so that all old sequneces get the new columns.


### Related issue(s)  
-

### Testing

:boom: I launched a full run on branch [`nextclade-full-run-2021-09-30`](https://github.com/nextstrain/ncov-ingest/tree/nextclade-full-run-2021-09-30), with empty metadata.tsv and nextclade.tsv, so that they get recomputed 


