### PR TITLE
trigger_counts_pipeline: update repo name to forecasts-ncov

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -449,7 +449,7 @@ rule trigger_counts_pipeline:
         dispatch_type = f"{database}/clade-counts"
     shell:
         """
-        ./bin/trigger counts {params.dispatch_type}
+        ./bin/trigger forecasts-ncov {params.dispatch_type}
         """
 
 ################################################################


### PR DESCRIPTION
We've decide to rename the counts repo to forecasts-ncov.
This PR updates the `trigger_counts_pipeline` rule to send the trigger to the new repo name.

Tested locally with 
```
touch data/gisaid/upload.done
envdir ../env.d/github_pat/ snakemake --cores all --configfile config/gisaid.yaml --config trigger_counts=True
```
Successfully triggered the [gisaid/clade-counts workflow](https://github.com/nextstrain/forecasts-ncov/actions/runs/2348912525) (which was then manually cancelled). 