### PR TITLE
docs: update readme instructions regarding nextclade full run

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,27 @@ If needed, the runs can be also launched from a local machine, by one of these s
 
 The resulting nextclade.tsv.gz should be then available in the subdirectory nextclade-full-run in the usual S3 location for the particular database:
 
-```txt
-s3://nextstrain-ncov-private/nextclade-full-run/nextclade.tsv.gz
-s3://nextstrain-data/files/ncov/open/nextclade-full-run/nextclade.tsv.gz
+```bash
+aws s3 ls s3://nextstrain-data/files/ncov/open/nextclade-full-run
+aws s3 ls s3://nextstrain-ncov-private/nextclade-full-run
 ```
 
-The nextclade.tsv.gz should be manually inspected for scientific correctness, comparing to the old one, if necessary. If all went well, after agreeing with ingest team, the nextclade.tsv.gz should then be copied to the location where the daily ingest can find it, overwriting the old one. These locations are:
+Copy the output files to your local machine by using the path returned by `aws s3 ls` or using tab completion from `aws s3 cp s3://nextstrain-data/files/ncov/open/nextclade-full-run`:
+
+```bash
+# enter aws s3 cp s3://nextstrain-data/files/ncov/open/nextclade-full-run and use tab completion for exact date
+aws s3 cp s3://nextstrain-data/files/ncov/open/nextclade-full-run-2021-11-19--02-34-23--UTC/nextclade.tsv.gz open.tsv.gz
+aws s3 cp s3://nextstrain-ncov-private/nextclade-full-run-2021-11-18--23-37-14--UTC/nextclade.tsv.gz private.tsv.gz
+```
+
+The nextclade.tsv.gz should be manually inspected for scientific correctness, comparing to the old one, if necessary. Check that clades aren't broken by running for example:
+
+```bash
+gzcat open.tsv.gz | tsv-summarize -H --group-by clade --count | sort
+gzcat private.tsv.gz | tsv-summarize -H --group-by clade --count | sort
+```
+
+If all went well, after agreeing with ingest team, the nextclade.tsv.gz should then be copied to the location where the daily ingest can find it, overwriting the old one. These locations are:
 
 ```txt
 s3://nextstrain-ncov-private/nextclade.tsv.gz
@@ -106,6 +121,13 @@ s3://nextstrain-data/files/ncov/open/nextclade.tsv.gz
 ```
 
 (just omit the subdirectory nextclade-full-run)
+
+You can use the following commands:
+
+```bash
+aws s3 cp private.tsv.gz s3://nextstrain-ncov-private/nextclade.tsv.gz
+aws s3 cp open.tsv.gz s3://nextstrain-data/ncov/open/nextclade.tsv.gz
+```
 
 For detailed explanation see PR [#218](https://github.com/nextstrain/ncov-ingest/pull/218).
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ If needed, the runs can be also launched from a local machine, by one of these s
 ./bin/run-nextclade-full-docker    # Schedules an AWS Batch Job and runs there
 ```
 
-In case of AWS Batch option, the results of the computation, the new `nextclade.tsv` will be uploaded to S3 into a subdirectory in the directory which is the usual location of this file for the database. The subdirectory name will contain a date, so that there is no confusion about versions. The Slack announcement will contain the full path. These files then need to be manually inspected for correctness and scientific soundness and id all good, copied to the usual location where the daily ingest can find them. From that point the clades are considered fresh.
+With the AWS Batch option, the results of the computation – the new `nextclade.tsv` – will be uploaded to S3 into a subdirectory of the directory which is the usual location of this file for the database. The subdirectory name will contain a date, so that there is no confusion about versions. The Slack announcement will contain the full path. These files then need to be manually inspected for correctness and scientific soundness and if all good, copied to the usual location where the daily ingest can find them. From that point the clades are considered fresh.
 
 For detailed explanation see PR [#218](https://github.com/nextstrain/ncov-ingest/pull/218).
 


### PR DESCRIPTION
### Description of proposed changes    

This documents the new scripts and GitHub Actions workflows for full Nextclade runs. Section is titled "Refreshing clades: Nextclade full run".

More convenient to read here:
https://github.com/nextstrain/ncov-ingest/tree/docs/nextclade-full-run#refreshing-clades-nextclade-full-run


### Related issue(s)  
<!-- Start typing the name of a related issue and GitHub will auto-suggest the issue number for you.  -->
Related to #218 #221

### Testing

Careful read, grammar checks.
