### PR TITLE
Add zstd uploads

### DIFF
--- a/bin/download-from-s3
+++ b/bin/download-from-s3
@@ -22,6 +22,8 @@ main() {
             gunzip -cfq
         elif  [[ "$src" == *.xz ]]; then
             xz -T0 -dcq
+        elif [[ "$src" == *.zst ]]; then
+            zstd -T0 -dcq
         else
             cat
         fi > "$dst"

--- a/bin/local-ingest-gisaid
+++ b/bin/local-ingest-gisaid
@@ -163,6 +163,12 @@ upload-outputs() {
   ./bin/upload-to-s3 "${OUTPUT_DIR}/additional_info.tsv" "${S3_BUCKET}/additional_info.tsv.gz"
   ./bin/upload-to-s3 "${OUTPUT_DIR}/flagged_metadata.txt" "${S3_BUCKET}/flagged_metadata.txt.gz"
   ./bin/upload-to-s3 "${OUTPUT_DIR}/sequences.fasta" "${S3_BUCKET}/sequences.fasta.xz"
+
+  # Parallel uploads of zstd compressed files to slowly transition to this format
+  ./bin/upload-to-s3 "${OUTPUT_DIR}/metadata.tsv" "${S3_BUCKET}/metadata.tsv.zst"
+  ./bin/upload-to-s3 "${OUTPUT_DIR}/additional_info.tsv" "${S3_BUCKET}/additional_info.tsv.zst"
+  ./bin/upload-to-s3 "${OUTPUT_DIR}/flagged_metadata.txt" "${S3_BUCKET}/flagged_metadata.txt.zst"
+  ./bin/upload-to-s3 "${OUTPUT_DIR}/sequences.fasta" "${S3_BUCKET}/sequences.fasta.zst"
 }
 
 print-help() {

--- a/bin/run-nextclade-full
+++ b/bin/run-nextclade-full
@@ -132,6 +132,10 @@ main() {
   ./bin/upload-to-s3 ${silent:+--quiet} "${OUTPUT_TSV}" "$S3_DST/nextclade.tsv.gz"
   ./bin/upload-to-s3 ${silent:+--quiet} "${OUTPUT_FASTA}" "$S3_DST/aligned.fasta.xz"
 
+  # Parallel uploads of zstd compressed files to slowly transition to this format
+  ./bin/upload-to-s3 ${silent:+--quiet} "${OUTPUT_TSV}" "$S3_DST/nextclade.tsv.zst"
+  ./bin/upload-to-s3 ${silent:+--quiet} "${OUTPUT_FASTA}" "$S3_DST/aligned.fasta.zst"
+
   # Cut the running time by deleting working directory and avoiding zipping it.
   # We are unlikely to inspect it anyways. But keep the TSV result file, just in
   # case.

--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -37,6 +37,8 @@ main() {
             gzip -c "$src"
         elif  [[ "$dst" == *.xz ]]; then
             xz -2 -T0 -c "$src"
+        elif [[ "$dst" == *.zst ]]; then
+            zstd -T0 -c "$src"
         else
             cat "$src"
         fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash",recordcount="$src_record_count" "$(content-type "$dst")"
@@ -68,6 +70,7 @@ content-type() {
         *.ndjson)   echo --content-type=application/x-ndjson;;
         *.gz)       echo --content-type=application/gzip;;
         *.xz)       echo --content-type=application/x-xz;;
+        *.zst)      echo --content-type=application/zstd;;
         *)          echo --content-type=text/plain;;
     esac
 }

--- a/workflow/snakemake_rules/upload.smk
+++ b/workflow/snakemake_rules/upload.smk
@@ -9,12 +9,18 @@ Produces the following outputs:
     "data/{database}/raw.upload.done"
     "data/{database}/upload.done"
 These output files are empty flag files to force Snakemake to run the upload rules.
+
+Note: we are doing parallel uploads of zstd compressed files to slowly make the transition to this format.
 """
 
-raw_files_to_upload = {f"{database}.ndjson.xz": f"data/{database}.ndjson"}
+raw_files_to_upload = {
+    f"{database}.ndjson.xz": f"data/{database}.ndjson",
+    f"{database}.ndjson.zst": f"data/{database}.ndjson",
+}
 
 if database=="genbank":
     raw_files_to_upload["biosample.ndjson.gz"] = f"data/biosample.ndjson"
+    raw_files_to_upload["biosample.ndjson.zst"] = f"data/biosample.ndjson"
 
 rule upload_raw_ndjson:
     input:
@@ -32,19 +38,30 @@ rule upload_raw_ndjson:
 def compute_files_to_upload(wildcards):
     files_to_upload = {
                         "metadata.tsv.gz":              f"data/{database}/metadata.tsv",
-                        "sequences.fasta.xz":           f"data/{database}/sequences.fasta"}
+                        "sequences.fasta.xz":           f"data/{database}/sequences.fasta",
+
+                        "metadata.tsv.zst":             f"data/{database}/metadata.tsv",
+                        "sequences.fasta.zst":          f"data/{database}/sequences.fasta"}
     if database=="genbank":
         files_to_upload["biosample.tsv.gz"] =           f"data/{database}/biosample.tsv"
         files_to_upload["duplicate_biosample.txt.gz"] = f"data/{database}/duplicate_biosample.txt"
+
+        files_to_upload["biosample.tsv.zst"] =           f"data/{database}/biosample.tsv"
+        files_to_upload["duplicate_biosample.txt.zst"] = f"data/{database}/duplicate_biosample.txt"
     elif database=="gisaid":
         files_to_upload["additional_info.tsv.gz"] =     f"data/{database}/additional_info.tsv"
         files_to_upload["flagged_metadata.txt.gz"] =    f"data/{database}/flagged_metadata.txt"
+
+        files_to_upload["additional_info.tsv.zst"] =     f"data/{database}/additional_info.tsv"
+        files_to_upload["flagged_metadata.txt.zst"] =    f"data/{database}/flagged_metadata.txt"
 
     nextclade_sequences_path = checkpoints.get_sequences_without_nextclade_annotations.get().output.fasta
     if os.path.getsize(nextclade_sequences_path) > 0:
         files_to_upload["nextclade.tsv.gz"] =           f"data/{database}/nextclade.tsv"
         files_to_upload["aligned.fasta.xz"] =           f"data/{database}/aligned.fasta"
 
+        files_to_upload["nextclade.tsv.zst"] =           f"data/{database}/nextclade.tsv"
+        files_to_upload["aligned.fasta.zst"] =           f"data/{database}/aligned.fasta"
     return files_to_upload
 
 


### PR DESCRIPTION
### Description of proposed changes
Adds parallel uploads of zstd compressed files to S3 to slowly transition to this new format. 

### Related issue(s)
Resolves #341 

### Testing
~Doing a test run for GISAID on AWS Batch (job id: [fe39ec01-6b29-4939-b01d-cddd06316b8f](https://us-east-1.console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/fe39ec01-6b29-4939-b01d-cddd06316b8f)).~
Terminated the test because it was run without `zstd` in the `nextstrain:ncov-ingest` image. 
Files will get uploaded to `s3://nextstrain-ncov-private/branch/add-zstd-uploads/*`

(Shellcheck is currently failing due to snapcraft [being down](https://status.snapcraft.io/#/incident/Mds09Y8Kj0kJNmn3a_u1nPaVwxBNLQAAaQJxwfyy_0ubP4ozzrxr7Ds3oC_21hV6RqJxCljbe0A5QlZIwo4dQw==)) 
<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
