### PR TITLE
feat: add script to make full nextclade parallel run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,10 @@
 FROM nextstrain/base:branch-python-base
 
 # Install Python package for which Python 3.7 wheels do not yet exist on PyPI.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get --allow-releaseinfo-change-suite update && apt-get install -y --no-install-recommends \
         python3-netifaces \
         time\
+        csvkit \
         xz-utils
 
 # Install Python deps
@@ -41,15 +42,15 @@ RUN python3 -m pip install pipenv
 COPY Pipfile Pipfile.lock /nextstrain/ncov-ingest/
 RUN PIPENV_PIPFILE=/nextstrain/ncov-ingest/Pipfile pipenv sync --system
 
-# Install Nextclade
-RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-Linux-x86_64 \
-         -o /usr/local/bin/nextclade \
- && chmod a+rx /usr/local/bin/nextclade
-
-# Install Nextclade C++
-RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-Linux-x86_64 \
-         -o /usr/local/bin/nextclade \
- && chmod a+rx /usr/local/bin/nextclade
+## Install Nextclade
+#RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-Linux-x86_64 \
+#         -o /usr/local/bin/nextclade \
+# && chmod a+rx /usr/local/bin/nextclade
+#
+## Install Nextclade C++
+#RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-Linux-x86_64 \
+#         -o /usr/local/bin/nextclade \
+# && chmod a+rx /usr/local/bin/nextclade
 
 # Put any bin/ dir in the cwd on the path for more convenient invocation of
 # ncov-ingest's programs.

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,9 @@
 FROM nextstrain/base:branch-python-base
 
 # Install Python package for which Python 3.7 wheels do not yet exist on PyPI.
-RUN apt-get --allow-releaseinfo-change-suite update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
         python3-netifaces \
         time\
-        csvkit \
         xz-utils
 
 # Install Python deps
@@ -42,15 +41,15 @@ RUN python3 -m pip install pipenv
 COPY Pipfile Pipfile.lock /nextstrain/ncov-ingest/
 RUN PIPENV_PIPFILE=/nextstrain/ncov-ingest/Pipfile pipenv sync --system
 
-## Install Nextclade
-#RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-Linux-x86_64 \
-#         -o /usr/local/bin/nextclade \
-# && chmod a+rx /usr/local/bin/nextclade
-#
-## Install Nextclade C++
-#RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-Linux-x86_64 \
-#         -o /usr/local/bin/nextclade \
-# && chmod a+rx /usr/local/bin/nextclade
+# Install Nextclade
+RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-Linux-x86_64 \
+         -o /usr/local/bin/nextclade \
+ && chmod a+rx /usr/local/bin/nextclade
+
+# Install Nextclade C++
+RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-Linux-x86_64 \
+         -o /usr/local/bin/nextclade \
+ && chmod a+rx /usr/local/bin/nextclade
 
 # Put any bin/ dir in the cwd on the path for more convenient invocation of
 # ncov-ingest's programs.

