### PR TITLE
Full Nextclade runs

### DIFF
--- a/.github/workflows/ingest-full-genbank.yml
+++ b/.github/workflows/ingest-full-genbank.yml
@@ -1,0 +1,47 @@
+name: GenBank ingest with full Nextclade run
+
+on:
+  # Manually triggered using `./bin/trigger genbank/ingest-full`
+  # (or `ingest-full`, which includes GISAID)
+  repository_dispatch:
+    types:
+      - genbank/ingest-full
+      - ingest-full
+
+  # Manually triggered using GitHub's UI
+  workflow_dispatch:
+
+jobs:
+  ingest-genbank-with-full-nextclade-run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: 'nextclade-full-run-2021-09-30'
+
+    - name: setup
+      run: ./bin/setup-github-workflow
+
+    - name: ingest-genbank-with-full-nextclade-run
+      run: |
+        ./bin/write-envdir env.d \
+          AWS_DEFAULT_REGION \
+          GITHUB_REF \
+          SLACK_TOKEN \
+          SLACK_CHANNELS
+
+        nextstrain build \
+          --aws-batch \
+          --no-download \
+          --image nextstrain/ncov-ingest \
+          --cpus 16 \
+          --memory 30GiB \
+          --exec env \
+          . \
+            envdir env.d ingest-genbank --nextclade_full_run
+      env:
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+        SLACK_CHANNELS: ncov-genbank-updates

--- a/.github/workflows/ingest-full-genbank.yml
+++ b/.github/workflows/ingest-full-genbank.yml
@@ -34,8 +34,8 @@ jobs:
           --aws-batch \
           --no-download \
           --image nextstrain/ncov-ingest \
-          --cpus 16 \
-          --memory 30GiB \
+          --cpus 32 \
+          --memory 64GiB \
           --exec env \
           . \
             envdir env.d ingest-genbank --nextclade_full_run

--- a/.github/workflows/ingest-full-gisaid.yml
+++ b/.github/workflows/ingest-full-gisaid.yml
@@ -1,0 +1,51 @@
+name: GISAID ingest with full Nextclade run
+
+on:
+  # Manually triggered using `./bin/trigger gisaid/ingest-full`
+  # (or `ingest-full`, which includes GenBank)
+  repository_dispatch:
+    types:
+      - gisaid/ingest-full
+      - ingest-full
+
+  # Manually triggered using GitHub's UI
+  workflow_dispatch:
+
+jobs:
+  ingest-gisaid-with-full-nextclade-run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: 'nextclade-full-run-2021-09-30'
+
+    - name: setup
+      run: ./bin/setup-github-workflow
+
+    - name: ingest-gisaid-with-full-nextclade-run
+      run: |
+        ./bin/write-envdir env.d \
+          AWS_DEFAULT_REGION \
+          GISAID_API_ENDPOINT \
+          GISAID_USERNAME_AND_PASSWORD \
+          GITHUB_REF \
+          SLACK_TOKEN \
+          SLACK_CHANNELS
+
+        nextstrain build \
+          --aws-batch \
+          --no-download \
+          --image nextstrain/ncov-ingest \
+          --cpus 16 \
+          --memory 31GiB \
+          --exec env \
+          . \
+            envdir env.d ingest-gisaid --nextclade_full_run
+      env:
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        GISAID_API_ENDPOINT: ${{ secrets.GISAID_API_ENDPOINT }}
+        GISAID_USERNAME_AND_PASSWORD: ${{ secrets.GISAID_USERNAME_AND_PASSWORD }}
+        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+        SLACK_CHANNELS: ncov-gisaid-updates

--- a/.github/workflows/ingest-full-gisaid.yml
+++ b/.github/workflows/ingest-full-gisaid.yml
@@ -36,8 +36,8 @@ jobs:
           --aws-batch \
           --no-download \
           --image nextstrain/ncov-ingest \
-          --cpus 16 \
-          --memory 31GiB \
+          --cpus 32 \
+          --memory 64GiB \
           --exec env \
           . \
             envdir env.d ingest-gisaid --nextclade_full_run

--- a/bin/filter-fasta
+++ b/bin/filter-fasta
@@ -30,8 +30,12 @@ but missing the input TSV file. This is useful in order to find which sequences 
 def main():
     args = parse_args()
 
-    tsv = pd.read_csv(args.input_tsv, sep="\t", low_memory=False)
-    tsv_ids = set(tsv['seqName'])
+    tsv_ids = set()
+    try:
+        tsv = pd.read_csv(args.input_tsv, sep="\t", low_memory=False)
+        tsv_ids = set(tsv['seqName'])
+    except pd.errors.EmptyDataError:
+        pass
 
     with open(args.input_fasta) as f_input:
         with open(args.output_fasta, "w") as f_output:

