### PR TITLE
Shellcheck for workflows

### DIFF
--- a/.github/workflows/update-image.yml
+++ b/.github/workflows/update-image.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Describe git revision for image build arg
         run: |
-          echo "GIT_REVISION=$(git describe --always --long --dirty)" | tee -a $GITHUB_ENV
+          echo "GIT_REVISION=$(git describe --always --long --dirty)" | tee -a "$GITHUB_ENV"
 
       - uses: docker/build-push-action@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ Thumbs.db
 
 node_modules/
 tmp/
+
+# Transient files for ./bin/shellcheck
+/.github/workflows/_shellcheck/

--- a/bin/extract-shell-from-gh-workflow
+++ b/bin/extract-shell-from-gh-workflow
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+usage: extract-gh-actions-shell <output-dir> <workflow-file> [<workflow-file> […]]
+
+Writes the shell snippets in a GitHub Actions workflow file to a set of
+separate files.  There's one file for each workflow × job × step (with a "run"
+block).
+"""
+from pathlib import Path
+import re
+import sys
+import yaml
+
+
+__usage__ = __doc__
+
+
+def main(output_dir, *workflow_files):
+    output_dir = Path(output_dir)
+
+    if not output_dir.is_dir():
+        return fatal(f"output path {output_dir!r} is not a directory or does not exist")
+
+    if not workflow_files:
+        return fatal(f"no workflow files given")
+
+    for workflow_file in (Path(w) for w in workflow_files):
+        with workflow_file.open("r", encoding = "utf-8") as fh:
+            workflow = yaml.safe_load(fh)
+
+        workflow_output_dir = output_dir / workflow_file.name
+        workflow_output_dir.mkdir()
+
+        for job_name, job in workflow.get("jobs", {}).items():
+            job_output_dir = workflow_output_dir / f"job-{fssafe(job_name)}"
+            job_output_dir.mkdir()
+
+            for step_idx, step in enumerate(job.get("steps", []), 1):
+                step_name = step.get("name", step_idx)
+                run_shell = step.get("run")
+
+                if run_shell is None:
+                    continue
+
+                step_output_file = job_output_dir / f"step-{fssafe(step_name)}"
+
+                with step_output_file.open("w", encoding = "utf-8") as fh:
+                    print("#!/bin/bash", file = fh)
+                    print(run_shell, file = fh)
+
+                print(step_output_file)
+
+
+def fssafe(name):
+    return re.sub(r'[^a-zA-Z0-9_-]+', "-", name)
+
+
+def fatal(error):
+    print(error, file = sys.stderr)
+    print(__usage__)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(*sys.argv[1:]))

--- a/bin/shellcheck
+++ b/bin/shellcheck
@@ -1,3 +1,31 @@
 #!/bin/bash
 set -euo pipefail
-git grep -lz '^#!/bin/bash' | xargs -0 shellcheck "$@"
+
+bin="$(dirname "$0")"
+base="$(realpath --relative-to . "$bin/..")"
+
+main() {
+    find-files | xargs -0 shellcheck "$@"
+}
+
+find-files() {
+    shell-files
+    workflow-shell
+}
+
+shell-files() {
+    git grep -lz '^#!/bin/bash'
+}
+
+workflow-shell() {
+    tmpdir="$base/.github/workflows/_shellcheck/"
+    rm -rf "$tmpdir"
+    mkdir "$tmpdir"
+    trap "rm -rf ${tmpdir@Q}" EXIT
+
+    git ls-files -z :/.github/workflows/'*'.y{a,}ml \
+        | xargs -0 "$bin"/extract-shell-from-gh-workflow "$tmpdir" \
+        | perl -pe 's/\n/\0/'
+}
+
+main "$@"


### PR DESCRIPTION
Workflow steps run bits of shell, and it's useful for Shellcheck to spot
potential issues with them.