### PR TITLE
chore: correct time in the comment [no ci]

### DIFF
--- a/.github/workflows/fetch-and-ingest-genbank-master.yml
+++ b/.github/workflows/fetch-and-ingest-genbank-master.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Note times are in UTC, which is 1 or 2 hours behind CET depending on daylight savings
-    # Currently triggers at 14.00 UTC which is 15.00 CET (as of Nov 2021)
+    # Currently triggers every day at 14:07 UTC which is 15:07 CET (as of Nov 2021)
     # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
     # https://crontab.guru/
     - cron:  '7 14 * * *'

--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     # Note times are in UTC, which is 1 or 2 hours behind CET depending on daylight savings
-    # Currently triggers at 14.00 UTC which is 15.00 CET (as of Nov 2021)
+    # Currently triggers every day at 14:07 UTC which is 15:07 CET (as of Nov 2021)
     # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
     # https://crontab.guru/
     - cron:  '7 14 * * *'


### PR DESCRIPTION
The scheduled ingests run at 14:07 UTC, not 14:00 UTC. The comment confused me for a minute (more precisely for 7 minutes :D). Let's fix that, so that nobody else gets confused.
