### PR TITLE
fix: remove unnecessary --output-basename nextclade param

### DIFF
--- a/bin/run-nextclade
+++ b/bin/run-nextclade
@@ -58,7 +58,6 @@ echo "[ INFO] ${0}:${LINENO}: Running Nextclade"
   --output-tsv="${OUTPUT_TSV}" \
   --genes="${GENES}" \
   --output-translations="${NEXTCLADE_OUTPUTS_DIR}/nextclade.gene.{gene}.fasta" \
-  --output-basename="nextclade" \
   --output-fasta="${OUTPUT_FASTA}" \
   --output-insertions="${OUTPUT_INSERTIONS}" \
   ${NEXTCLADE_THREADS}


### PR DESCRIPTION
### Description of proposed changes

Removes `--output-basename` which is not needed

### Related issue(s)

Followup of #319
