### PR TITLE
feat: use parallel version of bzip2 to decompress gisaid snapshot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ FROM nextstrain/base:branch-python-base
 RUN apt-get update && apt-get install -y --no-install-recommends \
         python3-netifaces \
         time\
-        xz-utils
+        xz-utils \
+        lbzip2
 
 # Install Python deps
 RUN python3 -m pip install pipenv

--- a/bin/fetch-from-gisaid
+++ b/bin/fetch-from-gisaid
@@ -7,4 +7,4 @@ set -euo pipefail
 curl "$GISAID_API_ENDPOINT" \
     --user "$GISAID_USERNAME_AND_PASSWORD" \
     --fail --silent --show-error --location-trusted --http1.1 \
-    | bunzip2
+    | lbzip2 -d

--- a/bin/fetch-from-gisaid
+++ b/bin/fetch-from-gisaid
@@ -4,7 +4,7 @@ set -euo pipefail
 : "${GISAID_API_ENDPOINT:?The GISAID_API_ENDPOINT environment variable is required.}"
 : "${GISAID_USERNAME_AND_PASSWORD:?The GISAID_USERNAME_AND_PASSWORD environment variable is required.}"
 
-apt-get update && apt-get install lbzip2
+apt-get update --allow-releaseinfo-change && apt-get install lbzip2
 
 curl "$GISAID_API_ENDPOINT" \
     --user "$GISAID_USERNAME_AND_PASSWORD" \

--- a/bin/fetch-from-gisaid
+++ b/bin/fetch-from-gisaid
@@ -4,6 +4,8 @@ set -euo pipefail
 : "${GISAID_API_ENDPOINT:?The GISAID_API_ENDPOINT environment variable is required.}"
 : "${GISAID_USERNAME_AND_PASSWORD:?The GISAID_USERNAME_AND_PASSWORD environment variable is required.}"
 
+apt-get update && apt-get install lbzip2
+
 curl "$GISAID_API_ENDPOINT" \
     --user "$GISAID_USERNAME_AND_PASSWORD" \
     --fail --silent --show-error --location-trusted --http1.1 \


### PR DESCRIPTION
### Description of proposed changes    
I don't know if it's any faster, but why not.

Locally, it does use multiple threads, but not too many. We might be bound by download speed rather then decompression though.

### Related issue(s)  
<!-- Start typing the name of a related issue and GitHub will auto-suggest the issue number for you.  -->
Fixes #  
Related to https://github.com/nextstrain/ncov-ingest/issues/242

### Testing

This is a drop-in replacement. The results are correct in my local testing.
