### PR TITLE
feat: allow reverse complemented sequences to be aligned

### DIFF
--- a/bin/run-nextclade
+++ b/bin/run-nextclade
@@ -57,12 +57,13 @@ echo "[ INFO] ${0}:${LINENO}: Downloading Nextclade dataset \"sars-cov-2\""
 echo "[ INFO] ${0}:${LINENO}: Running Nextclade"
 ./nextclade run \
   "${INPUT_FASTA}" \
+  --retry-reverse-complement \
   --in-order \
   --verbosity=error \
   --input-dataset="${NEXTCLADE_DATASET_DIR}" \
   --output-tsv="${OUTPUT_TSV}" \
   --genes="${GENES}" \
   --output-translations="${NEXTCLADE_OUTPUTS_DIR}/nextclade.gene.{gene}.fasta" \
-  --output-fasta="${OUTPUT_FASTA}" \
+  --output-fasta=- \
   --output-insertions="${OUTPUT_INSERTIONS}" \
-  ${NEXTCLADE_THREADS}
+  "${NEXTCLADE_THREADS}" | seqkit seq -i >"${OUTPUT_FASTA}" #seqkit seq -i removes (reverse complemented) from the sequence names

--- a/bin/run-nextclade
+++ b/bin/run-nextclade
@@ -12,23 +12,21 @@ trap "exit" INT
 : "${3:?\"[ERROR] ${0}: Directory for Nextclade input data as the 3rd argument is required.\"}"
 : "${4:?\"[ERROR] ${0}: Output directory as the 4th argument is required.\"}"
 : "${5:?\"[ERROR] ${0}: Output fasta filename as the 5th argument is required.\"}"
-: "${6:?\"[ERROR] ${0}: Output insertions csv filename as the 6th argument is required.\"}"
-: "${7:?\"[ERROR] ${0}: List of genes as 7th argument is required.\"}"
-# Note: 8th argument is the (max) number of threads for nextclade and is optional
+: "${6:?\"[ERROR] ${0}: List of genes as 6th argument is required.\"}"
+# Note: 7th argument is the (max) number of threads for nextclade and is optional
 
 INPUT_FASTA="${1}"
 OUTPUT_TSV="${2}"
 NEXTCLADE_DATASET_DIR="${3}" # external data required for nextclade to function will be downloaded there
 NEXTCLADE_OUTPUTS_DIR="${4}" # files other than TSV will be written by Nextclade there (aligned sequences, peptides, etc.)
 OUTPUT_FASTA="${5}"
-OUTPUT_INSERTIONS="${6}"
-GENES="${7}"
+GENES="${6}"
 
 NEXTCLADE_THREADS=""
-if [ $# -eq 8 ]; then
-    echo "[ INFO] ${0}:${LINENO}: Nextclade will be limited to ${8} threads"
-    NEXTCLADE_THREADS="--jobs ${8}"
-elif [ $# -gt 8 ]; then
+if [ $# -eq 7 ]; then
+    echo "[ INFO] ${0}:${LINENO}: Nextclade will be limited to ${7} threads"
+    NEXTCLADE_THREADS="--jobs ${7}"
+elif [ $# -gt 7 ]; then
     echo "[ INFO] ${0}:${LINENO}: Too many arguments provided"
     exit 1
 fi
@@ -63,7 +61,5 @@ echo "[ INFO] ${0}:${LINENO}: Running Nextclade"
   --input-dataset="${NEXTCLADE_DATASET_DIR}" \
   --output-tsv="${OUTPUT_TSV}" \
   --genes="${GENES}" \
-  --output-translations="${NEXTCLADE_OUTPUTS_DIR}/nextclade.gene.{gene}.fasta" \
   --output-fasta=- \
-  --output-insertions="${OUTPUT_INSERTIONS}" \
   "${NEXTCLADE_THREADS}" | seqkit seq -i >"${OUTPUT_FASTA}" #seqkit seq -i removes (reverse complemented) from the sequence names

--- a/bin/run-nextclade-full
+++ b/bin/run-nextclade-full
@@ -24,7 +24,7 @@ disk_info() {
   lsblk -o MOUNTPOINT,FSSIZE,FSAVAIL,TYPE,NAME,ROTA,SIZE,MODEL || true
 
   echo "[ INFO] ${0}:${LINENO}: Summary of disk space usage:"
-  df -Th  || true | awk 'NR == 1; NR > 1 {print $0 | "sort -n"}'
+  df -Th || true | awk 'NR == 1; NR > 1 {print $0 | "sort -n"}'
 
   echo "[ INFO] ${0}:${LINENO}: Summary of occupied disk space:"
   du -bsch ./* 2>/dev/null || true | sort -h
@@ -121,12 +121,14 @@ main() {
   "${NEXTCLADE_BIN}" run \
     "${INPUT_FASTA}" \
     --jobs="${N_PROCESSORS}" \
+    --retry-reverse-complement \
     --in-order \
     --verbosity=error \
     --input-dataset="${TMP_DIR_NEXTCLADE_DATASET}" \
     --genes="${GENES}" \
     --output-tsv="${OUTPUT_TSV}" \
-    --output-fasta="${OUTPUT_FASTA}" \
+    --output-fasta=- |
+    seqkit seq -i >"${OUTPUT_FASTA}" #seqkit seq -i removes (reverse complemented) from the sequence names
 
   echo "[ INFO] ${0}:${LINENO}: Upload results"
   ./bin/upload-to-s3 ${silent:+--quiet} "${OUTPUT_TSV}" "$S3_DST/nextclade.tsv.gz"

--- a/workflow/snakemake_rules/nextclade.smk
+++ b/workflow/snakemake_rules/nextclade.smk
@@ -119,7 +119,6 @@ rule run_nextclade:
     output:
         info = f"data/{database}/nextclade_new.tsv",
         alignment = temp(f"data/{database}/nextclade.aligned.upd.fasta"),
-        insertions = temp(f"data/{database}/nextclade.insertions.csv")
     shell:
         """
         ./bin/run-nextclade \
@@ -128,7 +127,6 @@ rule run_nextclade:
             {params.nextclade_input_dir} \
             {params.nextclade_output_dir} \
             {output.alignment} \
-            {output.insertions} \
             {GENES}
         """
 


### PR DESCRIPTION
Allow reverse complemented sequences to be aligned - who knows, maybe there are some.

We should maybe do a full run with this setting on and see what happens before we invest time into adding a `is_reverse_complemented` column that may not be needed

### Tests

- Full run genbank: `fd6edce8-7f2d-413f-84d5-98b414d5a042`