### PR TITLE
reafactor: deduplicate downloading and decompressing logic

### DIFF
--- a/bin/download-from-s3
+++ b/bin/download-from-s3
@@ -11,10 +11,7 @@ main() {
 
     local src_hash dst_hash no_hash=0000000000000000000000000000000000000000000000000000000000000000
     dst_hash="$(sha256sum "$dst" 2>/dev/null | awk '{ print $1 }' || true)"
-    src_hash="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text || echo "$no_hash")"
-
-    echo "$src_hash $src"
-    echo "$dst_hash $dst"
+    src_hash="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
 
     echo "[ INFO] Downloading $src → $dst"
     if [[ $src_hash != "$dst_hash" ]]; then

--- a/bin/ingest-genbank
+++ b/bin/ingest-genbank
@@ -107,8 +107,8 @@ main() {
         ./bin/upload-to-s3 ${silent:+--quiet} data/genbank.ndjson "$S3_DST/genbank.ndjson.xz"
         ./bin/upload-to-s3 ${silent:+--quiet} data/biosample.ndjson "$S3_DST/biosample.ndjson.xz"
     else
-        aws s3 cp --no-progress "$S3_DST/genbank.ndjson.xz" - | xz -cdfq > data/genbank.ndjson
-        aws s3 cp --no-progress "$S3_DST/biosample.ndjson.xz" - | xz -cdfq > data/biosample.ndjson
+        ./bin/download-from-s3 "$S3_DST/genbank.ndjson.xz" "data/genbank.ndjson"
+        ./bin/download-from-s3 "$S3_DST/biosample.ndjson.xz" "data/biosample.ndjson"
     fi
 
     ./bin/transform-biosample data/biosample.ndjson \
@@ -124,10 +124,8 @@ main() {
         genbank_accession
 
     # Download old clades
-    (   aws s3 cp --no-progress "$S3_DST/nextclade.tsv.gz" - \
-        || aws s3 cp --no-progress "$S3_SRC/nextclade.tsv.gz" -) \
-        | gunzip -cfq \
-        > "data/genbank/nextclade_old.tsv"
+    ./bin/download-from-s3 "$S3_DST/nextclade.tsv.gz" "data/genbank/nextclade_old.tsv" ||  \
+    ./bin/download-from-s3 "$S3_SRC/nextclade.tsv.gz" "data/genbank/nextclade_old.tsv"
 
     # Find sequences in FASTA which don't have clades assigned yet
     ./bin/filter-fasta \

--- a/bin/ingest-gisaid
+++ b/bin/ingest-gisaid
@@ -86,7 +86,7 @@ main() {
         fi
         ./bin/upload-to-s3 --quiet data/gisaid.ndjson "$S3_DST/gisaid.ndjson.xz"
     else
-        aws s3 cp --no-progress "$S3_DST/gisaid.ndjson.xz" - | xz -cdfq > data/gisaid.ndjson
+        ./bin/download-from-s3 "$S3_DST/gisaid.ndjson.xz" "data/gisaid.ndjson"
     fi
 
     flagged_annotations="$(mktemp -t flagged-annotations-XXXXXX)"
@@ -97,10 +97,8 @@ main() {
         --output-unix-newline > "$flagged_annotations"
 
     # Download old clades
-    (   aws s3 cp --no-progress "$S3_DST/nextclade.tsv.gz" - \
-     || aws s3 cp --no-progress "$S3_SRC/nextclade.tsv.gz" -) \
-        | gunzip -cfq \
-        > "data/gisaid/nextclade_old.tsv"
+    ./bin/download-from-s3 "$S3_DST/nextclade.tsv.gz" "data/gisaid/nextclade_old.tsv" ||  \
+    ./bin/download-from-s3 "$S3_SRC/nextclade.tsv.gz" "data/gisaid/nextclade_old.tsv"
 
     # Find sequences in FASTA which don't have clades assigned yet
     ./bin/filter-fasta \

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -82,8 +82,8 @@ main() {
 download-inputs() {
   mkdir -p "${INPUT_DIR}"
 
-  aws s3 cp "${S3_BUCKET}/additional_info.tsv.gz" - | gunzip -cq >"data/gisaid/inputs/additional_info.tsv"
-  aws s3 cp "${S3_BUCKET}/metadata.tsv.gz" - | gunzip -cq >"data/gisaid/inputs/metadata.tsv"
+  ./bin/download-from-s3 "${S3_BUCKET}/additional_info.tsv.gz" "data/gisaid/inputs/additional_info.tsv"
+  ./bin/download-from-s3 "${S3_BUCKET}/metadata.tsv.gz" "data/gisaid/inputs/metadata.tsv"
 }
 
 download-gisaid() {

--- a/bin/notify-on-duplicate-biosample-change
+++ b/bin/notify-on-duplicate-biosample-change
@@ -18,7 +18,7 @@ trap "rm -f '$dst_local' '$diff'" EXIT
 # if the file is not already present, just exit
 "$bin"/s3-object-exists "$dst" || exit 0
 
-aws s3 cp --no-progress "$dst" - | gunzip -cfq > "$dst_local"
+"$bin"/download-from-s3 "$dst" "$dst_local"
 
 comm -13 \
     <(sort "$dst_local") \

--- a/bin/notify-on-flagged-metadata-change
+++ b/bin/notify-on-flagged-metadata-change
@@ -18,7 +18,7 @@ trap "rm -f '$dst_local' '$diff'" EXIT
 # if the file is not already present, just exit
 "$bin"/s3-object-exists "$dst" || exit 0
 
-aws s3 cp --no-progress "$dst" - | gunzip -cfq > "$dst_local"
+"$bin"/download-from-s3 "$dst" "$dst_local"
 
 comm -13 \
     <(sort "$dst_local") \

--- a/bin/notify-on-metadata-change
+++ b/bin/notify-on-metadata-change
@@ -20,7 +20,7 @@ trap "rm -f '$dst_local' '$diff' '$additions'" EXIT
 # if the file is not already present, just exit
 "$bin"/s3-object-exists "$dst" || exit 0
 
-aws s3 cp --no-progress "$dst" - | gunzip -cfq > "$dst_local"
+"$bin"/download-from-s3 "$dst" "$dst_local"
 
 csv-diff \
     "$dst_local" \


### PR DESCRIPTION
### Description of proposed changes    

This replaces `aws cp`  download commands with `./bin/download-from-s3` where possible and also makes download script less verbose.

### Related issue(s)  

:no_good: 

### Testing

:boom: 
