### PR TITLE
transform-genbank: update COG-UK metadata link

### DIFF
--- a/bin/transform-genbank
+++ b/bin/transform-genbank
@@ -178,7 +178,7 @@ if __name__ == '__main__':
                               | MergeUserAnnotatedMetadata(annotations, idKey = 'genbank_accession' )
                               | MergeUserAnnotatedMetadata(accessions, idKey = 'genbank_accession_rev' )
                               | FillDefaultLocationData()
-                              | patchUKData("https://cog-uk.s3.climb.ac.uk/accessions/latest.tsv", "https://cog-uk.s3.climb.ac.uk/phylogenetics/latest/cog_metadata.csv")
+                              | patchUKData("https://cog-uk.s3.climb.ac.uk/accessions/latest.tsv", "https://cog-uk.s3.climb.ac.uk/phylogenetics/latest/cog_metadata.csv.gz")
                               | GenbankProblematicFilter( args.problem_data,
                                                           ['genbank_accession', 'strain', 'region', 'country', 'url'],
                                                           restval = '?' ,


### PR DESCRIPTION
Update the link for the COG-UK metadata file because the COG-UK Data
site¹ now points to a gzipped metadata CSV file.

¹ https://data.covid19.climb.ac.uk/


### Testing
- [x] Test build running on [AWS Batch](https://us-east-1.console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/b9ecdb0e-d36a-4d01-9c4f-28d5dbac40c0)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
