### PR TITLE
notify-on-record-change: notify on all changes

### DIFF
--- a/bin/notify-on-record-change
+++ b/bin/notify-on-record-change
@@ -21,13 +21,19 @@ printf "%'4d %s\n" "$src_record_count" "$src"
 printf "%'4d %s\n" "$dst_record_count" "$dst"
 printf "%'4d added records\n" "$added_records"
 
+slack_message=""
+
 if [[ $added_records -gt 0 ]]; then
     echo "Notifying Slack about added records (n=$added_records)"
-    "$bin"/notify-slack "📈 New nCoV records (n=$added_records) found on $source_name."
+    slack_message="📈 New nCoV records (n=$added_records) found on $source_name."
 
 elif [[ $added_records -lt 0 ]]; then
-    echo "New file has fewer records‽"
+    echo "Notifying Slack about fewer records (n=$added_records)"
+    slack_message="📉 Fewer nCoV records (n=$added_records) found on $source_name."
 
 else
-    echo "Files have the same number of records, skipping notification"
+    echo "Notifying Slack about same number of records"
+    slack_message="⛔ No new nCoV records found on $source_name."
 fi
+
+"$bin"/notify-slack "$slack_message"


### PR DESCRIPTION
We've been having stale fetches from the GISAID endpoint that lack new
records. It would be helpful to have specific notifications about the
different types of record changes, not just new records. This way we get
early notifications about the status of our fetches instead of having
to look for messages buried in the pipeline logs.
