### PR TITLE
Spool GISAID download to disk while still decompressing concurrently

### DIFF
--- a/bin/fetch-from-gisaid
+++ b/bin/fetch-from-gisaid
@@ -4,7 +4,34 @@ set -euo pipefail
 : "${GISAID_API_ENDPOINT:?The GISAID_API_ENDPOINT environment variable is required.}"
 : "${GISAID_USERNAME_AND_PASSWORD:?The GISAID_USERNAME_AND_PASSWORD environment variable is required.}"
 
+bin="$(dirname "$0")"
+spool="$(mktemp -t gisaid-XXXXXX.ndjson.bz2)"
+semaphore="$(mktemp)"
+
+# Remove temporary files on exit, regardless of success or failure
+trap "rm -f ${spool@Q} >/dev/null" EXIT
+
+# Download compressed file direct to disk to avoid slowing down the network
+# transfer waiting on decompression.
 curl "$GISAID_API_ENDPOINT" \
     --user "$GISAID_USERNAME_AND_PASSWORD" \
     --fail --silent --show-error --location-trusted --http1.1 \
-    | bunzip2
+    > "$spool" \
+&
+
+# Decompress from disk to stdout on the fly; will wait for more data to appear
+# in the file if it hits EOF.
+"$bin"/halting-tailf "$semaphore" < "$spool" | bunzip2 &
+
+# After the download completes, signal halting-tailf via removal of the
+# semaphore file that it should halt after the next EOF instead of waiting for
+# more data.
+#
+# This wouldn't be necessary if bunzip2 could be configured to stop (and thus
+# break the pipe from tail) when it finds the end of stream marker in the
+# compressed data instead of waiting for another compression stream.
+wait %curl
+rm -f "$semaphore"
+
+# Wait for everything to wrap up.
+wait

--- a/bin/halting-tailf
+++ b/bin/halting-tailf
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""
+usage: ... | halting-tailf SEMAPHORE-FILE | ...
+
+Reads stdin, retrying on EOF (e.g. like tail -f) as long as SEMAPHORE-FILE
+still exists, and writes to stdout.  When SEMAPHORE-FILE is removed, exits the
+next time it hits EOF on stdin.
+"""
+import sys
+from pathlib import Path
+from time import sleep
+
+
+def main(semaphore_file):
+    semaphore = Path(semaphore_file)
+
+    def halt_after_semaphore_removed():
+        if not semaphore.exists():
+            return True
+        else:
+            sleep(1)
+            return False
+
+    try:
+        for chunk in tailf(sys.stdin.buffer, halt_after_semaphore_removed):
+            sys.stdout.buffer.write(chunk)
+    except Halted:
+        pass
+
+
+def tailf(stream, halt = lambda: False):
+    while True:
+        try:
+            yield next(stream)
+        except StopIteration:
+            if halt():
+                raise Halted()
+            else:
+                continue
+
+
+class Halted(Exception):
+    pass
+
+
+if __name__ == "__main__":
+    main(*sys.argv[1:])


### PR DESCRIPTION
Streaming decompression pipelined with the network fetch leads to
decreased network transfer rates¹ and thus a longer network connection
lifetime.  As we sometimes see transient network disruptions that cause
the transfer to fail, my hypothesis is that reducing connection lifetime
by decompressing from a disk spool instead will meaningfully reduce our
exposure to transient disruptions.

Caveat emptor: I haven't benchmarked this, and it's possible that
pushing all data through Python (halting-tailf) will add more runtime
overhead than is saved.

For another speed boost, try replacing bunzip2 with lbunzip2 in a future
change.

h/t @ivan-aksamentov for the suggestion to decouple the spooling from
the decompression and do it in two separate processes instead of one
(as I did in my proof-of-concept bunzip2-tailf).

¹ About 75% slower in a single test case I ran on my laptop over the
  Hutch's wired network.

----

Alternative to #245.