### PR TITLE
chore: cleanup docker container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
-/data
+*
+!Pipfile
+!Pipfile.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ FROM nextstrain/base
 # Install Python package for which Python 3.7 wheels do not yet exist on PyPI.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     aria2 \
+    build-essential \
     lbzip2 \
     pigz \
     pixz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,33 +23,22 @@
 # ncov-ingest themselves.  This means the image only needs to be updated when
 # dependencies change, not when any pipeline change is made, and thus image
 # updates can be far less frequent.
-
-# XXX TODO: This can be updated to :latest eventually when the python-base
-# version becomes the new default, if this ncov-ingest image itself is still
-# relevant at that time.
-#   -trs, 19 Jan 2020
-FROM nextstrain/base:branch-python-base
+FROM nextstrain/base
 
 # Install Python package for which Python 3.7 wheels do not yet exist on PyPI.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        python3-netifaces \
-        time\
-        xz-utils
+    aria2 \
+    lbzip2 \
+    pigz \
+    pixz \
+    python3-netifaces \
+    time \
+    xz-utils \
 
 # Install Python deps
 RUN python3 -m pip install pipenv
 COPY Pipfile Pipfile.lock /nextstrain/ncov-ingest/
 RUN PIPENV_PIPFILE=/nextstrain/ncov-ingest/Pipfile pipenv sync --system
-
-# Install Nextclade
-RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-Linux-x86_64 \
-         -o /usr/local/bin/nextclade \
- && chmod a+rx /usr/local/bin/nextclade
-
-# Install Nextclade C++
-RUN curl -fsSL https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-Linux-x86_64 \
-         -o /usr/local/bin/nextclade \
- && chmod a+rx /usr/local/bin/nextclade
 
 # Put any bin/ dir in the cwd on the path for more convenient invocation of
 # ncov-ingest's programs.

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pixz \
     python3-netifaces \
     time \
-    xz-utils \
+    xz-utils
 
 # Install Python deps
 RUN python3 -m pip install pipenv


### PR DESCRIPTION
This:

 - Removes duplicated nextclade downloads. Nobody knows what version they are and when they are updated. Latest version of nextclade is already downloaded in the `./bin/run-nextclade` and `./bin/run-nextclade-fill` scripts. We want it to always be cutting edge. Nextclade releases are frequent. We may consider bringing it back into the image later if we setup automated rebuild of the image on Nextclade release. However I also often play with different custom versions of Nextclade in full runs and having other versions may cause mistakes. Mixed feelings here.

 - Adds various tools we might want to play with on branches:
    - aria2 - for downloading on multiple connections (for [#258](https://github.com/nextstrain/ncov-ingest/pull/258))
    - lbzip2  - for parallel unbzipping  (for [#247](https://github.com/nextstrain/ncov-ingest/pull/247) and [#258](https://github.com/nextstrain/ncov-ingest/pull/258))
    - pigz - for parallel gz/ungz
    - pixz - for parallel xz/unxz

 - Adds `build-essential` package. Pipenv insists on building the `netifaces` package from scratch now and if there's no GCC, the following error is produced: [error.txt](https://github.com/nextstrain/ncov-ingest/files/7735449/error.txt). I am not sure why `netifaces` are needed and whether there's a better solution.

 - Changes base image to `nextstrain/base` as suggested in https://github.com/nextstrain/ncov-ingest/pull/253. We don't use much out of it, so I am not super convinced it's needed, but not a big deal. Hopefully it will update the apt cache, so I can install deps again :) 

 - Extends dockerignore to everything but the 2 files we need. There is about 100 megs of data in the repo that gets transferred currently into the build context. If this is accepted, then later on, if you need to COPY or ADD something, don't forget to whitelist that thing in the dockerignore (by adding `!thing` line).

Current inconvenience is that for any changes in deps on branches (e.g. if I want to play with aria2c and lbzip2) we need to change the container on master and/or publish an image and change the tag in the GitHub Action on master. Which both disrupt production. We might consider installing deps dynamically on AWS batch instead. I tired and it failed because currently the debian repo cache in the image is too old. Or maybe there's a better way to play with new tools right now? In any case, mixing prod and dev as it is now seems weird and unproductive, we might think about a dedicated, simpler dev flow.


Related to
 - https://github.com/nextstrain/ncov-ingest/pull/247
 - https://github.com/nextstrain/ncov-ingest/pull/258
