### PR TITLE
Remove GenBank metadata diff

### DIFF
--- a/.github/workflows/fetch-and-ingest-genbank-master.yml
+++ b/.github/workflows/fetch-and-ingest-genbank-master.yml
@@ -48,14 +48,14 @@ jobs:
           --no-download \
           --image nextstrain/ncov-ingest \
           --cpus 16 \
-          --memory 60GiB \
+          --memory 30GiB \
           --exec env \
           . \
             envdir env.d snakemake \
               --configfile config/genbank.yaml \
               --config "${config[@]}" \
               --cores 16 \
-              --resources mem_mb=55000 \
+              --resources mem_mb=30000 \
               --printshellcmds
       env:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}

--- a/Snakefile
+++ b/Snakefile
@@ -284,7 +284,6 @@ rule notify_gisaid:
 rule notify_genbank:
     input:
         flagged_annotations = rules.transform_genbank_data.output.flagged_annotations,
-        metadata = "data/genbank/metadata.tsv",
         location_hierarchy = "data/genbank/location_hierarchy.tsv",
         duplicate_biosample = "data/genbank/duplicate_biosample.txt"
     params:
@@ -293,7 +292,6 @@ rule notify_genbank:
         touch("data/genbank/notify.done")
     run:
         shell("./bin/notify-slack --upload flagged-annotations < {input.flagged_annotations}")
-        shell("./bin/notify-on-metadata-change {input.metadata} {params.s3_bucket}/metadata.tsv.gz genbank_accession")
         # TODO - which rule produces data/genbank/problem_data.tsv? (was not explicit in `ingest-genbank` bash script)
         shell("./bin/notify-on-problem-data data/genbank/problem_data.tsv")
         shell("./bin/notify-on-location-hierarchy-addition {input.location_hierarchy} source-data/location_hierarchy.tsv")


### PR DESCRIPTION
The `csv-diff` within `notify-on-metadata-change` began running into
a MemoryError on December 26, 2021. This was patched during the holidays
by increasing the memory for Genbank ingest runs (bd2c2ca).

Further investigation showed that we have not been receiving the
metadata diff output files since we switched to Snakemake on
December 1, 2021 (74de8b1). The `upload` rule has been running before
`notify_genbank` resulting in diffing of the same file that has been
uploaded to S3. This is caused by `upload` not having any dependencies
on `notify_genbank` and `notify_genbank` having an additional dependency
on `check_locations`. This prompted an [internal discussion](https://bedfordlab.slack.com/archives/C0159227X7Y/p1641237304011100) that showed
no one has been using the outputs of this metadata diff.