### PR TITLE
Mask bad collection date

### DIFF
--- a/bin/transform-genbank
+++ b/bin/transform-genbank
@@ -25,6 +25,7 @@ from utils.transformpipeline.transforms import (
     DropSequenceData,
     FillDefaultLocationData,
     FixLabs,
+    MaskBadCollectionDate,
     MergeBiosampleMetadata,
     MergeUserAnnotatedMetadata,
     ParseGeographicColumnsGenbank,
@@ -169,6 +170,7 @@ if __name__ == '__main__':
                               | FixLabs()
                               | ParsePatientAge()
                               | ParseSex()
+                              | MaskBadCollectionDate()
                               | StandardizeGenbankStrainNames()
                               | ParseGeographicColumnsGenbank( base / 'source-data/us-state-codes.tsv' )
                               | AbbreviateAuthors()

--- a/bin/transform-gisaid
+++ b/bin/transform-gisaid
@@ -24,6 +24,7 @@ from utils.transformpipeline.transforms import (
     FillDefaultLocationData,
     FixLabs,
     MergeUserAnnotatedMetadata,
+    MaskBadCollectionDate,
     ParsePatientAge,
     ParseSex,
     RenameAndAddColumns,
@@ -162,6 +163,7 @@ if __name__ == '__main__':
             | AbbreviateAuthors()
             | ParsePatientAge()
             | ParseSex()
+            | MaskBadCollectionDate()
             | AddHardcodedMetadata()
         )
 

--- a/bin/transform-gisaid
+++ b/bin/transform-gisaid
@@ -82,7 +82,7 @@ if __name__ == '__main__':
             "e.g.\n\t"
             "Europe/Spain/Catalunya/Mataró\tEurope/Spain/Catalunya/Mataro\n\t")
     parser.add_argument("--output-metadata",
-        default=str( base / "data/gisaid/metadata.tsv" ), 
+        default=str( base / "data/gisaid/metadata.tsv" ),
         help="Output location of generated metadata tsv. Defaults to `data/gisaid/metadata.tsv`")
     parser.add_argument("--output-fasta",
         default=str( base / "data/gisaid/sequences.fasta" ) ,
@@ -154,7 +154,7 @@ if __name__ == '__main__':
 
         if not args.sorted_fasta:
             pipeline = pipeline | DropSequenceData()
-        
+
         pipeline = (
             pipeline
             | ExpandLocation()
@@ -162,22 +162,22 @@ if __name__ == '__main__':
             | AbbreviateAuthors()
             | ParsePatientAge()
             | ParseSex()
-            | AddHardcodedMetadata() 
+            | AddHardcodedMetadata()
         )
 
         # writing the raw metadata in a tsv file
-        pipeline = ( pipeline  | WriteCSV(RAW_METADATA_FILENAME, 
-                                            METADATA_COLUMNS , 
-                                            restval = '?' , 
-                                            extrasaction ='ignore' , 
-                                            delimiter  = '\t', 
+        pipeline = ( pipeline  | WriteCSV(RAW_METADATA_FILENAME,
+                                            METADATA_COLUMNS ,
+                                            restval = '?' ,
+                                            extrasaction ='ignore' ,
+                                            delimiter  = '\t',
                                             dict_writer_kwargs  = {'lineterminator': args.newline} ) )
 
 
         # applying the substitution rules (temporary : writing the intermediary data to verify effect )
         dict_writer_kwargs = {'lineterminator': args.newline}
 
-        
+
         pipeline = (pipeline
             | ApplyUserGeoLocationSubstitutionRules(geoRules)
             | MergeUserAnnotatedMetadata(annotations)

--- a/lib/utils/transformpipeline/transforms.py
+++ b/lib/utils/transformpipeline/transforms.py
@@ -4,6 +4,7 @@ import unicodedata
 from collections import defaultdict
 from typing import Any, Collection, List, MutableMapping, Sequence, Tuple , Dict , Union
 import pandas as pd
+from datetime import datetime
 
 
 from utils.transform import format_date, titlecase
@@ -387,6 +388,27 @@ class ParseSex(Transformer):
         entry['sex'] = re.sub(r"^(female|F|Femal)$", "Female", entry['sex'])
         # Cleanup unknowns
         entry['sex'] = re.sub(r"^(unknown|N/A|NA|not applicable)$", "?", entry['sex'])
+        return entry
+
+
+class MaskBadCollectionDate(Transformer):
+    """
+    Masks collection date with 'XXXX-XX-XX' if the collection date is the same
+    day as or after the submission date.
+
+    Only masks the collection date if both dates are properly formatted as
+    ISO 8601 date (YYYY-MM-DD).
+    """
+    def transform_value(self, entry: dict) -> dict:
+        expected_date_format = '%Y-%m-%d'
+        try:
+            collection_date = datetime.strptime(entry['date'], expected_date_format)
+            submission_date = datetime.strptime(entry['date_submitted'], expected_date_format)
+            if collection_date >= submission_date:
+                entry['date'] = 'XXXX-XX-XX'
+        except ValueError:
+            pass
+
         return entry
 
 


### PR DESCRIPTION
Masks the collection date with `XXXX-XX-XX` if the collection date is
the same day as or after the submission date.

This was suggested by @trvrb when @corneliusroemer noticed that a subset
of GISAID data had collection dates identical to the submitting date.
It is most likely impossible to sample, PCR, sequence, and submit on
same day. However, if we do determine this is possible, the masking
can be overridden for specific cases via the manual annotations.