### PR TITLE
Restore `notify-on-record-change`

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -37,7 +37,10 @@ if config.get("s3_dst"):
 # and the `s3_src` is provided in config since some notify scripts depend
 # do diffs with files on S3 from previous runs
 if send_notifications and config.get("s3_src"):
-    all_targets.append(f"data/{database}/notify.done")
+    all_targets.extend([
+        f"data/{database}/notify-on-record-change.done",
+        f"data/{database}/notify.done"
+    ])
 
 rule all:
     input: all_targets

--- a/workflow/snakemake_rules/slack_notifications.smk
+++ b/workflow/snakemake_rules/slack_notifications.smk
@@ -9,17 +9,32 @@ All rules here require two environment variables:
 
 Expects different inputs for GISAID vs GenBank:
     GISAID:
+        ndjson = "data/gisaid.ndjson"
         flagged_annotations = "data/gisaid/flagged-annotations"
         additional_info = "data/gisaid/additional_info.tsv"
         flagged_metadata = "data/gisaid/flagged_metadata.txt"
     GenBank:
+        ndjson = "data/gisaid.ndjson"
         flagged_annotations = "data/genbank/flagged-annotations"
         duplicate_biosample = "data/genbank/duplicate_biosample.txt"
 
 Produces the output file as:
+    "data/{database}/notify-on-record-change.done"
     "data/{database}/notify.done"
 The output files is an empty flag file to force Snakemake to run the notify rules.
 """
+rule notify_on_record_change:
+    input:
+        ndjson = f"data/{database}.ndjson"
+    params:
+        ndjson_on_s3 = f"{config['s3_src']}/{database}.ndjson.xz"
+    output:
+        touch(f"data/{database}/notify-on-record-change.done")
+    shell:
+        """
+        ./bin/notify-on-record-change {input.ndjson} {params.ndjson_on_s3} {database}
+        """
+
 
 rule notify_gisaid:
     input:


### PR DESCRIPTION
This notification got lost in the changes in a18dde58eee3830a939cd5fed21accb03c6db3f2.
Restore the notification on record changes as a separate rule that can
run after the database fetch has completed.


