### PR TITLE
trigger_preprocessing_pipeline: import requests

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -331,6 +331,7 @@ rule trigger_preprocessing_pipeline:
         dispatch_type = f"preprocess-{database}",
         token = os.environ.get("PAT_GITHUB_DISPATCH", "")
     run:
+        import requests
         headers = {
                 'Content-type': 'application/json',
                 'authorization': f"Bearer {params.token}",


### PR DESCRIPTION
We forgot to import `requests` when we converted to Snakemake.
Importing within `trigger_preprocessing_pipeline` since it is the
only rule that uses `requests`.