### PR TITLE
feat: add Nextclade_pango column to metadata

### DIFF
--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -15,6 +15,7 @@ reference_day = datetime(2020,1,1).toordinal()
 
 column_map = {
     "clade": "Nextstrain_clade",
+    "Nextclade_pango": "Nextclade_pango",
     "totalMissing": "missing_data",
     "totalSubstitutions": "divergence",
     "totalNonACGTNs": "nonACGTN",


### PR DESCRIPTION
Copies the [new](https://github.com/nextstrain/nextclade/releases/tag/1.11.0) `Nextclade_pango` column from nextclade.tsv to metadata.tsv. This column contains Pango lineages assigned using Nextclade.

Symmetrical PR in ncov: https://github.com/nextstrain/ncov/pull/892