### PR TITLE
chore: cleanup logs

### DIFF
--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -25,7 +25,7 @@ main() {
 
     local src_hash dst_hash no_hash=0000000000000000000000000000000000000000000000000000000000000000
     src_hash="$("$bin/sha256sum" < "$src")"
-    dst_hash="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text || echo "$no_hash")"
+    dst_hash="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
 
     echo "$src_hash $src"
     echo "$dst_hash $dst"

--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -27,9 +27,6 @@ main() {
     src_hash="$("$bin/sha256sum" < "$src")"
     dst_hash="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
 
-    echo "$src_hash $src"
-    echo "$dst_hash $dst"
-
     if [[ $src_hash != "$dst_hash" ]]; then
         echo "Uploading $src → $dst"
         if [[ "$dst" == *.gz ]]; then

--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -46,7 +46,7 @@ main() {
             echo "Notifying Slack failed, but exiting with success anyway."
         fi
     else
-        echo "Files are identical, skipping upload"
+        echo "Uploading $src → $dst: files are identical, skipping upload"
     fi
 }
 


### PR DESCRIPTION
This attempts to improve the log readability:

 - Removes error message in case where fetching S3 object metadata cannot find an object. This not an error for us, as objects that never uploaded is a valid case. This change is a bit uncertain, because there might be other errors, not just "object not found", but this change hides all. Maybe there is a better way?
 - Removes printing of hashes of uploaded files. This is probably leftovers from debugging.
 - Prints filenames in the "skip uploading" branch, for more info and symmetry with the "do uploading" branch.
 