### PR TITLE
Restore automatic running of the update-image workflow for branches

### DIFF
--- a/.github/workflows/update-image.yml
+++ b/.github/workflows/update-image.yml
@@ -2,6 +2,8 @@ name: Update image
 
 on:
   push:
+    branches:
+      - '**'
     tags-ignore:
       - '**'
     paths:


### PR DESCRIPTION
When "Build and push nextstrain/ncov-ingest:branch-* images" (17e9d54) removed the restriction of the workflow to the "master" branch by removing the "branches" key, it inadvertently had the opposite effect: instead of allowing the workflow to run on every branch push, it ran on no branch pushes (_and_ also no tag pushes).  This is because, per GitHub Actions documentation¹:

> If you define only tags/tags-ignore or only branches/branches-ignore,
> the workflow won't run for events affecting the undefined Git ref. If
> you define neither tags/tags-ignore or branches/branches-ignore, the
> workflow will run for events affecting either branches or tags.

Since this is a bit unintuitive, specify both "branches" and "tags-ignore" to be explicit about what we run on.

¹ https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore

