### PR TITLE
Fix a bug which causes download-from-s3 to hang forever in certain contexts

### DIFF
--- a/bin/download-from-s3
+++ b/bin/download-from-s3
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+bin="$(dirname "$0")"
+
 main() {
     local src="${1:?A source s3:// URL is required as the first argument.}"
     local dst="${2:?A destination file path is required as the second argument.}"
@@ -10,7 +12,7 @@ main() {
     local key="${s3path#*/}"
 
     local src_hash dst_hash no_hash=0000000000000000000000000000000000000000000000000000000000000000
-    dst_hash="$(sha256sum "$dst" 2>/dev/null | awk '{ print $1 }' || true)"
+    dst_hash="$("$bin/sha256sum" < "$dst" || true)"
     src_hash="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
 
     echo "[ INFO] Downloading $src → $dst"


### PR DESCRIPTION
### Description of proposed changes    
The GNU coreutils sha256sum takes a filename as an argument, but our
portable bin/sha256sum does not and only reads from stdin.  The Docker
container prepends our bin/ to PATH as a convenience, which means inside
the container the unqualified sha256sum command refers to ours and as
such, it hung forever waiting for data on stdin that would never come.

download-from-s3 now matches upload-to-s3 here (which predates it) and
is explicit about using our version of sha256sum.

I ran into this bug while launching a local ingest (sans fetch) run
inside a container (using `nextstrain build`).  The run sat there for a
long time "downloading" the inputs before I realized something must be
wrong.  I think this hasn't been noticed until now because CI always
runs fetch + ingest jobs where download-to-s3 isn't used to provision
inputs.  But I'm not sure how it wasn't noticed in the other places
download-from-s3 is called?!

### Testing
I am able to successfully run the following locally, unlike before:

```
nextstrain build --image nextstrain/ncov-ingest . \
  download_main_ndjson \
  --configfile config/genbank.yaml
```

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
