### PR TITLE
GISAID: Decompress after download

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Relies on data from https://simplemaps.com/data/us-cities.
 ## Running locally
 If you're using Pipenv (see below), then run commands from `./bin/…` inside a `pipenv shell` or wrapped with `pipenv run ./bin/…`.
 
-1. Run `./bin/fetch-from-gisaid > data/gisaid.ndjson`
+1. Run `./bin/fetch-from-gisaid | bunzip2 > data/gisaid.ndjson`
 2. Run `./bin/transform-gisaid data/gisaid.ndjson`
 3. Look at `data/gisaid/sequences.fasta` and `data/gisaid/metadata.tsv`
 

--- a/Snakefile
+++ b/Snakefile
@@ -54,7 +54,7 @@ if config.get("fetch_from_database", False):
         message:
             """Fetching data using the database API"""
         output:
-            ndjson = temp(f"data/{database}.ndjson")
+            ndjson = temp(f"data/{database}.ndjson" + (".bz2" if database == "gisaid" else ""))
         run:
             run_shell_command_n_times(
                 msg = f"Fetching from {database}",
@@ -74,6 +74,13 @@ else:
             ./bin/download-from-s3 {params.file_on_s3_dst} {output.ndjson} ||  \
             ./bin/download-from-s3 {params.file_on_s3_src} {output.ndjson}
         """
+
+
+rule bunzip2:
+    message: "Decompressing {input}"
+    input: "{stem}.bz2"
+    output: "{stem}"
+    shell: "bunzip2 {input:q}"
 
 
 rule notify_on_database_change:

--- a/Snakefile
+++ b/Snakefile
@@ -51,7 +51,6 @@ rule download_main_ndjson:
     message:
         """Fetching data using the database API"""
     params:
-        s3_src_bucket = config["s3_src"],
         file_on_s3_dst= f"{config['s3_dst']}/{database}.ndjson.xz",
         file_on_s3_src= f"{config['s3_src']}/{database}.ndjson.xz"
     output:
@@ -67,7 +66,7 @@ rule download_main_ndjson:
             cleanup_failed_cmd = f"rm {output.ndjson}"
             run_shell_command_n_times(cmd, msg, cleanup_failed_cmd)
             if send_notifications:
-                shell("./bin/notify-on-record-change {output.ndjson} {params.s3_src_bucket}/gisaid.ndjson.xz {database}")
+                shell("./bin/notify-on-record-change {output.ndjson} {params.file_on_s3_src} {database}")
         else:
             shell("""
                 ./bin/download-from-s3 {params.file_on_s3_dst} {output.ndjson} ||  \

--- a/bin/fetch-from-gisaid
+++ b/bin/fetch-from-gisaid
@@ -6,5 +6,4 @@ set -euo pipefail
 
 curl "$GISAID_API_ENDPOINT" \
     --user "$GISAID_USERNAME_AND_PASSWORD" \
-    --fail --silent --show-error --location-trusted --http1.1 \
-    | bunzip2
+    --fail --silent --show-error --location-trusted --http1.1


### PR DESCRIPTION
This PR drafts a change we discussed [in Slack](https://bedfordlab.slack.com/archives/CTZKJC7PZ/p1638495448287000) and summarized in #242. Drafted now so it's ready in case we end up needing it sooner than later. If we never need it, ok to trash this PR.

---

Decompress gisaid.ndjson.bz2 after download instead of during

Streaming decompression during the network fetch leads to decreased network transfer rates[^1] and thus a longer network connection lifetime. As we sometimes see transient network disruptions that cause the transfer to fail, my hypothesis is that reducing connection lifetime by decompressing after download will meaningfully reduce our exposure to transient disruptions.

This may come at the cost of potentially increasing overall runtime by some unknown amount, but we could try to address that other ways such as switching to xz (with GISAID's cooperation) for faster decompression and/or performing decompression concurrently with downloading but using a disk spool in between (assuming disk io isn't a bottleneck).

[^1]: About 75% slower in a single test case I ran on my laptop over the Hutch's wired network.

---

[Update 10 Dec 2021] The concurrent-decompression-with-disk-spool approach could be implemented using [a program like this, dubbed bunzip2-tailf](https://gist.github.com/tsibley/aa16902ae53cd35196d280cf8d22d330) to do the decompression. As it'd be hard to reliably coordinate the concurrent processes (curl and bunzip2-tailf) with separate Snakemake rules/jobs, we'd want to use shell job handling instead. For example, updating `fetch-from-gisaid` to read something like:

```bash
# Download compressed file direct to disk to avoid slowing down the network transfer waiting on decompression.
curl … > gisaid.ndjson.bz2 &

# Decompress from disk to stdout on the fly; will wait for more data to appear in the file if it hits EOF (up to a time limit).
bunzip2-tailf < gisaid.ndjson.bz2 &

# Wait for both background jobs above to complete.
wait
```