### PR TITLE
Use actions/checkout@v2

### DIFF
--- a/.github/workflows/fetch-and-ingest-genbank-branch.yml
+++ b/.github/workflows/fetch-and-ingest-genbank-branch.yml
@@ -11,7 +11,7 @@ jobs:
   ingest:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: setup
       run: ./bin/setup-github-workflow

--- a/.github/workflows/fetch-and-ingest-genbank-master.yml
+++ b/.github/workflows/fetch-and-ingest-genbank-master.yml
@@ -23,7 +23,7 @@ jobs:
   fetch-and-ingest:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: setup
       run: ./bin/setup-github-workflow

--- a/.github/workflows/fetch-and-ingest-gisaid-branch.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-branch.yml
@@ -11,7 +11,7 @@ jobs:
   ingest:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: setup
       run: ./bin/setup-github-workflow

--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -22,7 +22,7 @@ jobs:
   ingest:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: setup
       run: ./bin/setup-github-workflow

--- a/.github/workflows/ingest-genbank-master.yml
+++ b/.github/workflows/ingest-genbank-master.yml
@@ -15,7 +15,7 @@ jobs:
   ingest:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: setup
       run: ./bin/setup-github-workflow

--- a/.github/workflows/ingest-gisaid-master.yml
+++ b/.github/workflows/ingest-gisaid-master.yml
@@ -15,7 +15,7 @@ jobs:
   ingest:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: setup
       run: ./bin/setup-github-workflow

--- a/.github/workflows/rebuild-gisaid.yml
+++ b/.github/workflows/rebuild-gisaid.yml
@@ -15,7 +15,7 @@ jobs:
   rebuild-gisaid:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: setup
       run: ./bin/setup-github-workflow

--- a/.github/workflows/rebuild-open.yml
+++ b/.github/workflows/rebuild-open.yml
@@ -18,7 +18,7 @@ jobs:
   rebuild-open:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: setup
       run: ./bin/setup-github-workflow

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -7,7 +7,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: install
         run: sudo snap install --channel=edge shellcheck

--- a/.github/workflows/update-image.yml
+++ b/.github/workflows/update-image.yml
@@ -26,7 +26,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1
         with:


### PR DESCRIPTION
`actions/checkout@v1` is no longer maintained as of November 2019. See [CHANGELOG](https://github.com/actions/checkout/blob/main/CHANGELOG.md) for more info.