### PR TITLE
Trigger ncov counts

### DIFF
--- a/.github/workflows/fetch-and-ingest-genbank-master.yml
+++ b/.github/workflows/fetch-and-ingest-genbank-master.yml
@@ -54,6 +54,7 @@ jobs:
         config+=(
           fetch_from_database=True
           trigger_rebuild=True
+          trigger_counts=True
         )
 
         nextstrain build \

--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -55,6 +55,7 @@ jobs:
         config+=(
           fetch_from_database=True
           trigger_rebuild=True
+          trigger_counts=True
         )
 
         nextstrain build \

--- a/README.md
+++ b/README.md
@@ -19,24 +19,32 @@ AWS credentials are stored in this repository's secrets and are associated with 
 
 ## Manually triggering the automation
 A full run is a now done in 3 steps via manual triggers:
-1. Fetch new sequences and ingest them by running `./bin/trigger gisaid/fetch-and-ingest --user <your-github-username>`.
+1. Fetch new sequences and ingest them by running `./bin/trigger ncov-ingest gisaid/fetch-and-ingest --user <your-github-username>`.
 2. Add manual annotations, update location hierarchy as needed, and run ingest without fetching new sequences.
     * Pushes of `source-data/*-annotations.tsv` to the master branch will automatically trigger a run of ingest.
