### PR TITLE
Update data frame with pandas loc

### DIFF
--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -110,7 +110,7 @@ def main():
     offset = result["Nextstrain_clade"].apply(lambda x: offset_by_clade.get(x, 2.0))
     # calculate divergence
     result["clock_deviation"] = np.array(div_array - ((t-reference_day)*rate_per_day + offset), dtype=int)
-    result["clock_deviation"][np.isnan(div_array)|np.isnan(t)] = np.nan
+    result.loc[np.isnan(div_array)|np.isnan(t), "clock_deviation"] = np.nan
 
     for col in list(column_map.values()) + ["clock_deviation"]:
         result[col] = result[col].fillna(VALUE_MISSING_DATA)


### PR DESCRIPTION
### Description of proposed changes    

Avoid modifying a copy of a pandas data frame by using [the more appropriate `loc` attribute](https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#why-does-assignment-fail-when-using-chained-indexing) to select rows with missing data and then set the clock deviation to a missing value for those rows.

### Related issue(s)  

Fixes #248

### Testing

 - [x] Tested locally to confirm lack of `SettingWithCopyWarning`
 - [x] Tested by CI