### PR TITLE
CloudFront Invalidation

### DIFF
--- a/.github/workflows/fetch-and-ingest-genbank-branch.yml
+++ b/.github/workflows/fetch-and-ingest-genbank-branch.yml
@@ -21,6 +21,7 @@ jobs:
         config+=(
           fetch_from_database=True
           s3_dst=s3://nextstrain-staging/files/ncov/open/branch/"${GITHUB_BRANCH}"
+          cloudfront_domain=staging.nextstrain.org
         )
 
         nextstrain build \

--- a/Snakefile
+++ b/Snakefile
@@ -109,10 +109,11 @@ rule upload_raw_ndjson:
         touch(f"data/{database}/raw.upload.done")
     params:
         quiet = "" if send_notifications else "--quiet",
-        s3_bucket = config["s3_dst"]
+        s3_bucket = config["s3_dst"],
+        cloudfront_domain = config.get("cloudfront_domain", "")
     run:
         for remote, local in input.items():
-            shell("./bin/upload-to-s3 {params.quiet} {local:q} {params.s3_bucket:q}/{remote:q}")
+            shell("./bin/upload-to-s3 {params.quiet} {local:q} {params.s3_bucket:q}/{remote:q} {params.cloudfront_domain}")
 
 rule transform_biosample:
     input:
@@ -420,10 +421,11 @@ rule upload:
         touch(f"data/{database}/upload.done")
     params:
         quiet = "" if send_notifications else "--quiet",
-        s3_bucket = config["s3_dst"]
+        s3_bucket = config["s3_dst"],
+        cloudfront_domain = config.get("cloudfront_domain", "")
     run:
         for remote, local in input.items():
-            shell("./bin/upload-to-s3 {params.quiet} {local:q} {params.s3_bucket:q}/{remote:q}")
+            shell("./bin/upload-to-s3 {params.quiet} {local:q} {params.s3_bucket:q}/{remote:q} {params.cloudfront_domain}")
 
 
 rule trigger_rebuild_pipeline:

--- a/bin/cloudfront-invalidate
+++ b/bin/cloudfront-invalidate
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Originally from @tsibley's gist: https://gist.github.com/tsibley/a66262d341dedbea39b02f27e2837ea8
+set -euo pipefail
+
+main() {
+    local domain="$1"
+    shift
+    local paths=("$@")
+    local distribution invalidation
+
+    echo "-> Finding CloudFront distribution"
+    distribution=$(
+        aws cloudfront list-distributions \
+            --query "DistributionList.Items[?contains(Aliases.Items, \`$domain\`)] | [0].Id" \
+            --output text
+    )
+
+    if [[ -z $distribution || $distribution == None ]]; then
+        exec >&2
+        echo "Unable to find CloudFront distribution id for $domain"
+        echo
+        echo "Are your AWS CLI credentials for the right account?"
+        exit 1
+    fi
+
+    echo "-> Creating CloudFront invalidation for distribution $distribution"
+    invalidation=$(
+        aws cloudfront create-invalidation \
+            --distribution-id "$distribution" \
+            --paths "${paths[@]}" \
+            --query Invalidation.Id \
+            --output text
+    )
+
+    echo "-> Waiting for CloudFront invalidation $invalidation to complete"
+    echo "   Ctrl-C to stop waiting."
+    aws cloudfront wait invalidation-completed \
+        --distribution-id "$distribution" \
+        --id "$invalidation"
+}
+
+main "$@"

--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -18,6 +18,7 @@ main() {
 
     local src="${1:?A source file is required as the first argument.}"
     local dst="${2:?A destination s3:// URL is required as the second argument.}"
+    local cloudfront_domain="${3:-}"
 
     local s3path="${dst#s3://}"
     local bucket="${s3path%%/*}"
@@ -36,6 +37,13 @@ main() {
         else
             cat "$src"
         fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash" "$(content-type "$dst")"
+
+        if [[ -n $cloudfront_domain ]]; then
+            echo "Creating CloudFront invalidation for $cloudfront_domain/$key"
+            if ! "$bin"/cloudfront-invalidate "$cloudfront_domain" "/$key"; then
+                echo "CloudFront invalidation failed, but exiting with success anyway."
+            fi
+        fi
 
         if [[ $quiet == 1 ]]; then
             echo "Quiet mode. No Slack notification sent."

--- a/config/genbank.yaml
+++ b/config/genbank.yaml
@@ -6,5 +6,6 @@ trigger_counts: false
 
 s3_src: "s3://nextstrain-data/files/ncov/open"
 s3_dst: "s3://nextstrain-data/files/ncov/open"
+cloudfront_domain: "data.nextstrain.org"
 
 keep_all_files: False


### PR DESCRIPTION
Invalidate CloudFront after file has been uploaded to S3 so that we serve latest file at data.nextstrain.org.

(Adding the same CloudFront invalidation in [monkeypox/ingest](https://github.com/nextstrain/monkeypox/pull/52))