### PR TITLE
Combined PRs #351 and #352

### DIFF
--- a/bin/run-nextclade-full
+++ b/bin/run-nextclade-full
@@ -24,7 +24,7 @@ disk_info() {
   lsblk -o MOUNTPOINT,FSSIZE,FSAVAIL,TYPE,NAME,ROTA,SIZE,MODEL || true
 
   echo "[ INFO] ${0}:${LINENO}: Summary of disk space usage:"
-  df -Th  || true | awk 'NR == 1; NR > 1 {print $0 | "sort -n"}'
+  df -Th || true | awk 'NR == 1; NR > 1 {print $0 | "sort -n"}'
 
   echo "[ INFO] ${0}:${LINENO}: Summary of occupied disk space:"
   du -bsch ./* 2>/dev/null || true | sort -h
@@ -69,8 +69,8 @@ main() {
   S3_DST="$S3_SRC/nextclade-full-run-${DATE_UTC}"
 
   INPUT_FASTA="data/${DATABASE}/sequences.fasta.xz"
-  OUTPUT_FASTA="data/${DATABASE}/aligned.fasta"
-  OUTPUT_TSV="data/${DATABASE}/nextclade.tsv"
+  OUTPUT_FASTA="data/${DATABASE}/aligned.fasta.xz"
+  OUTPUT_TSV="data/${DATABASE}/nextclade.tsv.gz"
 
   TMP_DIR_NEXTCLADE_DATASET="tmp/dataset"
 
@@ -129,12 +129,18 @@ main() {
     --output-fasta="${OUTPUT_FASTA}" \
 
   echo "[ INFO] ${0}:${LINENO}: Upload results"
-  ./bin/upload-to-s3 ${silent:+--quiet} "${OUTPUT_TSV}" "$S3_DST/nextclade.tsv.gz"
-  ./bin/upload-to-s3 ${silent:+--quiet} "${OUTPUT_FASTA}" "$S3_DST/aligned.fasta.xz"
+  ./bin/upload-to-s3 ${silent:+--quiet} "${OUTPUT_TSV}" "$S3_DST/nextclade.tsv.gz" &
+  P1=$!
+  ./bin/upload-to-s3 ${silent:+--quiet} "${OUTPUT_FASTA}" "$S3_DST/aligned.fasta.xz" &
+  P2=$!
 
   # Parallel uploads of zstd compressed files to slowly transition to this format
-  ./bin/upload-to-s3 ${silent:+--quiet} "${OUTPUT_TSV}" "$S3_DST/nextclade.tsv.zst"
-  ./bin/upload-to-s3 ${silent:+--quiet} "${OUTPUT_FASTA}" "$S3_DST/aligned.fasta.zst"
+  ./bin/upload-to-s3 ${silent:+--quiet} "${OUTPUT_TSV}" "$S3_DST/nextclade.tsv.zst" &
+  P3=$!
+  ./bin/upload-to-s3 ${silent:+--quiet} "${OUTPUT_FASTA}" "$S3_DST/aligned.fasta.zst" &
+  P4=$!
+
+  wait $P1 $P2 $P3 $P4
 
   # Cut the running time by deleting working directory and avoiding zipping it.
   # We are unlikely to inspect it anyways. But keep the TSV result file, just in

--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -25,23 +25,46 @@ main() {
     local key="${s3path#*/}"
 
     local src_hash dst_hash no_hash=0000000000000000000000000000000000000000000000000000000000000000
-    src_hash="$("$bin/sha256sum" < "$src")"
+    src_hash="$("$bin/sha256sum" <"$src")"
     dst_hash="$(aws s3api head-object --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
 
     if [[ $src_hash != "$dst_hash" ]]; then
         # The record count may have changed
-        src_record_count="$(wc -l < "$src")"
+        src_record_count="$(wc -l <"$src")"
+
+        src_filename=$(basename -- "$src")
+        src_extension="${src_filename##*.}"
+        src_filename="${src_filename%.*}"
+
+        dst_filename=$(basename -- "$dst")
+        dst_extension="${dst_filename##*.}"
+        dst_filename="${dst_filename%.*}"
 
         echo "Uploading $src → $dst"
-        if [[ "$dst" == *.gz ]]; then
-            gzip -c "$src"
-        elif  [[ "$dst" == *.xz ]]; then
-            xz -2 -T0 -c "$src"
-        elif [[ "$dst" == *.zst ]]; then
-            zstd -T0 -c "$src"
+
+        if [[ "$src_extension" == "$dst_extension" ]]; then
+            aws s3 cp --no-progress "$src" "$dst" --metadata sha256sum="$src_hash",recordcount="$src_record_count" "$(content-type "$dst")"cat "$src"
         else
-            cat "$src"
-        fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash",recordcount="$src_record_count" "$(content-type "$dst")"
+            # Uncompress input if compressed
+            if "$src" == "*.gz"; then
+                gunzip -c
+            elif [[ "$dst" == *.xz ]]; then
+                xz --decompress -c
+            elif [[ "$dst" == *.zst ]]; then
+                zstdcat -c
+            else
+                cat
+            fi "$src" | \
+            if [[ "$dst" == *.gz ]]; then
+                gzip -c
+            elif [[ "$dst" == *.xz ]]; then
+                xz -2 -T0 -c
+            elif [[ "$dst" == *.zst ]]; then
+                zstd -T0 -c
+            else
+                cat
+            fi | aws s3 cp --no-progress - "$dst" --metadata sha256sum="$src_hash",recordcount="$src_record_count" "$(content-type "$dst")"
+        fi
 
         if [[ -n $cloudfront_domain ]]; then
             echo "Creating CloudFront invalidation for $cloudfront_domain/$key"


### PR DESCRIPTION
- feat: accept compressed input in bin/upload-to-s3
- Make logic simpler
- fix: shellcheck
- feat: let nextclade compress outputs, upload in parallel
- Uncompress input if necessary
