### PR TITLE
perf: split curl and bunzip2 when downloading from gisaid

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -59,7 +59,7 @@ rule download_main_ndjson:
         if config.get("fetch_from_database", False):
             if database=="gisaid":
                 msg = "Fetching from GISAID API"
-                cmd = f"./bin/fetch-from-gisaid > {output.ndjson}"
+                cmd = f"./bin/fetch-from-gisaid {output.ndjson}"
             else:
                 msg = "Fetching from GenBank API"
                 cmd = f"./bin/fetch-from-genbank > {output.ndjson}"

--- a/bin/fetch-from-gisaid
+++ b/bin/fetch-from-gisaid
@@ -4,7 +4,15 @@ set -euo pipefail
 : "${GISAID_API_ENDPOINT:?The GISAID_API_ENDPOINT environment variable is required.}"
 : "${GISAID_USERNAME_AND_PASSWORD:?The GISAID_USERNAME_AND_PASSWORD environment variable is required.}"
 
+: "${1:?Output file path is required.}"
+
+GISAID_OUTPUT="${1}"
+GISAID_SNAPSHOT="${GISAID_OUTPUT}.bz2"
+
 curl "$GISAID_API_ENDPOINT" \
     --user "$GISAID_USERNAME_AND_PASSWORD" \
-    --fail --silent --show-error --location-trusted --http1.1 \
-    | bunzip2
+    --fail --show-error --location-trusted --http1.1 \
+    --progress-bar \
+    --output "${GISAID_SNAPSHOT}"
+
+bunzip2 -cd "${GISAID_SNAPSHOT}" > "${GISAID_OUTPUT}"


### PR DESCRIPTION
We are trying to shorten the connection time to GISAID while downloading the snapshot, and potentially speed things up in general. Best explained in https://github.com/nextstrain/ncov-ingest/pull/256

This is the simplest working solution currently. But probably also the slowest.

Solutions to compare:

 - [Spool GISAID download to disk while still decompressing concurrently #256](https://github.com/nextstrain/ncov-ingest/pull/256)
 - [perf: split curl and bunzip2 when downloading from gisaid #259](https://github.com/nextstrain/ncov-ingest/pull/259)  <-- you are here
 - [feat: use parallel version of bzip2 to decompress gisaid snapshot #247](https://github.com/nextstrain/ncov-ingest/pull/247)
 - [perf: use aria2c and lbzip2 for faster* downloads #258](https://github.com/nextstrain/ncov-ingest/pull/258)


