### PR TITLE
feat: accept compressed input in bin/upload-to-s3

### DIFF
--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -41,17 +41,30 @@ main() {
         dst_filename="${dst_filename%.*}"
 
         echo "Uploading $src → $dst"
-        if [[ "$src_extension" != "$dst_extension" ]]; then
-            cat "$src"
-        elif [[ "$dst" == *.gz ]]; then
-            gzip -c "$src"
-        elif [[ "$dst" == *.xz ]]; then
-            xz -2 -T0 -c "$src"
-        elif [[ "$dst" == *.zst ]]; then
-            zstd -T0 -c "$src"
+
+        if [[ "$src_extension" == "$dst_extension" ]]; then
+            aws s3 cp --no-progress "$src" "$dst" --metadata sha256sum="$src_hash",recordcount="$src_record_count" "$(content-type "$dst")"cat "$src"
         else
-            cat "$src"
-        fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash",recordcount="$src_record_count" "$(content-type "$dst")"
+            # Uncompress input if compressed
+            if "$src" == "*.gz"; then
+                gunzip -c
+            elif [[ "$dst" == *.xz ]]; then
+                xz --decompress -c
+            elif [[ "$dst" == *.zst ]]; then
+                zstdcat -c
+            else
+                cat
+            fi "$src" | \
+            if [[ "$dst" == *.gz ]]; then
+                gzip -c
+            elif [[ "$dst" == *.xz ]]; then
+                xz -2 -T0 -c
+            elif [[ "$dst" == *.zst ]]; then
+                zstd -T0 -c
+            else
+                cat
+            fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash",recordcount="$src_record_count" "$(content-type "$dst")"
+        fi
 
         if [[ -n $cloudfront_domain ]]; then
             echo "Creating CloudFront invalidation for $cloudfront_domain/$key"

--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -25,20 +25,32 @@ main() {
     local key="${s3path#*/}"
 
     local src_hash dst_hash no_hash=0000000000000000000000000000000000000000000000000000000000000000
-    src_hash="$("$bin/sha256sum" < "$src")"
+    src_hash="$("$bin/sha256sum" <"$src")"
     dst_hash="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
 
     if [[ $src_hash != "$dst_hash" ]]; then
         # The record count may have changed
-        src_record_count="$(wc -l < "$src")"
+        src_record_count="$(wc -l <"$src")"
+
+        local src_filename=$(basename -- "$src")
+        local src_extension="${src_filename##*.}"
+        local src_filename="${src_filename%.*}"
+
+        local dst_filename=$(basename -- "$dst")
+        local dst_extension="${dst_filename##*.}"
+        local dst_filename="${dst_filename%.*}"
 
         echo "Uploading $src → $dst"
-        if [[ "$dst" == *.gz ]]; then
-            gzip -c "$src"
-        elif  [[ "$dst" == *.xz ]]; then
-            xz -2 -T0 -c "$src"
-        elif [[ "$dst" == *.zst ]]; then
-            zstd -T0 -c "$src"
+        if [[ "$src_extension" != "$dst_extension" ]]; then
+            if [[ "$dst" == *.gz ]]; then
+                gzip -c "$src"
+            elif [[ "$dst" == *.xz ]]; then
+                xz -2 -T0 -c "$src"
+            elif [[ "$dst" == *.zst ]]; then
+                zstd -T0 -c "$src"
+            else
+                cat "$src"
+            fi
         else
             cat "$src"
         fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash",recordcount="$src_record_count" "$(content-type "$dst")"

--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -42,15 +42,13 @@ main() {
 
         echo "Uploading $src → $dst"
         if [[ "$src_extension" != "$dst_extension" ]]; then
-            if [[ "$dst" == *.gz ]]; then
-                gzip -c "$src"
-            elif [[ "$dst" == *.xz ]]; then
-                xz -2 -T0 -c "$src"
-            elif [[ "$dst" == *.zst ]]; then
-                zstd -T0 -c "$src"
-            else
-                cat "$src"
-            fi
+            cat "$src"
+        elif [[ "$dst" == *.gz ]]; then
+            gzip -c "$src"
+        elif [[ "$dst" == *.xz ]]; then
+            xz -2 -T0 -c "$src"
+        elif [[ "$dst" == *.zst ]]; then
+            zstd -T0 -c "$src"
         else
             cat "$src"
         fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash",recordcount="$src_record_count" "$(content-type "$dst")"

--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -32,13 +32,13 @@ main() {
         # The record count may have changed
         src_record_count="$(wc -l <"$src")"
 
-        local src_filename=$(basename -- "$src")
-        local src_extension="${src_filename##*.}"
-        local src_filename="${src_filename%.*}"
+        src_filename=$(basename -- "$src")
+        src_extension="${src_filename##*.}"
+        src_filename="${src_filename%.*}"
 
-        local dst_filename=$(basename -- "$dst")
-        local dst_extension="${dst_filename##*.}"
-        local dst_filename="${dst_filename%.*}"
+        dst_filename=$(basename -- "$dst")
+        dst_extension="${dst_filename##*.}"
+        dst_filename="${dst_filename%.*}"
 
         echo "Uploading $src → $dst"
         if [[ "$src_extension" != "$dst_extension" ]]; then


### PR DESCRIPTION
Right now, compression takes up most of the time in ingest.

It would hence be good to start compression as soon as possible, e.g. as soon as nextclade outputs sequences in full run.

We could output sequences from nextclade to stdout and then compress directly with xz. So that Nextclade and compression can run in parallel.

However, at the moment, `upload-to-s3` accepts uncompressed inputs only. This PR adds logic to skip compression when the input to `upload-to-s3` is already compressed by comparing extensions of `src` and `dst`
