### PR TITLE
feat: scrap checkpoint and parallelize s3 uploads

### DIFF
--- a/workflow/snakemake_rules/nextclade.smk
+++ b/workflow/snakemake_rules/nextclade.smk
@@ -69,7 +69,7 @@ if config.get("s3_dst") and config.get("s3_src"):
             """
 
 
-checkpoint get_sequences_without_nextclade_annotations:
+rule get_sequences_without_nextclade_annotations:
     """Find sequences in FASTA which don't have clades assigned yet"""
     input:
         fasta = f"data/{database}/sequences.fasta",
@@ -162,25 +162,10 @@ rule combine_alignments:
         fi
         """
 
-def _get_nextclade_output(wildcards):
-    ## the nextclade metadata should represent the entire dataset. If there are new sequences
-    ## this has to be generated; if not then we can use the previous (cached) file.
-    nextclade_sequences_path = checkpoints.get_sequences_without_nextclade_annotations.get().output.fasta
-    output = {
-        "nextclade_tsv": f"data/{database}/nextclade_old.tsv",
-        "aligned_fasta": f"data/{database}/nextclade.aligned.old.fasta",
-    }
-    if os.path.getsize(nextclade_sequences_path) > 0:
-        # Return all two output files here so that they get pulled through
-        # the Snakemake DAG even if we are not uploading them to S3.
-        output["nextclade_tsv"] = f"data/{database}/nextclade.tsv"
-        output["aligned_fasta"] = f"data/{database}/aligned.fasta"
-
-    return output
-
 rule generate_metadata:
     input:
-        unpack(_get_nextclade_output),
+        nextclade_tsv = f"data/{database}/nextclade.tsv",
+        aligned_fasta = f"data/{database}/aligned.fasta",
         existing_metadata = f"data/{database}/metadata_transformed.tsv",
     output:
         metadata = f"data/{database}/metadata.tsv"

--- a/workflow/snakemake_rules/nextclade.smk
+++ b/workflow/snakemake_rules/nextclade.smk
@@ -103,7 +103,6 @@ rule run_nextclade:
     params:
         nextclade_input_dir = temp(directory(f"data/{database}/nextclade_inputs")),
         nextclade_output_dir = temp(directory(f"data/{database}/nextclade")),
-    threads: 64
     output:
         info = f"data/{database}/nextclade_new.tsv",
         alignment = temp(f"data/{database}/nextclade.aligned.upd.fasta"),
@@ -117,8 +116,7 @@ rule run_nextclade:
             {params.nextclade_output_dir} \
             {output.alignment} \
             {output.insertions} \
-            {GENES} \
-            {threads}
+            {GENES}
         """
 
 rule nextclade_info:

--- a/workflow/snakemake_rules/nextclade.smk
+++ b/workflow/snakemake_rules/nextclade.smk
@@ -139,7 +139,7 @@ rule nextclade_info:
                 {input.new_info:q} \
                 -o {output.nextclade_info:q}
         else
-            cp {input.new_info} {output.nextclade_info}
+            mv {input.new_info} {output.nextclade_info}
         fi
         """
 
@@ -156,9 +156,10 @@ rule combine_alignments:
     shell:
         """
         if [[ -s {input.old_alignment} ]]; then
-            cat {input.old_alignment} {input.new_alignment} > {output.alignment}
+            mv {input.old_alignment} {output.alignment}
+            cat {input.new_alignment} >> {output.alignment}
         else
-            cp {input.new_alignment} {output.alignment}
+            mv {input.new_alignment} {output.alignment}
         fi
         """
 

--- a/workflow/snakemake_rules/upload.smk
+++ b/workflow/snakemake_rules/upload.smk
@@ -41,7 +41,16 @@ def compute_files_to_upload(wildcards):
                         "sequences.fasta.xz":           f"data/{database}/sequences.fasta",
 
                         "metadata.tsv.zst":             f"data/{database}/metadata.tsv",
-                        "sequences.fasta.zst":          f"data/{database}/sequences.fasta"}
+                        "sequences.fasta.zst":          f"data/{database}/sequences.fasta",
+
+                        # It shouldn't harm to upload these as upload-to-s3 only updates if hashes differ
+                        "nextclade.tsv.gz":           f"data/{database}/nextclade.tsv",
+                        "aligned.fasta.xz":           f"data/{database}/aligned.fasta",
+
+                        "nextclade.tsv.zst":           f"data/{database}/nextclade.tsv",
+                        "aligned.fasta.zst":           f"data/{database}/aligned.fasta",
+                    }
+
     if database=="genbank":
         files_to_upload["biosample.tsv.gz"] =           f"data/{database}/biosample.tsv"
         files_to_upload["duplicate_biosample.txt.gz"] = f"data/{database}/duplicate_biosample.txt"
@@ -55,13 +64,6 @@ def compute_files_to_upload(wildcards):
         files_to_upload["additional_info.tsv.zst"] =     f"data/{database}/additional_info.tsv"
         files_to_upload["flagged_metadata.txt.zst"] =    f"data/{database}/flagged_metadata.txt"
 
-    nextclade_sequences_path = checkpoints.get_sequences_without_nextclade_annotations.get().output.fasta
-    if os.path.getsize(nextclade_sequences_path) > 0:
-        files_to_upload["nextclade.tsv.gz"] =           f"data/{database}/nextclade.tsv"
-        files_to_upload["aligned.fasta.xz"] =           f"data/{database}/aligned.fasta"
-
-        files_to_upload["nextclade.tsv.zst"] =           f"data/{database}/nextclade.tsv"
-        files_to_upload["aligned.fasta.zst"] =           f"data/{database}/aligned.fasta"
     return files_to_upload
 
 

--- a/workflow/snakemake_rules/upload.smk
+++ b/workflow/snakemake_rules/upload.smk
@@ -79,7 +79,6 @@ rule upload_single:
         quiet = "" if send_notifications else "--quiet",
         s3_bucket = config.get("s3_dst",""),
         cloudfront_domain = config.get("cloudfront_domain", ""),
-        local_filename = lambda wildcards: compute_files_to_upload(wildcards)[wildcards.remote_filename]
     shell:
         "./bin/upload-to-s3 {params.quiet} {input:q} {params.s3_bucket:q}/{wildcards.remote_filename:q} {params.cloudfront_domain}"
 


### PR DESCRIPTION
### Description of proposed changes

Uploads to s3 currently consume 6hr, which is about half of the total time taken by ingest.

The main reason for upload taking so long is that uploads are currently sequential.

This PR changes the Snakemake workflow to parallelize uploads. Uploads are done as soon as a file is ready.

I have also removed a checkpoint that does not seem to save any time: if I understand correctly the goal of the checkpoint is to avoid uploading a file if it is unchanged - but in our upload-to-s3 function we already check if the file is identical or not. If it is identical upload is skipped.

The checkpoint means uploads are deferred and the workflow is more complicated. It's cleaner snakemake without.

I tested the Snakefile in dry run mode and it seemed to work fine.

We can cut another hour with PR #354.

Test run:  `nextstrain build --aws-batch --no-download --attach 85c4cf28-27bd-457d-9fc2-12b911c30849  .`

Test worked well, shaving off 3 hours by parallelizing uploads.