### PR TITLE
perf: use multithreaded mode of xz

### DIFF
--- a/bin/download-from-s3
+++ b/bin/download-from-s3
@@ -22,7 +22,7 @@ main() {
         if [[ "$src" == *.gz ]]; then
             gunzip -cfq
         elif  [[ "$src" == *.xz ]]; then
-            xz -dcq
+            xz -T0 -dcq
         else
             cat
         fi > "$dst"

--- a/bin/ingest-genbank
+++ b/bin/ingest-genbank
@@ -107,8 +107,8 @@ main() {
         ./bin/upload-to-s3 ${silent:+--quiet} data/genbank.ndjson "$S3_DST/genbank.ndjson.xz"
         ./bin/upload-to-s3 ${silent:+--quiet} data/biosample.ndjson "$S3_DST/biosample.ndjson.xz"
     else
-        aws s3 cp --no-progress "$S3_DST/genbank.ndjson.xz" - | xz -cdfq > data/genbank.ndjson
-        aws s3 cp --no-progress "$S3_DST/biosample.ndjson.xz" - | xz -cdfq > data/biosample.ndjson
+        aws s3 cp --no-progress "$S3_DST/genbank.ndjson.xz" - | xz -T0 -cdfq > data/genbank.ndjson
+        aws s3 cp --no-progress "$S3_DST/biosample.ndjson.xz" - | xz -T0 -cdfq > data/biosample.ndjson
     fi
 
     ./bin/transform-biosample data/biosample.ndjson \

--- a/bin/ingest-gisaid
+++ b/bin/ingest-gisaid
@@ -86,7 +86,7 @@ main() {
         fi
         ./bin/upload-to-s3 --quiet data/gisaid.ndjson "$S3_DST/gisaid.ndjson.xz"
     else
-        aws s3 cp --no-progress "$S3_DST/gisaid.ndjson.xz" - | xz -cdfq > data/gisaid.ndjson
+        aws s3 cp --no-progress "$S3_DST/gisaid.ndjson.xz" - | xz -T0 -cdfq > data/gisaid.ndjson
     fi
 
     flagged_annotations="$(mktemp -t flagged-annotations-XXXXXX)"

--- a/bin/notify-on-record-change
+++ b/bin/notify-on-record-change
@@ -14,7 +14,7 @@ source_name=${3:?A record source name is required as the third argument.}
 "$bin"/s3-object-exists "$dst" || exit 0
 
 src_record_count="$(wc -l < "$src")"
-dst_record_count="$(wc -l < <(aws s3 cp --no-progress "$dst" - | xz -dcfq))"
+dst_record_count="$(wc -l < <(aws s3 cp --no-progress "$dst" - | xz -T0 -dcfq))"
 added_records="$(( src_record_count - dst_record_count ))"
 
 printf "%'4d %s\n" "$src_record_count" "$src"

--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -35,7 +35,7 @@ main() {
         if [[ "$dst" == *.gz ]]; then
             gzip -c "$src"
         elif  [[ "$dst" == *.xz ]]; then
-            xz -2 -c "$src"
+            xz -2 -T0 -c "$src"
         else
             cat "$src"
         fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash" "$(content-type "$dst")"


### PR DESCRIPTION
### Description of proposed changes    

Should make things a bit faster. Not sure if there are any disadvantages, but nothing comes to mind.

Threaded decompression has not been implemented yet, but compression should work. We could use [pixz](https://github.com/vasi/pixz) for threaded decompression as well.

From `man xz`:

```
-T threads, --threads=threads
       Specify the number of worker threads to use.  Setting threads to a special value 0 makes xz use as many
       threads as there are CPU cores on the system.  The actual number of threads can be less than threads if
       the input file is not big enough for threading with the given settings or if using more  threads  would
       exceed the memory usage limit.

       Currently  the  only threading method is to split the input into blocks and compress them independently
       from each other.  The default block size depends on the compression level and can be overriden with the
       --block-size=size option.

       Threaded  decompression  hasn't been implemented yet.  It will only work on files that contain multiple
       blocks with size information in block headers.  All files compressed in multi-threaded mode  meet  this
       condition, but files compressed in single-threaded mode don't even if --block-size=size is used.

```

Also:

 - https://stackoverflow.com/a/33441796
 - https://superuser.com/a/897325
 - https://git.tukaani.org/?p=xz.git;a=blob_plain;f=NEWS;hb=HEAD

### Related issue(s)  

 - #194 
 - #169 
 - #198 

### Testing

:boom: 
