### PR TITLE
This removes the automated on push running of ingest

### DIFF
--- a/.github/workflows/fetch-and-ingest-genbank-branch.yml
+++ b/.github/workflows/fetch-and-ingest-genbank-branch.yml
@@ -1,11 +1,7 @@
 name: GenBank fetch and ingest (on branch)
 
-on:
-  push:
-    branches-ignore:
-      - master
-    tags-ignore:
-      - '**'
+# Manually triggered using GitHub's UI
+on: workflow_dispatch
 
 jobs:
   ingest:
@@ -19,7 +15,7 @@ jobs:
         ./bin/write-envdir env.d \
           AWS_DEFAULT_REGION \
           GITHUB_RUN_ID
-  
+
         GITHUB_BRANCH=${GITHUB_REF#refs/heads/}
         declare -a config
         config+=(

--- a/.github/workflows/fetch-and-ingest-gisaid-branch.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-branch.yml
@@ -1,11 +1,7 @@
 name: GISAID fetch and ingest (on branch)
 
-on:
-  push:
-    branches-ignore:
-      - master
-    tags-ignore:
-      - '**'
+# Manually triggered using GitHub's UI
+on: workflow_dispatch
 
 jobs:
   ingest:


### PR DESCRIPTION
### Description of proposed changes

Currently, any branch updates result in running the entire GISAID and GenBank ingest workflows via GitHub Actions. In current build schedule and curation routine this is no longer necessary.

This commit removes the "on push" trigger, but leaves the branch-specific workflows intact via the `workflow_dispatch` option. The idea would be to be able to run trial ingests when desired. Rather than having it happen with every push.


