### PR TITLE
feat: allow for custom Nextclade binary and dataset for full runs

### DIFF
--- a/bin/run-nextclade-full
+++ b/bin/run-nextclade-full
@@ -123,9 +123,13 @@ main() {
 
   ./bin/notify-on-job-start "🦬 'Nextclade full run: ${DATABASE}'" "The job involves ${N_PROCESSORS} CPUs and will run ${N_CONCURRENT_JOBS_MAX} Nextclade instances in parallel, each processing ${BATCH_SIZE} sequences at a time. The results will be uploaded to \`${S3_DST}\`. Someone needs to inspect these results and then copy them over to the S3 directory where the next scheduled ingest can find them, replacing the old files. For more details, see PR #218 in ncov-ingest."
 
-  echo "[ INFO] ${0}:${LINENO}: Downloading latest Nextclade version from '${NEXTCLADE_BIN_URL}' to '${NEXTCLADE_BIN}'"
-  curl -fsSL ${NEXTCLADE_BIN_URL} -o "${NEXTCLADE_BIN}"
-  chmod +x "${NEXTCLADE_BIN}"
+  if [ ! -f "${NEXTCLADE_BIN}" ]; then
+    echo "[ INFO] ${0}:${LINENO}: Downloading latest Nextclade version from '${NEXTCLADE_BIN_URL}' to '${NEXTCLADE_BIN}'"
+    curl -fsSL ${NEXTCLADE_BIN_URL} -o "${NEXTCLADE_BIN}"
+    chmod +x "${NEXTCLADE_BIN}"
+  else
+    echo "[ INFO] ${0}:${LINENO}: ⚠️Using existing Nextclade binary '${NEXTCLADE_BIN}' from the working directory. Skipping downloading the latest version. If this was not intended, cancel this run, remove '${NEXTCLADE_BIN}' from your working directory and rerun."
+  fi
 
   echo "[ INFO] ${0}:${LINENO}: installing csvkit"
   if ! command -v "csvstack"; then
@@ -170,8 +174,12 @@ main() {
   NEXTCLADE_VERSION="$(./${NEXTCLADE_BIN} --version)"
   echo "[ INFO] ${0}:${LINENO}: Nextclade version: ${NEXTCLADE_VERSION}"
 
-  echo "[ INFO] ${0}:${LINENO}: Downloading Nextclade dataset \"sars-cov-2\""
-  ./${NEXTCLADE_BIN} dataset get --name="sars-cov-2" --output-dir="${TMP_DIR_NEXTCLADE_DATASET}" --verbose
+  if [ ! -f "${TMP_DIR_NEXTCLADE_DATASET}/tree.json" ] || [ ! -f "${TMP_DIR_NEXTCLADE_DATASET}/reference.fasta" ]; then
+    echo "[ INFO] ${0}:${LINENO}: Downloading Nextclade dataset \"sars-cov-2\" into '${TMP_DIR_NEXTCLADE_DATASET}'"
+    ./${NEXTCLADE_BIN} dataset get --name="sars-cov-2" --output-dir="${TMP_DIR_NEXTCLADE_DATASET}" --verbose
+  else
+    echo "[ INFO] ${0}:${LINENO}: ⚠️Using existing Nextclade dataset '${TMP_DIR_NEXTCLADE_DATASET}' from the working directory. Skipping downloading the latest dataset. If this was not intended, cancel this run, remove '${TMP_DIR_NEXTCLADE_DATASET}' from your working directory and rerun."
+  fi
 
   # Run batches in parallel
   echo "[ INFO] ${0}:${LINENO}: Nextclade is allowed to use ${N_PROCESSORS} threads. Each invocation of Nextclade is allowed to use ${N_NEXTCLADE_THREADS} threads."


### PR DESCRIPTION
### Description of proposed changes    

This adds 2 checks in the beginning of "Nextclade full run" script:

1. Whether `nextclade` binary is present in the root of the project.

   By default the latest release of Nextclade CLI is downloaded. But if the `nextclade` file is detected, then the download is skipped and this file is used instead.

2. Whether `tmp/dataset/` directory contains `tree.json` and `reference.fasta` files.

   By default the latest dataset is downloaded. Hoverver, if a dataset is detected in the `tmp/dataset/`, the download is skipped and this dataset is used instead.

This allows to customize manual Nextclade full runs, when a combination of a specific Nextclade version (perhaps unreleased) and of a specific dataset is needed.

This customization is intended for cases when putting Nextclade binary and dataset into a local working directory of ncov-ingest and running one of the `./run-nextclade-full*` scripts manually. It would be nice to somehow simplify and automate this process, but for now I don't have good ideas for this. In particular, because the binary and datasets are different depending on a particular use-case for these custom runs.


### Related issue(s)  

Extends: #218 

### Testing

I am running these 2 jobs to check this:

```
nextstrain build --aws-batch --no-download --attach 4b6bbd1d-f8ff-4f31-8f53-157e4947b046 .
nextstrain build --aws-batch --no-download --attach 191a049c-5bae-4c5f-86d2-0536a625c84a .
```
These particular jobs are using the custom unreleased Nextclade version from https://github.com/nextstrain/nextclade/pull/610
