### PR TITLE
Require aiobotocore<2 when installing nextstrain-cli

### DIFF
--- a/bin/setup-github-workflow
+++ b/bin/setup-github-workflow
@@ -9,5 +9,5 @@ python3 -m pip install --upgrade pip setuptools wheel
 echo "::endgroup::"
 
 echo "::group::Installing nextstrain-cli"
-python3 -m pip install 'nextstrain-cli >=3.0.1'
+python3 -m pip install 'nextstrain-cli >=3.0.1' 'aiobotocore<2'
 echo "::endgroup::"


### PR DESCRIPTION
Works around an upstream dependency issue where Pip ends up installing
the latest aiobotocore with an older s3fs, which aren't compatible.¹
I'm not sure if the fault lies with Pip's resolution of dependencies or
with the dependency declarations in aiobotocore/s3fs/fsspec/boto3/…
themselves.

Jover's diagnosis of the issue, which I've confirmed and reproduced
locally², is:

> For some reason multiple versions of s3fs were downloaded in the setup
> step. It finally installs version 2021.7.0 of s3fs, which does not have
> the fix to support aiobotocore >= 1.4.0.

Hopefully this workaround can be temporary and removed soon: either
upstream will sort things out or we'll bake the workaround into a new
nextstrain-cli release (since currently all new installs of
nextstrain-cli will not work).

¹ Throws an «AttributeError: module 'aiobotocore' has no attribute
  'AioSession'» during upload of the workdir to S3, causing cascading
  failures.

² mkdir /tmp/venv
  python3 -m venv /tmp/venv
  source /tmp/venv/bin/activate
  pip install --upgrade pip setuptools wheel
  pip install nextstrain-cli
  nextstrain build --aws-batch zika-tutorial
