### PR TITLE
GitHub Actions for full Nextclade runs

### DIFF
--- a/.github/workflows/ingest-full-genbank.yml
+++ b/.github/workflows/ingest-full-genbank.yml
@@ -1,0 +1,47 @@
+name: GenBank ingest with full Nextclade run
+
+on:
+  # Manually triggered using `./bin/trigger genbank/ingest-full`
+  # (or `ingest-full`, which includes GISAID)
+  repository_dispatch:
+    types:
+      - genbank/ingest-full
+      - ingest-full
+
+  # Manually triggered using GitHub's UI
+  workflow_dispatch:
+
+jobs:
+  ingest-genbank-with-full-nextclade-run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: 'nextclade-full-run-2021-09-30'
+
+    - name: setup
+      run: ./bin/setup-github-workflow
+
+    - name: ingest-genbank-with-full-nextclade-run
+      run: |
+        ./bin/write-envdir env.d \
+          AWS_DEFAULT_REGION \
+          GITHUB_REF \
+          SLACK_TOKEN \
+          SLACK_CHANNELS
+
+        nextstrain build \
+          --aws-batch \
+          --no-download \
+          --image nextstrain/ncov-ingest \
+          --cpus 32 \
+          --memory 64GiB \
+          --exec env \
+          . \
+            envdir env.d ingest-genbank --nextclade_full_run
+      env:
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+        SLACK_CHANNELS: ncov-genbank-updates

--- a/.github/workflows/ingest-full-gisaid.yml
+++ b/.github/workflows/ingest-full-gisaid.yml
@@ -1,0 +1,51 @@
+name: GISAID ingest with full Nextclade run
+
+on:
+  # Manually triggered using `./bin/trigger gisaid/ingest-full`
+  # (or `ingest-full`, which includes GenBank)
+  repository_dispatch:
+    types:
+      - gisaid/ingest-full
+      - ingest-full
+
+  # Manually triggered using GitHub's UI
+  workflow_dispatch:
+
+jobs:
+  ingest-gisaid-with-full-nextclade-run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: 'nextclade-full-run-2021-09-30'
+
+    - name: setup
+      run: ./bin/setup-github-workflow
+
+    - name: ingest-gisaid-with-full-nextclade-run
+      run: |
+        ./bin/write-envdir env.d \
+          AWS_DEFAULT_REGION \
+          GISAID_API_ENDPOINT \
+          GISAID_USERNAME_AND_PASSWORD \
+          GITHUB_REF \
+          SLACK_TOKEN \
+          SLACK_CHANNELS
+
+        nextstrain build \
+          --aws-batch \
+          --no-download \
+          --image nextstrain/ncov-ingest \
+          --cpus 32 \
+          --memory 64GiB \
+          --exec env \
+          . \
+            envdir env.d ingest-gisaid --nextclade_full_run
+      env:
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        GISAID_API_ENDPOINT: ${{ secrets.GISAID_API_ENDPOINT }}
+        GISAID_USERNAME_AND_PASSWORD: ${{ secrets.GISAID_USERNAME_AND_PASSWORD }}
+        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+        SLACK_CHANNELS: ncov-gisaid-updates


### PR DESCRIPTION
### Description of proposed changes    

This PR contains new GitHub Actions workflows from https://github.com/nextstrain/ncov-ingest/pull/214.

I want to experiment with different options for full Nextclade runs (the experiments are in the #215, branch `nextclade-full-run-2021-09-30`, which combines #214 + some more stuff). The `.github/workflows/*` files need to be on master in order for GitHub actions to be triggerable. 

The triggers for the new workflows are currently manual.


Note that the new workflows temporarily hardcode the branch of #215 as follows:

```
    - uses: actions/checkout@v2
      with:
        ref: 'nextclade-full-run-2021-09-30'
```

We need the code from the branch to be able to trigger full runs. Once the code from #214 is on master, the hardcoded branch can (and need to) be removed.


### Related issue(s)  

 - #214 
 - #215

### Testing

Basically the [#215](#215) is my testing playground.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
