### PR TITLE
ingest master workflows: remove push triggers

### DIFF
--- a/.github/workflows/ingest-genbank-master.yml
+++ b/.github/workflows/ingest-genbank-master.yml
@@ -1,15 +1,6 @@
 name: GenBank ingest
 
 on:
-  push:
-    branches:
-      - master
-    tags-ignore:
-      - '**'
-    paths:
-      - source-data/genbank_annotations.tsv
-      - source-data/gisaid_geoLocationRules.tsv
-
   # Manually triggered using `./bin/trigger genbank/ingest` (or `ingest`, which
   # includes GISAID)
   repository_dispatch:

--- a/.github/workflows/ingest-gisaid-master.yml
+++ b/.github/workflows/ingest-gisaid-master.yml
@@ -1,15 +1,6 @@
 name: GISAID ingest
 
 on:
-  push:
-    branches:
-      - master
-    tags-ignore:
-      - '**'
-    paths:
-      - source-data/gisaid_annotations.tsv
-      - source-data/gisaid_geoLocationRules.tsv
-
   # Manually triggered using `./bin/trigger gisaid/ingest` (or `ingest`, which
   # includes GenBank)
   repository_dispatch:


### PR DESCRIPTION
Manual annotations are now decoupled from our automated workflows so
they no longer need automatically trigger `ingest` runs.