--- a/bin/ingest-genbank
+++ b/bin/ingest-genbank
@@ -78,7 +78,7 @@ main() {
     if [ "$nextclade_full_run" == 1 ]; then
       branch="nextclade_full_run"
       S3_DST="$S3_DST/nextclade-full-run/$(date "+%Y-%m-%d--%H-%M-%S--%Z")"
-    else
+    fi
 
     echo "S3_SRC is $S3_SRC"
     echo "S3_DST is $S3_DST"

--- a/bin/ingest-genbank
+++ b/bin/ingest-genbank
@@ -72,6 +72,14 @@ main() {
             ;;
     esac
 
+    # In 'full run' mode we pretend that we run from a git branch
+    # and we write results to a special directory on S3, to keep
+    # production (master) files intact.
+    if [ "$nextclade_full_run" == 1 ]; then
+      branch="nextclade_full_run"
+      S3_DST="$S3_DST/nextclade-full-run/$(date "+%Y-%m-%d--%H-%M-%S--%Z")"
+    else
+
     echo "S3_SRC is $S3_SRC"
     echo "S3_DST is $S3_DST"
 
@@ -143,7 +151,7 @@ main() {
           | gunzip -cfq \
           > "data/genbank/nextclade_old.tsv"
     else
-      touch "data/gisaid/nextclade_old.tsv"
+      touch "data/genbank/nextclade_old.tsv"
     fi
 
     # Find sequences in FASTA which don't have clades assigned yet

--- a/bin/ingest-genbank
+++ b/bin/ingest-genbank
@@ -1,5 +1,5 @@
 #!/bin/bash
-# usage: ingest-genbank [--fetch]
+# usage: ingest-genbank [--fetch] [--nextclade_full_run]
 #        ingest-genbank --help
 #
 # Ingest SARS-CoV-2 metadata and sequences from GenBank.
@@ -7,7 +7,13 @@
 # If the --fetch flag is given, new records are fetched from GenBank. Otherwise,
 # ingest from the existing GenBank NDJSON file on S3.
 #
-
+# If the --nextclade_full_run flag is given, the existing clade data is ignored
+# and a full Nextclade run is performed, recomputing clades and other metrics
+# for all sequences. This is necessary every time when new clades are defined or
+# when upgrading to the new version of Nextclade with breaking changes.
+# Note: this might take very long time to run, depending on available
+# computational resources.
+#
 set -euo pipefail
 
 : "${S3_SRC:=s3://nextstrain-data/files/ncov/open}"
@@ -15,6 +21,7 @@ set -euo pipefail
 
 main() {
     local fetch=0
+    local nextclade_full_run=0
 
     for arg; do
         case "$arg" in
@@ -24,6 +31,11 @@ main() {
                 ;;
             --fetch)
                 fetch=1
+                shift
+                break
+                ;;
+            --nextclade_full_run)
+                nextclade_full_run=1
                 shift
                 break
                 ;;
@@ -123,11 +135,16 @@ main() {
         data/genbank/location_hierarchy.tsv \
         genbank_accession
 
-    # Download old clades
-    (   aws s3 cp --no-progress "$S3_DST/nextclade.tsv.gz" - \
-        || aws s3 cp --no-progress "$S3_SRC/nextclade.tsv.gz" -) \
-        | gunzip -cfq \
-        > "data/genbank/nextclade_old.tsv"
+    # Nextclade will recompute all rows if nextclade_old.tsv is empty
+    if [ "$nextclade_full_run" == 0 ]; then
+      # Download old clades
+      (   aws s3 cp --no-progress "$S3_DST/nextclade.tsv.gz" - \
+          || aws s3 cp --no-progress "$S3_SRC/nextclade.tsv.gz" -) \
+          | gunzip -cfq \
+          > "data/genbank/nextclade_old.tsv"
+    else
+      touch "data/gisaid/nextclade_old.tsv"
+    fi
 
     # Find sequences in FASTA which don't have clades assigned yet
     ./bin/filter-fasta \

--- a/bin/ingest-gisaid
+++ b/bin/ingest-gisaid
@@ -72,6 +72,14 @@ main() {
             ;;
     esac
 
+    # In 'full run' mode we pretend that we run from a git branch
+    # and we write results to a special directory on S3, to keep
+    # production (master) files intact.
+    if [ "$nextclade_full_run" == 1 ]; then
+      branch="nextclade_full_run"
+      S3_DST="$S3_DST/nextclade-full-run/$(date "+%Y-%m-%d--%H-%M-%S--%Z")"
+    else
+
     echo "S3_SRC is $S3_SRC"
     echo "S3_DST is $S3_DST"
 

--- a/bin/ingest-gisaid
+++ b/bin/ingest-gisaid
@@ -78,7 +78,7 @@ main() {
     if [ "$nextclade_full_run" == 1 ]; then
       branch="nextclade_full_run"
       S3_DST="$S3_DST/nextclade-full-run/$(date "+%Y-%m-%d--%H-%M-%S--%Z")"
-    else
+    fi
 
     echo "S3_SRC is $S3_SRC"
     echo "S3_DST is $S3_DST"

--- a/bin/ingest-gisaid
+++ b/bin/ingest-gisaid
@@ -85,6 +85,8 @@ main() {
 
     cd "$(dirname "$0")/.."
 
+    set -x
+
     if [[ "$fetch" == 1 ]]; then
         local attempt=0 max_attempts=5
 
@@ -102,6 +104,7 @@ main() {
             echo "Failed to fetch"
             exit 1
         fi
+
         if [[ "$branch" == master ]]; then
             ./bin/notify-on-record-change data/gisaid.ndjson "$S3_SRC/gisaid.ndjson.xz" "GISAID"
         fi

--- a/bin/ingest-gisaid
+++ b/bin/ingest-gisaid
@@ -1,11 +1,18 @@
 #!/bin/bash
-# usage: ingest-gisaid [--fetch]
+# usage: ingest-gisaid [--fetch] [--nextclade_full_run]
 #        ingest-gisaid --help
 #
 # Ingest SARS-CoV-2 metadata and sequences from GISAID.
 #
 # If the --fetch flag is given, new records are fetched from GISAID. Otherwise,
 # ingest from the existing GISAID NDJSON file on S3.
+#
+# If the --nextclade_full_run flag is given, the existing clade data is ignored
+# and a full Nextclade run is performed, recomputing clades and other metrics
+# for all sequences. This is necessary every time when new clades are defined or
+# when upgrading to the new version of Nextclade with breaking changes.
+# Note: this might take very long time to run, depending on available
+# computational resources.
 #
 set -euo pipefail
 
@@ -14,6 +21,7 @@ set -euo pipefail
 
 main() {
     local fetch=0
+    local nextclade_full_run=0
 
     for arg; do
         case "$arg" in
@@ -23,6 +31,11 @@ main() {
                 ;;
             --fetch)
                 fetch=1
+                shift
+                break
+                ;;
+            --nextclade_full_run)
+                nextclade_full_run=1
                 shift
                 break
                 ;;
@@ -96,11 +109,16 @@ main() {
         --output-fasta data/gisaid/sequences.fasta \
         --output-unix-newline > "$flagged_annotations"
 
-    # Download old clades
-    (   aws s3 cp --no-progress "$S3_DST/nextclade.tsv.gz" - \
-     || aws s3 cp --no-progress "$S3_SRC/nextclade.tsv.gz" -) \
-        | gunzip -cfq \
-        > "data/gisaid/nextclade_old.tsv"
+    # Nextclade will recompute all rows if nextclade_old.tsv is empty
+    if [ "$nextclade_full_run" == 0 ]; then
+      # Download old clades
+      (   aws s3 cp --no-progress "$S3_DST/nextclade.tsv.gz" - \
+       || aws s3 cp --no-progress "$S3_SRC/nextclade.tsv.gz" -) \
+          | gunzip -cfq \
+          > "data/gisaid/nextclade_old.tsv"
+    else
+      touch "data/gisaid/nextclade_old.tsv"
+    fi
 
     # Find sequences in FASTA which don't have clades assigned yet
     ./bin/filter-fasta \


### PR DESCRIPTION
### Description of proposed changes    

This PR adds `--nextclade_full_run` flag for `ingest-gisaid` and `ingest-genbank` scripts as well as a pair of GitHub actions. This flag is needed to trigger full run of Nextclade on all available sequences.

In current implementation, clade results (and other metrics) are cached in `nextclade.tsv` file. Upon rerun, the sequences in `sequences.fasta` and  `nextclade.tsv` files are compared and only sequences that are missing in `nextclade.tsv` undergo analysis with Nextclade. The results are then appended to `nextclade.tsv`. Then `nextclade.tsv` gets merged with `metadata.tsv` and that's how clades and some of the other Nextclade metrics appear in the medatata.

With the new flag `--nextclade_full_run` provided, the `nextclade.tsv` (cached clades from the previous run) does not get downloaded. So the comparison always gives a list of all sequences and Nextclade processes them all again, and metadata table gets refreshed clades and metrics for all rows.

This refresh is necessary every time when new clades are defined or when upgrading to the new version of Nextclade with breaking changes.

Previously we used to perform these runs manually on external resources, but now we are thinking about automating this.

The trigger should probably still be manual, because not every Nextclade release needs the full run.

Depending on the manual data curation flow, these runs can be performed on master or on a separate branch. If on separate branch, the resulting `metadata.tsv` and `nextclade.tsv` will end up in the `branch/` subdirectory and should be copied manually to the location when the next ingest from master can find them.

Another challenge arises when we want to perform this full run before the required Nextclade version is released. Nextclade currently does not publishes pre-releases of CLI, but that can be worked out. Although automated C++ builds from master branch might be too costly in terms of CI credits. I currently experiment with the pre-released binaries in #215, branch [nextclade-full-run-2021-09-30](https://github.com/nextstrain/ncov-ingest/commits/nextclade-full-run-2021-09-30)

### Related issue(s)  

 - #215 

### Testing

Let's experiment a little in [#215] and see how well it goes :) 

We need to make sure the workflow for full reruns is convenient and the results are correct (that is that the full run actually happens and clades get recomputed).