-    * You can also run ingest manually by running `./bin/trigger gisaid/ingest --user <your-github-username>`.
-3. Once all manual fixes are complete, trigger a rebuild of [nextstrain/ncov](https://github.com/nextstrain/ncov) by running `./bin/trigger rebuild --user <your-github-username>`.
+    * You can also run ingest manually by running `./bin/trigger ncov-ingest gisaid/ingest --user <your-github-username>`.
+3. Once all manual fixes are complete, trigger a rebuild of [nextstrain/ncov](https://github.com/nextstrain/ncov) by running `./bin/trigger ncov-ingest rebuild --user <your-github-username>`.
 
-See the output of `./bin/trigger gisaid/fetch-and-ingest --user <your-github-username>`, `./bin/trigger gisaid/ingest` or `./bin/trigger rebuild` for more information about authentication with GitHub.
+See the output of `./bin/trigger ncov-ingest gisaid/fetch-and-ingest --user <your-github-username>`, `./bin/trigger ncov-ingest gisaid/ingest` or `./bin/trigger ncov-ingest rebuild` for more information about authentication with GitHub.
 
-Note: running `./bin/trigger` posts a GitHub `repository_dispatch`.
+Note: running `./bin/trigger ncov-ingest` posts a GitHub `repository_dispatch`.
 Regardless of which branch you are on, it will trigger the specified action on the master branch.
 
-Valid dispatch types for `./bin/trigger` are:
+Valid dispatch types for `./bin/trigger ncov-ingest` are:
 
   - `ingest` (both GISAID and GenBank)
   - `gisaid/ingest`
   - `genbank/ingest`
+  - `fetch-and-ingest` (both GISAID and GenBank)
   - `gisaid/fetch-and-ingest`
+  - `genbank/fetch-and-ingest`
   - `rebuild`
+  - `gisaid/rebuild`
+  - `open/rebuild`
+  - `genbank/rebuild`
+  - `nextclade-full-run` (both GISAID and GenBank)
+  - `gisaid/nextclade-full-run`
+  - `genbank/nextclade-full-run`
 
 ## Updating manual annotations
 Manual annotations should be added to `source-data/gisaid_annotations.tsv`.

--- a/Snakefile
+++ b/Snakefile
@@ -20,6 +20,8 @@ all_targets = [f"data/{database}/upload.done"]
 
 if config.get("trigger_rebuild", False):
     all_targets.append(f"data/{database}/trigger-rebuild.done")
+if config.get("trigger_counts", False):
+    all_targets.append(f"data/{database}/trigger-counts.done")
 if send_notifications:
     all_targets.append(f"data/{database}/notify.done")
 if config.get("fetch_from_database", False):
@@ -454,6 +456,19 @@ rule trigger_rebuild_pipeline:
     shell:
         """
         ./bin/trigger ncov {params.dispatch_type}
+        """
+
+rule trigger_counts_pipeline:
+    message: "Triggering nextstrain/counts clade counts action (via repository dispatch)"
+    input:
+        f"data/{database}/upload.done"
+    output:
+        touch(f"data/{database}/trigger-counts.done")
+    params:
+        dispatch_type = f"{database}/clade-counts"
+    shell:
+        """
+        ./bin/trigger counts {params.dispatch_type}
         """
 
 ################################################################

--- a/Snakefile
+++ b/Snakefile
@@ -450,18 +450,11 @@ rule trigger_rebuild_pipeline:
     output:
         touch(f"data/{database}/trigger-rebuild.done")
     params:
-        dispatch_type = f"{database}/rebuild",
-        token = os.environ.get("PAT_GITHUB_DISPATCH", "")
-    run:
-        import requests
-        headers = {
-                'Content-type': 'application/json',
-                'authorization': f"Bearer {params.token}",
-                'Accept': 'application/vnd.github.v3+json'}
-        data = {"event_type": params.dispatch_type}
-        print(f"Triggering ncov rebuild GitHub action via repository dispatch type: {params.dispatch_type}")
-        response = requests.post("https://api.github.com/repos/nextstrain/ncov/dispatches", headers=headers, data=json.dumps(data))
-        response.raise_for_status()
+        dispatch_type = f"{database}/rebuild"
+    shell:
+        """
+        ./bin/trigger ncov {params.dispatch_type}
+        """
 
 ################################################################
 ################################################################

--- a/bin/trigger
+++ b/bin/trigger
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
-TOKEN="${PAT_GITHUB_DISPATCH:-}"
+: "${PAT_GITHUB_DISPATCH:=}"
 
 repo="${1:?A repository name is required as the first argument.}"
 event_type="${2:?An event type is required as the second argument.}"
 shift 2
 
-if [[ $# -eq 0 && -z $TOKEN ]]; then
+if [[ $# -eq 0 && -z $PAT_GITHUB_DISPATCH ]]; then
     cat >&2 <<.
 You must specify options to curl for your GitHub credentials.  For example, you
 can specify your GitHub username, and will be prompted for your password:
@@ -38,8 +38,8 @@ which will then not require you to type your password every time.
 fi
 
 auth=':'
-if [[ $TOKEN ]]; then
-  auth="Authorization: Bearer ${TOKEN}"
+if [[ -n $PAT_GITHUB_DISPATCH ]]; then
+  auth="Authorization: Bearer ${PAT_GITHUB_DISPATCH}"
 fi
 
 if curl -fsS "https://api.github.com/repos/nextstrain/${repo}/dispatches" \

--- a/bin/trigger
+++ b/bin/trigger
@@ -3,15 +3,16 @@ set -euo pipefail
 
 TOKEN="${PAT_GITHUB_DISPATCH:-}"
 
-event_type="${1:?An event type (fetch-and-ingest, ingest, rebuild, or update-image) is required as the first argument.}"
-shift
+repo="${1:?A repository name is required as the first argument.}"
+event_type="${2:?An event type is required as the second argument.}"
+shift 2
 
 if [[ $# -eq 0 && -z $TOKEN ]]; then
     cat >&2 <<.
 You must specify options to curl for your GitHub credentials.  For example, you
 can specify your GitHub username, and will be prompted for your password:
 
-  $0 $event_type --user <your-github-username>
+  $0 $repo $event_type --user <your-github-username>
 
 Be sure to enter a personal access token¹ as your password since GitHub has
 discontinued password authentication to the API starting on November 13, 2020².
@@ -25,7 +26,7 @@ file³:
 
 and then tell curl to use it:
 
-  $0 $event_type --netrc
+  $0 $repo $event_type --netrc
 
 which will then not require you to type your password every time.
 
@@ -41,7 +42,7 @@ if [[ $TOKEN ]]; then
   auth="Authorization: Bearer ${TOKEN}"
 fi
 
-if curl -fsS https://api.github.com/repos/nextstrain/ncov-ingest/dispatches \
+if curl -fsS "https://api.github.com/repos/nextstrain/${repo}/dispatches" \
     -H 'Accept: application/vnd.github.v3+json' \
     -H 'Content-Type: application/json' \
     -H "$auth" \

--- a/bin/trigger
+++ b/bin/trigger
@@ -1,18 +1,23 @@
 #!/bin/bash
 set -euo pipefail
 
+TOKEN="${PAT_GITHUB_DISPATCH:-}"
+
 event_type="${1:?An event type (fetch-and-ingest, ingest, rebuild, or update-image) is required as the first argument.}"
 shift
 
-if [[ $# -eq 0 ]]; then
+if [[ $# -eq 0 && -z $TOKEN ]]; then
     cat >&2 <<.
 You must specify options to curl for your GitHub credentials.  For example, you
 can specify your GitHub username, and will be prompted for your password:
 
   $0 $event_type --user <your-github-username>
 
-You can also store your credentials or a personal access token¹ in a netrc
-file²:
+Be sure to enter a personal access token¹ as your password since GitHub has
+discontinued password authentication to the API starting on November 13, 2020².
+
+You can also store your credentials or a personal access token in a netrc
+file³:
 
   machine api.github.com
   login <your-username>
@@ -25,14 +30,21 @@ and then tell curl to use it:
 which will then not require you to type your password every time.
 
 ¹ https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
-² https://ec.haxx.se/usingcurl/usingcurl-netrc
+² https://docs.github.com/en/rest/overview/other-authentication-methods#via-username-and-password
+³ https://ec.haxx.se/usingcurl/usingcurl-netrc
 .
     exit 1
+fi
+
+auth=':'
+if [[ $TOKEN ]]; then
+  auth="Authorization: Bearer ${TOKEN}"
 fi
 
 if curl -fsS https://api.github.com/repos/nextstrain/ncov-ingest/dispatches \
     -H 'Accept: application/vnd.github.v3+json' \
     -H 'Content-Type: application/json' \
+    -H "$auth" \
     -d '{"event_type":"'"$event_type"'"}' \
     "$@"
 then

--- a/config/genbank.yaml
+++ b/config/genbank.yaml
@@ -2,6 +2,7 @@ database_name: "genbank"
 
 fetch_from_database: false
 trigger_rebuild: false
+trigger_counts: false
 
 s3_src: "s3://nextstrain-data/files/ncov/open"
 s3_dst: "s3://nextstrain-data/files/ncov/open"

--- a/config/gisaid.yaml
+++ b/config/gisaid.yaml
@@ -2,6 +2,7 @@ database_name: "gisaid"
 
 fetch_from_database: false
 trigger_rebuild: false
+trigger_counts: false
 
 s3_src: "s3://nextstrain-ncov-private"
 s3_dst: "s3://nextstrain-ncov-private"


### PR DESCRIPTION
### Description of proposed changes
Add trigger for nexstrain/counts clade counts to run after the metadata TSV has been uploaded to S3.

Cannot be fully tested until https://github.com/nextstrain/counts/pull/2 has been merged since repository dispatch events only run on the default branch. 