### PR TITLE
feat: speed up slow rule by using mv instead of cp

### DIFF
--- a/workflow/snakemake_rules/nextclade.smk
+++ b/workflow/snakemake_rules/nextclade.smk
@@ -156,9 +156,10 @@ rule combine_alignments:
     shell:
         """
         if [[ -s {input.old_alignment} ]]; then
-            cat {input.old_alignment} {input.new_alignment} > {output.alignment}
+            mv {input.old_alignment} {output.alignment}
+            cat {input.new_alignment} >> {output.alignment}
         else
-            cp {input.new_alignment} {output.alignment}
+            mv {input.new_alignment} {output.alignment}
         fi
         """
 


### PR DESCRIPTION
A rule that simply copies all aligned sequences currently takes 1hr - this seems to be due to slow write of the 300+ GB file.

This PR uses the faster `mv` in place of `cp`.