### PR TITLE
chore: make notify-slack less verbose

### DIFF
--- a/bin/notify-slack
+++ b/bin/notify-slack
@@ -31,7 +31,7 @@ if [[ "$upload" == 1 ]]; then
         --form filetype=text \
         --fail --silent --show-error \
         --http1.1 \
-        --include
+        --output /dev/null
 else
     echo "Posting Slack message: $text"
     curl https://slack.com/api/chat.postMessage \
@@ -40,5 +40,5 @@ else
         --form-string text="$text" \
         --fail --silent --show-error \
         --http1.1 \
-        --include
+        --output /dev/null
 fi


### PR DESCRIPTION
This modifies `curl` invocation:

 - remove `--include` flag to not show response headers
 - add `--output /dev/null` to not show response body.

This information only clutters the logs and not useful for routine diagnostics. Without it it logs will be more readable. Errors will still be shown.
