### PR TITLE
Move GISAID Auto-Ingest Time Later

### DIFF
--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -4,10 +4,10 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Note times are in UTC, which is 1 or 2 hours behind CET depending on daylight savings
-    # Currently triggers at 12 UTC which is 13 CET (as of Nov 21)
+    # Currently triggers at 14.00 UTC which is 15.00 CET (as of Nov 2021)
     # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
     # https://crontab.guru/
-    - cron:  '7 12 * * *'
+    - cron:  '7 14 * * *'
 
   # Manually triggered using `./bin/trigger gisaid/fetch-and-ingest`
   repository_dispatch:


### PR DESCRIPTION
Adjusts the time of the auto-ingest of GISAID from 1pm CET to 3pm CET in order to be more in line with when GISAID seems to be updating their files.
Currently we run at 1pm but we have often missed the dump (or sometimes only caught it because our ingest starts late). However, keeping in mind that it often takes ~40 minutes for our ingest to start, we could also pull this time back slightly (I'm not sure how to set it to start on anything other than the top of the hour), so that we start earlier.

One remaining question - there is no reason to move the Genbank ingest as we pull in realtime, but do we want to keep the ingest times in sync just for neatness? (Currently I modify only GISAID)

