### PR TITLE
perf: let's try parallel xz and gz

### DIFF
--- a/bin/download-from-s3
+++ b/bin/download-from-s3
@@ -17,9 +17,9 @@ main() {
     if [[ $src_hash != "$dst_hash" ]]; then
         aws s3 cp --no-progress "$src" - |
         if [[ "$src" == *.gz ]]; then
-            gunzip -cfq
+            pigz -cdq
         elif  [[ "$src" == *.xz ]]; then
-            xz -T0 -dcq
+            pixz -cdq
         else
             cat
         fi > "$dst"

--- a/bin/notify-on-record-change
+++ b/bin/notify-on-record-change
@@ -14,7 +14,7 @@ source_name=${3:?A record source name is required as the third argument.}
 "$bin"/s3-object-exists "$dst" || exit 0
 
 src_record_count="$(wc -l < "$src")"
-dst_record_count="$(wc -l < <(aws s3 cp --no-progress "$dst" - | xz -T0 -dcfq))"
+dst_record_count="$(wc -l < <(aws s3 cp --no-progress "$dst" - | pixz -cdq))"
 added_records="$(( src_record_count - dst_record_count ))"
 
 printf "%'4d %s\n" "$src_record_count" "$src"

--- a/bin/run-nextclade-full
+++ b/bin/run-nextclade-full
@@ -139,7 +139,7 @@ main() {
   fi
 
   echo "[ INFO] ${0}:${LINENO}: Downloading '${S3_SRC}/sequences.fasta.xz' to '${INPUT_FASTA}'"
-  aws s3 cp --no-progress "${S3_SRC}/sequences.fasta.xz" - | xz -T0 -cdfq >"${INPUT_FASTA}"
+  aws s3 cp --no-progress "${S3_SRC}/sequences.fasta.xz" - | pixz -cdq >"${INPUT_FASTA}"
 
   echo "[ INFO] ${0}:${LINENO}: Splitting '${INPUT_FASTA}' into batches of size ${BATCH_SIZE} sequences and storing them in '${INPUT_WILDCARD}'"
   # Split fasta file to multiple batches

--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -33,9 +33,9 @@ main() {
     if [[ $src_hash != "$dst_hash" ]]; then
         echo "Uploading $src → $dst"
         if [[ "$dst" == *.gz ]]; then
-            gzip -c "$src"
+            pigz -c "$src"
         elif  [[ "$dst" == *.xz ]]; then
-            xz -2 -T0 -c "$src"
+            pixz -2 -c "$src"
         else
             cat "$src"
         fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash" "$(content-type "$dst")"


### PR DESCRIPTION
This is more of an experiment, then a real thing. This may or may not give a little speedup.

`pixz` has been a parallel alternative to `xz` for some time before `xz` finally implemented -T flag for compression. And it has parallel decompression, while `xz -d`, ignores this flag until very recent versions (and we use a pretty old Debian distro).

`pigz` is a parallel `gz` from the author of the algorithm himself. Definitely faster, but we only use `gz` on smaller files, will not necessarily be noticeable, but why not squeeze it anyways.

Both `pixz` and `pigz` are compatible with their respective "default" tool, in both directions.
