### PR TITLE
Build and push nextstrain/ncov-ingest:branch-* images

### DIFF
--- a/.github/workflows/update-image.yml
+++ b/.github/workflows/update-image.yml
@@ -2,8 +2,6 @@ name: Update image
 
 on:
   push:
-    branches:
-      - master
     tags-ignore:
       - '**'
     paths:
@@ -37,13 +35,24 @@ jobs:
         run: |
           echo "GIT_REVISION=$(git describe --always --long --dirty)" | tee -a "$GITHUB_ENV"
 
+      - name: Determine image tag
+        run: |
+          if [[ "$GITHUB_REF_NAME" == master ]]; then
+            IMAGE_TAG=latest
+          else
+            IMAGE_TAG="branch-${GITHUB_REF_NAME//[^A-Za-z0-9._-]/-}"
+          fi
+          echo "IMAGE_TAG=$IMAGE_TAG" | tee -a "$GITHUB_ENV"
+
       - uses: docker/build-push-action@v2
         with:
           context: .
           file: ./Dockerfile
           push: true
-          tags: nextstrain/ncov-ingest:latest
-          cache-from: type=registry,ref=nextstrain/ncov-ingest:latest
+          tags: nextstrain/ncov-ingest:${{ env.IMAGE_TAG }}
+          cache-from: |
+            type=registry,ref=nextstrain/ncov-ingest:latest
+            type=registry,ref=nextstrain/ncov-ingest:${{ env.IMAGE_TAG }}
           cache-to: type=inline,mode=max
           build-args: |
             GIT_REVISION=${{ env.GIT_REVISION }}


### PR DESCRIPTION
### Description of proposed changes    

For use in dev and testing.  Parallels the pattern used by the
nextstrain/base images.

I was going to use the GitHub Action docker/metadata-action@v3 to
generate tags, but that started becoming more complicated than a small
bit of shell to set an env var.

With per-branch images, we could now also adjust the per-branch ingest
workflows use these images for the AWS Batch jobs (if a branch image
exists).

### Related issue(s)  
Related to #257.

### Testing
~I believe we're unable to test in actual CI until merged to master, which is unfortunate, as GitHub won't run the updated update-image workflow on this branch since the workflow on master says not to.~

I manually triggered an `update-image` [workflow run on this branch](https://github.com/nextstrain/ncov-ingest/runs/4565626219?check_suite_focus=true) and it DTRT.

![image](https://user-images.githubusercontent.com/79913/146611187-680cb4a7-8f05-4ebe-8307-33f6e461dbac.png)
