### PR TITLE
chore: delay GISAID download to 16:07 CET

### DIFF
--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # Note times are in UTC, which is 1 or 2 hours behind CET depending on daylight savings.
     #
-    # Currently, we aim to trigger ingest every day at 14:07 UTC which is 15:07 CET (as of Nov 2021).
+    # Currently, we aim to trigger ingest every day at 15:07 UTC which is 16:07 CET (as of Jan 2021).
     # Note the actual runs might be late. As of right now, the action starts only around 14:22 UTC.
     # Numerous people were confused, about that, including me:
     #  - https://github.community/t/scheduled-action-running-consistently-late/138025/11
@@ -20,7 +20,7 @@ on:
     #
     # Looks like you are about to modify this schedule? Make sure you also modify the schedule for the
     # sister GenBank job, so that we don't need to keep two schedules in our heads.
-    - cron:  '7 14 * * *'
+    - cron:  '7 15 * * *'
 
   # Manually triggered using `./bin/trigger gisaid/fetch-and-ingest`
   repository_dispatch:


### PR DESCRIPTION
Adjusts the time of the auto-ingest of GISAID from 3pm CET to 4pm CET in order to be more in line with when GISAID seems to be updating their files.

One remaining question - there is no reason to move the Genbank ingest as we pull in realtime, but do we want to keep the ingest times in sync just for neatness? (Currently I modify only GISAID)
