### PR TITLE
Fix incorrect remote filename for biosample.ndjson.gz

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -81,8 +81,8 @@ rule download_biosample:
     message:
         """Obtaining Biosample data (GenBank only)"""
     params:
-        file_on_s3_dst = config["s3_dst"] + '/biosample.ndjson.xz',
-        file_on_s3_src = config["s3_src"] + '/biosample.ndjson.xz',
+        file_on_s3_dst = config["s3_dst"] + '/biosample.ndjson.gz',
+        file_on_s3_src = config["s3_src"] + '/biosample.ndjson.gz',
     output:
         biosample = "data/biosample.ndjson"
     run:


### PR DESCRIPTION
The "download_biosample" rule never found the remote file for download
when fetch_from_database=False because it was looking for the wrong
filename.  This mismatch has been present since the introduction of
Snakemake in ab59826.