--- a/bin/run-nextclade-full
+++ b/bin/run-nextclade-full
@@ -123,7 +123,9 @@ main() {
     --output_dir="${TMP_DIR_FASTA}"
 
   # Check if batches exist and report
+  # shellcheck disable=SC2086 # We want globbing here
   if ls ${INPUT_WILDCARD} 1>/dev/null 2>&1; then
+    # shellcheck disable=SC2086,SC2012 # We want globbing here
     NUM_BATCHES="$(ls -Ubad1 -- ${INPUT_WILDCARD} 2>/dev/null | wc -l)"
     echo "[ INFO] ${0}:${LINENO}: There are now ${NUM_BATCHES} batches of sequences to process with Nextclade (batch size is ${BATCH_SIZE})"
   else
@@ -161,6 +163,7 @@ main() {
     output_filename="${TMP_DIR_TSV}/${output_basename}"
 
     # Wait until there is an empty job slot to run. This is to avoid oversubscription.
+    # shellcheck disable=SC2004  # It does not seem to be working without the '$'
     while ((${N_JOBS_CURRENT@P} >= $N_CONCURRENT_JOBS_MAX)); do
       wait -n
     done
@@ -181,11 +184,13 @@ main() {
 
   for job in $(jobs -p); do
     echo "[ INFO] ${0}:${LINENO}: Waiting until all Nextclade background jobs finish"
-    wait $job
+    wait "$job"
   done
 
   # Check if output batches exist and report
+  # shellcheck disable=SC2086 # We want globbing here
   if ls ${OUTPUT_WILDCARD} 1>/dev/null 2>&1; then
+    # shellcheck disable=SC2012 # We want globbing here
     NUM_OUTPUT_BATCHES="$(ls -Ubad1 -- ${OUTPUT_WILDCARD} 2>/dev/null | wc -l)"
     echo "[ INFO] ${0}:${LINENO}: There are now ${NUM_OUTPUT_BATCHES} output batches to concatenate (batch size is ${BATCH_SIZE})"
     echo "[ INFO] ${0}:${LINENO}: Concatenating Nextclade output batches from '${OUTPUT_WILDCARD}' into '${OUTPUT_TSV}'"
@@ -198,6 +203,7 @@ main() {
   fi
 
   # Check if output batches exist and report
+  # shellcheck disable=SC2086 # We want globbing here
   if ! ls ${OUTPUT_TSV} 1>/dev/null 2>&1; then
     echo "[ERROR] ${0}:${LINENO}: Concatenated result not found: '${OUTPUT_TSV}'. Concatenation of output batches must have failed."
     exit 1

--- a/bin/run-nextclade-full
+++ b/bin/run-nextclade-full
@@ -111,6 +111,13 @@ main() {
   curl -fsSL ${NEXTCLADE_BIN_URL} -o "${NEXTCLADE_BIN}"
   chmod +x "${NEXTCLADE_BIN}"
 
+  echo "[ INFO] ${0}:${LINENO}: installing csvkit"
+  if ! command -v "csvstack"; then
+    pip3 install --upgrade --quiet csvkit
+    BIN="/tmp/.local/bin"
+    export PATH=${BIN}${PATH:+:$PATH}
+  fi
+
   echo "[ INFO] ${0}:${LINENO}: Downloading '${S3_SRC}/sequences.fasta.xz' to '${INPUT_FASTA}'"
   aws s3 cp --no-progress "${S3_SRC}/sequences.fasta.xz" - | xz -T0 -cdfq >"${INPUT_FASTA}"
 
@@ -194,9 +201,7 @@ main() {
     NUM_OUTPUT_BATCHES="$(ls -Ubad1 -- ${OUTPUT_WILDCARD} 2>/dev/null | wc -l)"
     echo "[ INFO] ${0}:${LINENO}: There are now ${NUM_OUTPUT_BATCHES} output batches to concatenate (batch size is ${BATCH_SIZE})"
     echo "[ INFO] ${0}:${LINENO}: Concatenating Nextclade output batches from '${OUTPUT_WILDCARD}' into '${OUTPUT_TSV}'"
-    for output in ${OUTPUT_WILDCARD}; do
-      ./bin/join-rows "$output" "${OUTPUT_TSV}" -o "${OUTPUT_TSV}"
-    done
+    csvstack --tabs ${OUTPUT_WILDCARD} | csvformat --out-tabs > "${OUTPUT_TSV}"
   else
     echo "[ERROR] ${0}:${LINENO}: Output batches are not found: '${OUTPUT_WILDCARD}'. Nextclade jobs mush have failed to write their results."
     exit 1

--- a/bin/run-nextclade-full
+++ b/bin/run-nextclade-full
@@ -77,7 +77,8 @@ main() {
     exit 1
   fi
 
-  S3_DST="$S3_SRC/nextclade-full-run"
+  DATE_UTC=$(date -u "+%Y-%m-%d--%H-%M-%S--%Z")
+  S3_DST="$S3_SRC/nextclade-full-run-${DATE_UTC}"
 
   INPUT_FASTA="data/${DATABASE}/sequences.fasta"
   OUTPUT_TSV="data/${DATABASE}/nextclade.tsv"

--- a/bin/run-nextclade-full
+++ b/bin/run-nextclade-full
@@ -204,6 +204,14 @@ main() {
   fi
 
   ./bin/upload-to-s3 ${silent:+--quiet} "${OUTPUT_TSV}" "$S3_DST/nextclade.tsv.gz"
+
+  # Cut the running time by deleting working directory and avoiding zipping it.
+  # We are unlikely to inspect it anyways. But keep the result file, just in
+  # case.
+  mv "${OUTPUT_TSV}" "nextclade.tsv"
+  rm -rf data tmp "${NEXTCLADE_BIN}"
+  mkdir -p "$(dirname "${OUTPUT_TSV}")"
+  mv "nextclade.tsv" "${OUTPUT_TSV}"
 }
 
 print-help() {

--- a/bin/run-nextclade-full
+++ b/bin/run-nextclade-full
@@ -1,0 +1,225 @@
+#!/bin/bash
+# usage: run-nextclade-full --database=gisaid|genbank [--n_processors] [--n_nextclade_threads] [--batch_size]
+#        run-nextclade-full --help
+#
+# Make a full Nextclade run, recomputing clades and other metrics
+# for all sequences. This is necessary every time when new clades are defined or
+# when upgrading to the new version of Nextclade with breaking changes.
+#
+# Implementation details: sequence data is split into batches of given size.
+# A number of Nextclade instances is launched concurrently, depending on
+# given number of processors and number of threads each instance is allowed to
+#
+#
+# Note: this might take very long time to run (hours to days), depending on
+# number of sequences to be processed and available computational resources.
+#
+# --database=gisaid|genbank   Database to use. This defines which sequences will
+#                             be downloaded and where the results will be
+#                             uploaded.
+#
+# --n_processors              Maximum number of threads all instances of
+#                             Nextclade are allowed to use.
+#
+# --n_nextclade_threads       Maximum number of threads each individual instance
+#                             of Nextclade is allowed to use
+#
+# --batch_size                Maximum number of sequences fed to an individual
+#                             instance of Nextclade
+set -euo pipefail
+
+main() {
+  # Total number of processors in the system that Nextclade can use.
+  # Default equals to the number of threads on all CPUs combined.
+  N_PROCESSORS=${N_PROCESSORS:-$(getconf _NPROCESSORS_ONLN)}
+
+  # Each invocation of Nextclade will use this number of threads
+  N_NEXTCLADE_THREADS=${N_NEXTCLADE_THREADS:-8}
+
+  # Each invocation of Nextclade will be given this number of sequences
+  BATCH_SIZE=${BATCH_SIZE:-100000}
+
+  DATABASE=
+
+  silent=0
+
+  for arg; do
+    case "$arg" in
+    -h | --help)
+      print-help
+      exit
+      ;;
+    --database=*)
+      DATABASE="${arg#*=}"
+      shift
+      ;;
+    --n_processors=*)
+      N_PROCESSORS="${arg#*=}"
+      shift
+      ;;
+    --n_nextclade_threads=*)
+      N_NEXTCLADE_THREADS="${arg#*=}"
+      shift
+      ;;
+    --batch_size=*)
+      BATCH_SIZE="${arg#*=}"
+      shift
+      ;;
+    esac
+  done
+
+  if [ "${DATABASE}" == "gisaid" ]; then
+    S3_SRC="s3://nextstrain-ncov-private"
+  elif [ "${DATABASE}" == "genbank" ]; then
+    S3_SRC="s3://nextstrain-data/files/ncov/open"
+  else
+    echo "[ERROR] ${0}:${LINENO}: Unknown database: The '--database' flag should be set to either 'gisaid' or 'genbank'"
+    exit 1
+  fi
+
+  S3_DST="$S3_SRC/nextclade-full-run"
+
+  INPUT_FASTA="data/${DATABASE}/sequences.fasta"
+  OUTPUT_TSV="data/${DATABASE}/nextclade.tsv"
+  TMP_DIR_FASTA="tmp/${DATABASE}/fasta"
+  TMP_DIR_TSV="tmp/${DATABASE}/clades"
+  TMP_DIR_NEXTCLADE_DATASET="tmp/dataset"
+  TMP_DIR_UNUSED="tmp/${DATABASE}/unused"
+  INPUT_WILDCARD="${TMP_DIR_FASTA}/*.fasta"
+  OUTPUT_WILDCARD="${TMP_DIR_TSV}/*.tsv"
+
+  NEXTCLADE_BIN_URL="https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-Linux-x86_64"
+  NEXTCLADE_BIN="nextclade"
+
+  # Maximum number of Nextclade invocations that can run concurrently
+  N_CONCURRENT_JOBS_MAX=$((N_PROCESSORS / N_NEXTCLADE_THREADS + 1))
+  if [ $N_CONCURRENT_JOBS_MAX == 0 ]; then
+    N_CONCURRENT_JOBS_MAX=1
+  fi
+
+  echo "[ INFO] ${0}:${LINENO}: Nextclade full run is starting"
+  echo "[ INFO] ${0}:${LINENO}:   DATABASE=${DATABASE}"
+  echo "[ INFO] ${0}:${LINENO}:   N_PROCESSORS=${N_PROCESSORS}"
+  echo "[ INFO] ${0}:${LINENO}:   N_NEXTCLADE_THREADS=${N_NEXTCLADE_THREADS}"
+  echo "[ INFO] ${0}:${LINENO}:   N_CONCURRENT_JOBS_MAX=${N_CONCURRENT_JOBS_MAX}"
+  echo "[ INFO] ${0}:${LINENO}:   BATCH_SIZE=${BATCH_SIZE}"
+  echo "[ INFO] ${0}:${LINENO}:   S3_SRC=${S3_SRC}"
+  echo "[ INFO] ${0}:${LINENO}:   S3_DST=${S3_DST}"
+  echo "[ INFO] ${0}:${LINENO}:   NEXTCLADE_BIN_URL=${NEXTCLADE_BIN_URL}"
+
+  echo "[ INFO] ${0}:${LINENO}: Downloading latest Nextclade version from '${NEXTCLADE_BIN_URL}' to '${NEXTCLADE_BIN}'"
+  curl -fsSL ${NEXTCLADE_BIN_URL} -o "${NEXTCLADE_BIN}"
+  chmod +x "${NEXTCLADE_BIN}"
+
+  echo "[ INFO] ${0}:${LINENO}: Downloading '${S3_SRC}/sequences.fasta.xz' to '${INPUT_FASTA}'"
+  aws s3 cp --no-progress "${S3_SRC}/sequences.fasta.xz" - | xz -T0 -cdfq >"${INPUT_FASTA}"
+
+  echo "[ INFO] ${0}:${LINENO}: Splitting '${INPUT_FASTA}' into batches of size ${BATCH_SIZE} sequences and storing them in '${INPUT_WILDCARD}'"
+  # Split fasta file to multiple batches
+  mkdir -p "${TMP_DIR_FASTA}"
+  ./bin/split-fasta \
+    "${INPUT_FASTA}" \
+    --batch_size="${BATCH_SIZE}" \
+    --output_dir="${TMP_DIR_FASTA}"
+
+  # Check if batches exist and report
+  if ls ${INPUT_WILDCARD} 1>/dev/null 2>&1; then
+    NUM_BATCHES="$(ls -Ubad1 -- ${INPUT_WILDCARD} 2>/dev/null | wc -l)"
+    echo "[ INFO] ${0}:${LINENO}: There are now ${NUM_BATCHES} batches of sequences to process with Nextclade (batch size is ${BATCH_SIZE})"
+  else
+    echo "[ INFO] ${0}:${LINENO}: There are no sequences to process. Skipping Nextclade step."
+    rm -rf "${TMP_DIR_FASTA}"
+    exit 0
+  fi
+
+  if ! command -v ./${NEXTCLADE_BIN} &>/dev/null; then
+    echo "[ERROR] ${0}:${LINENO}: Nextclade executable not found"
+    exit 1
+  fi
+
+  NEXTCLADE_VERSION="$(./${NEXTCLADE_BIN} --version)"
+  echo "[ INFO] ${0}:${LINENO}: Nextclade version: ${NEXTCLADE_VERSION}"
+
+  echo "[ INFO] ${0}:${LINENO}: Downloading Nextclade dataset \"sars-cov-2\""
+  ./${NEXTCLADE_BIN} dataset get --name="sars-cov-2" --output-dir="${TMP_DIR_NEXTCLADE_DATASET}" --verbose
+
+  # Run batches in parallel
+  echo "[ INFO] ${0}:${LINENO}: Nextclade is allowed to use ${N_PROCESSORS} threads. Each invocation of Nextclade is allowed to use ${N_NEXTCLADE_THREADS} threads."
+  echo "[ INFO] ${0}:${LINENO}: Will run ${NUM_BATCHES} total Nextclade jobs, at most ${N_CONCURRENT_JOBS_MAX} concurrent jobs at a time."
+  mkdir -p "${TMP_DIR_TSV}"
+  N_JOBS_CURRENT="\j"
+  for input in ${INPUT_WILDCARD}; do
+    if [ ! -e "${input}" ]; then
+      # If ${input} does not exist, this means that INPUT_WILDCARD was not expanded,
+      # there are no batch files and we should not attempt to run the processing.
+      # If we would, then it will crash.
+      break
+    fi
+
+    input_basename="$(basename "${input}")"
+    output_basename="${input_basename%.fasta}.tsv"
+    output_filename="${TMP_DIR_TSV}/${output_basename}"
+
+    # Wait until there is an empty job slot to run. This is to avoid oversubscription.
+    while ((${N_JOBS_CURRENT@P} >= $N_CONCURRENT_JOBS_MAX)); do
+      wait -n
+    done
+
+    echo "[ INFO] ${0}:${LINENO}: Running Nextclade for batch ${input} as a background job"
+    ./${NEXTCLADE_BIN} run \
+      --jobs="${N_NEXTCLADE_THREADS}" \
+      --in-order \
+      --verbosity=error \
+      --input-fasta="${input}" \
+      --input-dataset="${TMP_DIR_NEXTCLADE_DATASET}" \
+      --output-tsv="${output_filename}" \
+      --genes=E,M,N,ORF1a,ORF1b,ORF3a,ORF6,ORF7a,ORF7b,ORF8,ORF9b,S \
+      --output-dir="${TMP_DIR_UNUSED}" \
+      --output-basename="nextclade" \
+      &
+  done
+
+  for job in $(jobs -p); do
+    echo "[ INFO] ${0}:${LINENO}: Waiting until all Nextclade background jobs finish"
+    wait $job
+  done
+
+  # Check if output batches exist and report
+  if ls ${OUTPUT_WILDCARD} 1>/dev/null 2>&1; then
+    NUM_OUTPUT_BATCHES="$(ls -Ubad1 -- ${OUTPUT_WILDCARD} 2>/dev/null | wc -l)"
+    echo "[ INFO] ${0}:${LINENO}: There are now ${NUM_OUTPUT_BATCHES} output batches to concatenate (batch size is ${BATCH_SIZE})"
+    echo "[ INFO] ${0}:${LINENO}: Concatenating Nextclade output batches from '${OUTPUT_WILDCARD}' into '${OUTPUT_TSV}'"
+    for output in ${OUTPUT_WILDCARD}; do
+      ./bin/join-rows "$output" "${OUTPUT_TSV}" -o "${OUTPUT_TSV}"
+    done
+  else
+    echo "[ERROR] ${0}:${LINENO}: Output batches are not found: '${OUTPUT_WILDCARD}'. Nextclade jobs mush have failed to write their results."
+    exit 1
+  fi
+
+  # Check if output batches exist and report
+  if ! ls ${OUTPUT_TSV} 1>/dev/null 2>&1; then
+    echo "[ERROR] ${0}:${LINENO}: Concatenated result not found: '${OUTPUT_TSV}'. Concatenation of output batches must have failed."
+    exit 1
+  fi
+
+  ./bin/upload-to-s3 ${silent:+--quiet} "${OUTPUT_TSV}" "$S3_DST/nextclade.tsv.gz"
+}
+
+print-help() {
+  # Print the help comments at the top of this file ($0)
+  local line
+  while read -r line; do
+    if [[ $line =~ ^#! ]]; then
+      continue
+    elif [[ $line =~ ^# ]]; then
+      line="${line/##/}"
+      line="${line/# /}"
+      echo "$line"
+    else
+      break
+    fi
+  done <"$0"
+}
+
+main "$@"

--- a/bin/run-nextclade-full-aws
+++ b/bin/run-nextclade-full-aws
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# usage: run-nextclade-full --database=gisaid|genbank [--aws_batch_cpus] [--aws_batch_memory] [--n_processors] [--n_nextclade_threads] [--batch_size]
+#        run-nextclade-full --help
+#
+# Make a full Nextclade run, recomputing clades and other metrics
+# for all sequences. This version schedules run on AWS batch.
+#
+# See `./bin/run-nextclade-full` for more details.
+#
+# --database=gisaid|genbank   Database to use. This defines which sequences will
+#                             be downloaded and where the results will be
+#                             uploaded.
+#
+# --aws_batch_cpus=96         Number of processors to request from AWS Batch
+#
+# --aws_batch_memory=180GiB   Amount of memory to request from AWS Batch
+#
+# --n_processors              Maximum number of threads all instances of
+#                             Nextclade are allowed to use.
+#
+# --n_nextclade_threads       Maximum number of threads each individual instance
+#                             of Nextclade is allowed to use
+#
+# --batch_size                Maximum number of sequences fed to an individual
+#                             instance of Nextclade
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+trap "exit" INT
+
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-}"
+export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-}"
+
+bin=$(dirname "$0")
+
+main() {
+  # These variables are passed through to the `./bin/run-nextclade-full`
+  # as corresponding CLi flags
+  DATABASE=
+  N_PROCESSORS=
+  N_NEXTCLADE_THREADS=
+  BATCH_SIZE=
+
+
+  AWS_BATCH_CPUS=96
+  AWS_BATCH_MEMORY=180GiB
+
+  for arg; do
+    case "$arg" in
+    -h | --help)
+      print-help
+      exit
+      ;;
+    --database=*)
+      DATABASE="${arg#*=}"
+      shift
+      ;;
+    --aws_batch_cpus=*)
+      AWS_BATCH_CPUS="${arg#*=}"
+      shift
+      ;;
+    --aws_batch_memory=*)
+      AWS_BATCH_MEMORY="${arg#*=}"
+      shift
+      ;;
+    --n_processors=*)
+      N_PROCESSORS="${arg#*=}"
+      shift
+      ;;
+    --n_nextclade_threads=*)
+      N_NEXTCLADE_THREADS="${arg#*=}"
+      shift
+      ;;
+    --batch_size=*)
+      BATCH_SIZE="${arg#*=}"
+      shift
+      ;;
+    esac
+  done
+
+  if [ "${DATABASE}" != "gisaid" ] && [ "${DATABASE}" != "genbank" ]; then
+    echo "[ERROR] ${0}:${LINENO}: Unknown database: The '--database' flag should be set to either 'gisaid' or 'genbank'"
+    exit 1
+  fi
+
+  "$bin/write-envdir" env.d \
+    AWS_DEFAULT_REGION \
+    AWS_ACCESS_KEY_ID \
+    AWS_SECRET_ACCESS_KEY
+
+  echo "[ INFO] ${0}:${LINENO}: Submitting Nextclade full run on AWS Batch"
+  echo "[ INFO] ${0}:${LINENO}:   DATABASE=${DATABASE}"
+  echo "[ INFO] ${0}:${LINENO}:   AWS_BATCH_CPUS=${AWS_BATCH_CPUS}"
+  echo "[ INFO] ${0}:${LINENO}:   AWS_BATCH_MEMORY=${AWS_BATCH_MEMORY}"
+  echo "[ INFO] ${0}:${LINENO}:   N_PROCESSORS=${N_PROCESSORS}"
+  echo "[ INFO] ${0}:${LINENO}:   N_NEXTCLADE_THREADS=${N_NEXTCLADE_THREADS}"
+  echo "[ INFO] ${0}:${LINENO}:   BATCH_SIZE=${BATCH_SIZE}"
+
+  nextstrain build \
+    --aws-batch \
+    --no-download \
+    --image nextstrain/ncov-ingest \
+    --cpus "$AWS_BATCH_CPUS" \
+    --memory "$AWS_BATCH_MEMORY" \
+    --exec env \
+    . \
+    envdir env.d run-nextclade-full \
+      --database="${DATABASE}" \
+      ${N_PROCESSORS:+--n_processors=$N_PROCESSORS} \
+      ${N_NEXTCLADE_THREADS:+--n_nextclade_threads=$N_NEXTCLADE_THREADS} \
+      ${BATCH_SIZE:+--batch_size=$BATCH_SIZE}
+}
+
+print-help() {
+  # Print the help comments at the top of this file ($0)
+  local line
+  while read -r line; do
+    if [[ $line =~ ^#! ]]; then
+      continue
+    elif [[ $line =~ ^# ]]; then
+      line="${line/##/}"
+      line="${line/# /}"
+      echo "$line"
+    else
+      break
+    fi
+  done <"$0"
+}
+
+main "$@"

--- a/bin/run-nextclade-full-docker
+++ b/bin/run-nextclade-full-docker
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# usage: run-nextclade-full --database=gisaid|genbank [--n_processors] [--n_nextclade_threads] [--batch_size]
+#        run-nextclade-full --help
+#
+# Make a full Nextclade run, recomputing clades and other metrics
+# for all sequences. This version runs in a Docker container.
+#
+# See `./bin/run-nextclade-full` for more details.
+#
+# This script accepts the same arguments as `./bin/run-nextclade-full`
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+trap "exit" INT
+
+DOCKER_IMAGE_NAME="nextstrain/ncov-ingest"
+DOCKER_CONTAINER_NAME="${DOCKER_IMAGE_NAME//\//-}-$(date +%s)"
+
+AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:=us-east-1}"
+
+mkdir -p data tmp cache
+
+docker run -it --rm \
+--init \
+--name="${DOCKER_CONTAINER_NAME}" \
+--hostname="${DOCKER_IMAGE_NAME}" \
+--env "DOCKER_IMAGE_NAME=${DOCKER_IMAGE_NAME}" \
+--env "DOCKER_CONTAINER_NAME=${DOCKER_CONTAINER_NAME}" \
+--env "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}" \
+--env "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}" \
+--env "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}" \
+--user="$(id -u):$(id -g)" \
+--volume="$(pwd):/workdir" \
+--workdir=/workdir \
+${DOCKER_IMAGE_NAME} \
+bash -c "./bin/run-nextclade-full $*"

--- a/bin/split-fasta
+++ b/bin/split-fasta
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+import argparse
+import os
+
+from Bio import SeqIO
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Splits a fasta file into batch of given size")
+    parser.add_argument("input_file", help="Path to the input fasta file.")
+    parser.add_argument(
+        "--batch_size", "-c",
+        required=True,
+        help="Size of each batch. Note that the last batch might be smaller than that."
+    )
+    parser.add_argument(
+        "--output_dir", "-o",
+        required=True,
+        help="Output directory. Batches will be named as `{output_dir}/{basename(input_file)}.batch-{i:05}.fasta`, where `i:05` is the index of a batch zeri-padded to length of 5."
+    )
+    return parser.parse_args()
+
+
+# From https://biopython.org/wiki/Split_large_file
+def batch_iterator(iterator, batch_size):
+    """Returns lists of length batch_size.
+
+    This can be used on any iterator, for example to batch up
+    SeqRecord objects from Bio.SeqIO.parse(...), or to batch
+    Alignment objects from Bio.AlignIO.parse(...), or simply
+    lines from a file handle.
+
+    This is a generator function, and it returns lists of the
+    entries from the supplied iterator.  Each list will have
+    batch_size entries, although the final list may be shorter.
+    """
+    entry = True  # Make sure we loop once
+    while entry:
+        batch = []
+        while len(batch) < batch_size:
+            try:
+                entry = next(iterator)
+            except StopIteration:
+                entry = None
+            if entry is None:
+                # End of file
+                break
+            batch.append(entry)
+        if batch:
+            yield batch
+
+
+def main():
+    file_format = "fasta"
+    args = parse_args()
+    input_filename = os.path.basename(args.input_file)
+    batch_size = int(args.batch_size)
+
+    with open(args.input_file) as f_input:
+        record_iter = SeqIO.parse(f_input, file_format)
+        for i, batch in enumerate(batch_iterator(record_iter, batch_size)):
+            filename = os.path.join(args.output_dir, f"{input_filename}.batch-{i:05}.fasta")
+            with open(filename, "w") as f_output:
+                count = SeqIO.write(batch, f_output, file_format)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Description of proposed changes
 
This PR adds script `./bin/run-nextclade-full` and a set of helper scripts, to trigger full run of Nextclade: all available sequences will be processed again. The goal here is to automate, at least partially, the tedious task of performing these full runs.

The changes in this PR should not affect the normal daily flow and are just helpers for the full reruns that are performed occasionally.

#### Previously

In the routine daily ingests only the new sequences get processed by Nextclade. Clade results (and other metrics) from previous runs are cached in `nextclade.tsv` file. Upon rerun, the sequences in `sequences.fasta` and `nextclade.tsv` files are compared and only sequences that are missing in `nextclade.tsv` undergo analysis with Nextclade. The results are then appended to `nextclade.tsv`. Then nextclade.tsv gets merged with metadata.tsv and that's how clades and some of the other Nextclade metrics appear in the medatata file.

However, the cache needs to be invalidated when
 - clades names or definitions change
 - we want to upgrade Nextclade to a new version that has breaking changes 
 - we want to change what columns we add to metadata
a full rerun on all sequences is needed in order to refresh the metadata table.

It takes a while to run it, and back in the day, when ingest ran purely on GitHub Actions, @rneher was running these full runs on an external cluster. It's a tedious task, so my goal here is to automate the flow, at least partially. Especially now that ingest is on AWS.


#### In this PR

The following scripts are introduced:

 - `./bin/run-nextclade-full` - runs locally (not feasible computationally for most people). For development and debugging. The script accepts `--database=gisaid|genbank` flag to set the input and output sources on S3. It downloads currently available `sequence.fasta` (from daily workflow). It splits this file into batches and runs several instances of Nextclade in parallel on a single batch to achieve better resource utilization. The batch size and number of threads per Nextclade instance is configurable. Nextclade instances are allocated a certain number of threads and they wait until previous instances finish to not cause too much oversubscription. A small overlap is given to oversubscribe slightly for better resource use.

 - `./bin/run-nextclade-full-docker` - runs `./bin/run-nextclade-full` in a Docker container (still not feasible computationally for most people). For more convenient development and debugging.

 - `./bin/run-nextclade-full-aws` - schedules `./bin/run-nextclade-full` on AWS Batch. There are additional flags to set number of requested CPUs and memory from AWS Batch.

 - `./bin/split-fasta` - brought back from the olden days: 9bce646534ac436a414d31ba7126135a446bf0c4. It was removed in 94b0372d0e9afbe2c7668c5af92f034f541d98a5 when Nextclade became multithreaded. This scrip is what splits sequences into batches.


##### Intended usage

When it's decided that a full run is needed, a dedicated person should run:

```bash
cd ncov-ingest
./bin/run-nextclade-full-aws --database=gisaid
./bin/run-nextclade-full-aws --database=genbank
```
(making sure AWS credentials are available for the script)

The resulting `nextclade.tsv.gz` should be then available in the subdirectory `nextclade-full-run` in the usual S3 location for the particular database:

```bash
s3://nextstrain-ncov-private/nextclade-full-run/nextclade.tsv.gz
s3://nextstrain-data/files/ncov/open/nextclade-full-run/nextclade.tsv.gz
```

The `nextclade.tsv.gz` should be manually inspected for scientific correctness, comparing to the old one, if necessary. If all went well, after agreeing with ingest team, the `nextclade.tsv.gz` should then be copied to the location where the daily ingest can find it, overwriting the old one. These locations are:

```
s3://nextstrain-ncov-private/nextclade.tsv.gz
s3://nextstrain-data/files/ncov/open/nextclade.tsv.gz
```
(just omit the subdirectory `nextclade-full-run`)

The next ingest will then include the freshly computed clades. We might try to automate this step as well. However, given that manual inspection is needed, the automation options are limited.



### Related issue(s)  

None

### Testing

The examples of AWS Batch jobs:

GISAID:
```
nextstrain build --aws-batch --no-download --attach 0591961b-fb72-4f18-b55f-38e8f8c9f20d .
```

GenBank:
```
nextstrain build --aws-batch --no-download --attach 20698f2c-69f1-4302-8df0-3b300ea69411 .
```

We need to make sure the workflow for full reruns is convenient and the results are correct (that is that the full run actually happens and clades get recomputed).
