### PR TITLE
Update gisaid ingest schedule to 1pm CET every day

### DIFF
--- a/.github/workflows/fetch-and-ingest-genbank-master.yml
+++ b/.github/workflows/fetch-and-ingest-genbank-master.yml
@@ -3,8 +3,9 @@ name: GenBank fetch and ingest
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    # "At 03:00 (05:00 CET, 20:00 PDT the previous day) every weekday."
-    - cron:  '0 3 * * MON-FRI'
+    # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
+    # https://crontab.guru/
+    - cron:  '7 13 * * *'
 
   # Manually triggered using `./bin/trigger genbank/fetch-and-ingest` (or `fetch-and-ingest`, which
   # includes GISAID)

--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -3,6 +3,8 @@ name: GISAID fetch and ingest
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
+    # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
+    # https://crontab.guru/
     - cron:  '7 13 * * *'
 
   # Manually triggered using `./bin/trigger gisaid/fetch-and-ingest`

--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -3,7 +3,6 @@ name: GISAID fetch and ingest
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    # "At 03:00 (05:00 CET) on every day-of-week from Monday through Friday."
     - cron:  '7 13 * * *'
 
   # Manually triggered using `./bin/trigger gisaid/fetch-and-ingest`

--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # "At 03:00 (05:00 CET) on every day-of-week from Monday through Friday."
-    - cron:  '1 2 * * MON-SUN'
+    - cron:  '7 13 * * *'
 
   # Manually triggered using `./bin/trigger gisaid/fetch-and-ingest`
   repository_dispatch:

--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # "At 03:00 (05:00 CET) on every day-of-week from Monday through Friday."
-    - cron:  '0 3 * * MON-FRI'
+    - cron:  '1 2 * * MON-SUN'
 
   # Manually triggered using `./bin/trigger gisaid/fetch-and-ingest`
   repository_dispatch:


### PR DESCRIPTION
Long term: 
- Change the start of pull-and-ingest time from 3AM UTC to 12PM UTC (should be 1pm CET), so that we catch the latest download update from GISAID (should be around 11am CET) - with room for delays on their end

Short term:
- Run pull-and-ingest every day (not just M-F) for the short-term to pull in new Omicron sequences ASAP


Not tested!