### PR TITLE
Store record count in S3 metadata

### DIFF
--- a/bin/notify-on-record-change
+++ b/bin/notify-on-record-change
@@ -20,7 +20,7 @@ key="${s3path#*/}"
 src_record_count="$(wc -l < "$src")"
 
 # Try getting record count from S3 object metadata
-dst_record_count="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.recordCount --output text 2>/dev/null)"
+dst_record_count="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.recordcount --output text 2>/dev/null)"
 if [[ $dst_record_count == "None" ]]; then
   # This object doesn't have the record count stored as metadata
   # We have to download it and count the lines locally

--- a/bin/notify-on-record-change
+++ b/bin/notify-on-record-change
@@ -20,7 +20,7 @@ key="${s3path#*/}"
 src_record_count="$(wc -l < "$src")"
 
 # Try getting record count from S3 object metadata
-dst_record_count="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.recordcount --output text 2>/dev/null)"
+dst_record_count="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.recordcount --output text 2>/dev/null | tr -d '"')"
 if [[ $dst_record_count == "None" ]]; then
   # This object doesn't have the record count stored as metadata
   # We have to download it and count the lines locally

--- a/bin/notify-on-record-change
+++ b/bin/notify-on-record-change
@@ -13,8 +13,20 @@ source_name=${3:?A record source name is required as the third argument.}
 # if the file is not already present, just exit
 "$bin"/s3-object-exists "$dst" || exit 0
 
+s3path="${dst#s3://}"
+bucket="${s3path%%/*}"
+key="${s3path#*/}"
+
 src_record_count="$(wc -l < "$src")"
-dst_record_count="$(wc -l < <(aws s3 cp --no-progress "$dst" - | xz -T0 -dcfq))"
+
+# Try getting record count from S3 object metadata
+dst_record_count="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.recordCount --output text 2>/dev/null)"
+if [[ $dst_record_count == "None" ]]; then
+  # This object doesn't have the record count stored as metadata
+  # We have to download it and count the lines locally
+  dst_record_count="$(wc -l < <(aws s3 cp --no-progress "$dst" - | xz -T0 -dcfq))"
+fi
+
 added_records="$(( src_record_count - dst_record_count ))"
 
 printf "%'4d %s\n" "$src_record_count" "$src"

--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -38,7 +38,7 @@ main() {
             xz -2 -T0 -c "$src"
         else
             cat "$src"
-        fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash",recordCount="$src_record_count" "$(content-type "$dst")"
+        fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash",recordcount="$src_record_count" "$(content-type "$dst")"
 
         if [[ $quiet == 1 ]]; then
             echo "Quiet mode. No Slack notification sent."

--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -28,6 +28,9 @@ main() {
     dst_hash="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
 
     if [[ $src_hash != "$dst_hash" ]]; then
+        # The record count may have changed
+        src_record_count="$(wc -l < "$src")"
+
         echo "Uploading $src → $dst"
         if [[ "$dst" == *.gz ]]; then
             gzip -c "$src"
@@ -35,7 +38,7 @@ main() {
             xz -2 -T0 -c "$src"
         else
             cat "$src"
-        fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash" "$(content-type "$dst")"
+        fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash",recordCount="$src_record_count" "$(content-type "$dst")"
 
         if [[ $quiet == 1 ]]; then
             echo "Quiet mode. No Slack notification sent."


### PR DESCRIPTION
### Description of proposed changes
This PR adds the record count of a file to the metadata in S3, similar to what has been done for the SHA-256 hash. If `notify-on-record-change` is run on a file where the destination has `recordcount` in its metadata, the lines only need to be counted on the source file. This avoids the need to download the destination file, uncompress it, and count the lines locally before determining whether records have been added/removed

### Related issue(s)
Fixes #243 

### Testing
I've tested some of these commands manually and they seem to work, but I haven't verified whether it works in the context of the rest of the pipeline.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
