### PR TITLE
fix: increase memory of gisaid run and add resource constraint to met…

### DIFF
--- a/.github/workflows/fetch-and-ingest-gisaid-branch.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-branch.yml
@@ -36,14 +36,14 @@ jobs:
           --no-download \
           --image nextstrain/ncov-ingest \
           --cpus 16 \
-          --memory 31GiB \
+          --memory 48GiB \
           --exec env \
           . \
             envdir env.d snakemake \
               --configfile config/gisaid.yaml \
               --config "${config[@]}" \
               --cores 16 \
-              --resources mem_mb=31000 \
+              --resources mem_mb=47000 \
               --printshellcmds
       env:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}

--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -62,14 +62,14 @@ jobs:
           --no-download \
           --image nextstrain/ncov-ingest \
           --cpus 16 \
-          --memory 31GiB \
+          --memory 48GiB \
           --exec env \
           . \
             envdir env.d snakemake \
               --configfile config/gisaid.yaml \
               --config "${config[@]}" \
               --cores 16 \
-              --resources mem_mb=31000 \
+              --resources mem_mb=47000 \
               --printshellcmds
       env:
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}

--- a/Snakefile
+++ b/Snakefile
@@ -308,7 +308,7 @@ rule mutation_summary:
 
 rule combine_mutation_summaries:
     message:
-        """ 
+        """
         Generating full mutation summary by combining with previous (cached) summary
         """
     input:
@@ -351,6 +351,9 @@ rule flag_metadata:
         metadata = "data/gisaid/metadata.tsv"
     output:
         metadata = "data/gisaid/flagged_metadata.txt"
+    resources:
+        # Memory use scales primarily with the size of the metadata file.
+        mem_mb=20000
     shell:
         """
         ./bin/flag-metadata {input.metadata} > {output.metadata}
@@ -363,6 +366,9 @@ rule check_locations:
         unique_id = "gisaid_epi_isl" if database=="gisaid" else "genbank_accession"
     output:
         location_hierarchy = f"data/{database}/location_hierarchy.tsv"
+    resources:
+        # Memory use scales primarily with the size of the metadata file.
+        mem_mb=20000
     shell:
         """
         ./bin/check-locations {input.metadata} {output.location_hierarchy} {params.unique_id}


### PR DESCRIPTION
Some rules read all metadata into memory. if several of them run in parallel, we run out of memory. This increases memory for the gisaid workflow and adds resource constraints to the `flag-annotation` and `check-location` rules. 
