### PR TITLE
Move ingest trigger up 1 hr to 1pm CET

### DIFF
--- a/.github/workflows/fetch-and-ingest-genbank-master.yml
+++ b/.github/workflows/fetch-and-ingest-genbank-master.yml
@@ -3,9 +3,11 @@ name: GenBank fetch and ingest
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
+    # Note times are in UTC, which is 1 or 2 hours behind CET depending on daylight savings
+    # Currently triggers at 12 UTC which is 13 CET (as of Nov 21)
     # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
     # https://crontab.guru/
-    - cron:  '7 13 * * *'
+    - cron:  '7 12 * * *'
 
   # Manually triggered using `./bin/trigger genbank/fetch-and-ingest` (or `fetch-and-ingest`, which
   # includes GISAID)

--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -3,9 +3,11 @@ name: GISAID fetch and ingest
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
+    # Note times are in UTC, which is 1 or 2 hours behind CET depending on daylight savings
+    # Currently triggers at 12 UTC which is 13 CET (as of Nov 21)
     # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
     # https://crontab.guru/
-    - cron:  '7 13 * * *'
+    - cron:  '7 12 * * *'
 
   # Manually triggered using `./bin/trigger gisaid/fetch-and-ingest`
   repository_dispatch:


### PR DESCRIPTION
Follow up to #234 - this just adjusts the timing to be 12 UTC which is currently 13 CET. (Previously it was 13 UTC which is 14 CET). Also added a comment that this is UTC and the relationship to CET, to help make this easier in future! (Though you still have to know if it's daylight savings or not, to know if it's 1 or 2 hours ahead of UTC....)

This is for both GISAID & Genbank