### PR TITLE
Fix COG-UK fetches

### DIFF
--- a/bin/fetch-from-cog-uk-accessions
+++ b/bin/fetch-from-cog-uk-accessions
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+curl "https://cog-uk.s3.climb.ac.uk/accessions/latest.tsv" \
+    --fail --silent --show-error --http1.1 \
+    --header 'User-Agent: https://github.com/nextstrain/ncov-ingest (hello@nextstrain.org)'

--- a/bin/fetch-from-cog-uk-metadata
+++ b/bin/fetch-from-cog-uk-metadata
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+curl "https://cog-uk.s3.climb.ac.uk/phylogenetics/latest/cog_metadata.csv.gz" \
+    --fail --silent --show-error --http1.1 \
+    --header 'User-Agent: https://github.com/nextstrain/ncov-ingest (hello@nextstrain.org)'

--- a/bin/transform-genbank
+++ b/bin/transform-genbank
@@ -73,6 +73,12 @@ if __name__ == '__main__':
         default=base / "data/genbank/biosample.tsv",
         help="Optional BioSample metadata TSV.\n"
             "The TSV file should be the output of `transform-biosample.py`")
+    parser.add_argument("--cog-uk-accessions",
+        default="https://cog-uk.s3.climb.ac.uk/accessions/latest.tsv",
+        help="The COG-UK sample accessions linkage TSV to help link COG-UK metadata with BioSample metadata.")
+    parser.add_argument("--cog-uk-metadata",
+        default="https://cog-uk.s3.climb.ac.uk/phylogenetics/latest/cog_metadata.csv.gz",
+        help="The COG-UK metadata CSV.")
     parser.add_argument("--output-metadata",
         default=base / "data/genbank/metadata.tsv",
         help="Output location of generated metadata tsv. Defaults to `data/genbank/metadata.tsv`")
@@ -178,7 +184,7 @@ if __name__ == '__main__':
                               | MergeUserAnnotatedMetadata(annotations, idKey = 'genbank_accession' )
                               | MergeUserAnnotatedMetadata(accessions, idKey = 'genbank_accession_rev' )
                               | FillDefaultLocationData()
-                              | patchUKData("https://cog-uk.s3.climb.ac.uk/accessions/latest.tsv", "https://cog-uk.s3.climb.ac.uk/phylogenetics/latest/cog_metadata.csv.gz")
+                              | patchUKData(args.cog_uk_accessions, args.cog_uk_metadata)
                               | GenbankProblematicFilter( args.problem_data,
                                                           ['genbank_accession', 'strain', 'region', 'country', 'url'],
                                                           restval = '?' ,

--- a/workflow/snakemake_rules/curate.smk
+++ b/workflow/snakemake_rules/curate.smk
@@ -36,7 +36,9 @@ rule transform_biosample:
 rule transform_genbank_data:
     input:
         biosample = "data/genbank/biosample.tsv",
-        ndjson = "data/genbank.ndjson"
+        ndjson = "data/genbank.ndjson",
+        cog_uk_accessions = "data/cog_uk_accessions.tsv",
+        cog_uk_metadata = "data/cog_uk_metadata.csv.gz"
     output:
         fasta = "data/genbank/sequences.fasta",
         metadata = "data/genbank/metadata_transformed.tsv",
@@ -47,6 +49,8 @@ rule transform_genbank_data:
         ./bin/transform-genbank {input.ndjson} \
             --biosample {input.biosample} \
             --duplicate-biosample {output.duplicate_biosample} \
+            --cog-uk-accessions {input.cog_uk_accessions} \
+            --cog-uk-metadata {input.cog_uk_metadata} \
             --output-metadata {output.metadata} \
             --output-fasta {output.fasta} > {output.flagged_annotations}
         """

--- a/workflow/snakemake_rules/fetch_sequences.smk
+++ b/workflow/snakemake_rules/fetch_sequences.smk
@@ -116,8 +116,8 @@ if config.get("s3_dst") and config.get("s3_src"):
         message:
             """Fetching BioSample NDJSON from AWS S3"""
         params:
-            file_on_s3_dst= f"{config['s3_dst']}/{database}.ndjson.gz",
-            file_on_s3_src= f"{config['s3_src']}/{database}.ndjson.gz"
+            file_on_s3_dst= f"{config['s3_dst']}/biosample.ndjson.gz",
+            file_on_s3_src= f"{config['s3_src']}/biosample.ndjson.gz"
         output:
             biosample = temp("data/biosample.ndjson")
         shell:

--- a/workflow/snakemake_rules/fetch_sequences.smk
+++ b/workflow/snakemake_rules/fetch_sequences.smk
@@ -13,6 +13,8 @@ Produces different final outputs for GISAID vs GenBank:
     GenBank:
         ndjson = "data/genbank.ndjson"
         biosample = "data/biosample.ndjson"
+        cog_uk_accessions = "data/cog_uk_accessions.tsv"
+        cog_uk_metadata = "data/cog_uk_metadata.csv.gz"
 """
 
 def run_shell_command_n_times(cmd, msg, cleanup_failed_cmd, retry_num=5):
@@ -57,6 +59,30 @@ rule fetch_biosample:
             f"./bin/fetch-from-biosample > {output.biosample}",
             "Fetch BioSample",
             f"rm {output.biosample}"
+        )
+
+rule fetch_cog_uk_accessions:
+    message:
+        """Fetching COG-UK sample accesions (GenBank only)"""
+    output:
+        cog_uk_accessions = temp("data/cog_uk_accessions.tsv")
+    run:
+        run_shell_command_n_times(
+            f"./bin/fetch-from-cog-uk-accessions > {output.cog_uk_accessions}",
+            "Fetch COG-UK sample accessions",
+            f"rm {output.cog_uk_accessions}"
+        )
+
+rule fetch_cog_uk_metadata:
+    message:
+        """Fetching COG-UK metadata (GenBank only)"""
+    output:
+        cog_uk_metadata = temp("data/cog_uk_metadata.csv.gz")
+    run:
+        run_shell_command_n_times(
+            f"./bin/fetch-from-cog-uk-metadata > {output.cog_uk_metadata}",
+            "Fetch COG-UK metadata",
+            f"rm {output.cog_uk_metadata}"
         )
 
 # Only include rules to fetch from S3 if S3 config params are provided


### PR DESCRIPTION
### Description of proposed changes
Since September 4th 2022, we've had multiple failures fetching the
COG-UK files where the connection was closed early by the server.

This PR tries to mitigate these errors by separating the fetch of COG-UK data from the transform script. 
Now the fetch occurs in a separate Snakemake rule that can retry the fetch multiple times. 

### Testing
See test run via [GitHub Actions](https://github.com/nextstrain/ncov-ingest/actions/runs/3040130723). 
[Test run completed successfully on AWS](https://us-east-1.console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/c3cb4626-2391-4c52-9e84-9f298e91d3e7), with resulting files uploaded to `s3://nextstrain-staging/files/ncov/open/branch/fix-cog-uk/`
<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
