### PR TITLE
Ingest RKI data and output to `open/rki`

### DIFF
--- a/.github/workflows/fetch-and-ingest-rki-branch.yml
+++ b/.github/workflows/fetch-and-ingest-rki-branch.yml
@@ -1,0 +1,47 @@
+name: RKI fetch and ingest (on branch)
+
+# Manually triggered using GitHub's UI
+on: workflow_dispatch
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
+
+      - name: run_pipeline
+        run: |
+          ./bin/write-envdir env.d \
+            AWS_DEFAULT_REGION \
+            GITHUB_RUN_ID
+
+          GITHUB_BRANCH=${GITHUB_REF#refs/heads/}
+          declare -a config
+          config+=(
+            fetch_from_database=True
+            s3_dst=s3://nextstrain-staging/files/ncov/open/branch/"${GITHUB_BRANCH}"
+            cloudfront_domain=staging.nextstrain.org
+          )
+
+          nextstrain build \
+            --aws-batch \
+            --detach \
+            --no-download \
+            --image nextstrain/ncov-ingest \
+            --cpus 16 \
+            --memory 30GiB \
+            --exec env \
+            . \
+              envdir env.d snakemake \
+                --configfile config/rki.yaml \
+                --config "${config[@]}" \
+                --cores 16 \
+                --resources mem_mb=30000 \
+                --printshellcmds
+        env:
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_REF: ${{ github.ref }}

--- a/.github/workflows/fetch-and-ingest-rki-branch.yml
+++ b/.github/workflows/fetch-and-ingest-rki-branch.yml
@@ -20,7 +20,7 @@ jobs:
           declare -a config
           config+=(
             fetch_from_database=True
-            s3_dst=s3://nextstrain-staging/files/ncov/open/branch/"${GITHUB_BRANCH}"
+            s3_dst=s3://nextstrain-staging/files/ncov/rki/branch/"${GITHUB_BRANCH}"
             cloudfront_domain=staging.nextstrain.org
           )
 

--- a/.github/workflows/fetch-and-ingest-rki-master.yml
+++ b/.github/workflows/fetch-and-ingest-rki-master.yml
@@ -1,0 +1,85 @@
+name: RKI fetch and ingest
+
+on:
+  schedule:
+    # Note times are in UTC, which is 1 or 2 hours behind CET depending on daylight savings.
+    #
+    # Currently, we aim to trigger ingest every day at 18:07 UTC which is 19:07 CET (as of Mar 2022).
+    # Note the actual runs might be late. As of right now, the action starts around 20 past the hour.
+    # Numerous people were confused, about that, including me:
+    #  - https://github.community/t/scheduled-action-running-consistently-late/138025/11
+    #  - https://github.com/github/docs/issues/3059
+    #
+    # Note, '*' is a special character in YAML, so you have to quote this string.
+    #
+    # Docs:
+    #  - https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
+    #
+    # Tool that deciphers this particular format of crontab string:
+    #  - https://crontab.guru/
+    #
+    # Looks like you are about to modify this schedule? Make sure you also modify the schedule for the
+    # sister GISAID job, so that we don't need to keep two schedules in our heads.
+    - cron: "7 18 * * *"
+
+  # Manually triggered using `./bin/trigger rki/fetch-and-ingest` (or `fetch-and-ingest`, which
+  # includes GISAID and Genbank as well)
+  repository_dispatch:
+    types:
+      - rki/fetch-and-ingest
+      - fetch-and-ingest
+
+  # Manually triggered using GitHub's UI
+  workflow_dispatch:
+
+jobs:
+  fetch-and-ingest:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_RUN_ID: ${{ github.run_id }}
+      SLACK_CHANNELS: ncov-genbank-updates
+      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
+
+      - name: run_pipeline
+        run: |
+          ./bin/write-envdir env.d \
+            AWS_DEFAULT_REGION \
+            GITHUB_RUN_ID \
+            SLACK_TOKEN \
+            SLACK_CHANNELS \
+            PAT_GITHUB_DISPATCH
+
+          declare -a config
+          config+=(
+            fetch_from_database=True
+            trigger_rebuild=False
+            trigger_counts=False
+          )
+
+          nextstrain build \
+            --aws-batch \
+            --detach \
+            --no-download \
+            --image nextstrain/ncov-ingest \
+            --cpus 16 \
+            --memory 30GiB \
+            --exec env \
+            . \
+              envdir env.d snakemake \
+                --configfile config/rki.yaml \
+                --config "${config[@]}" \
+                --cores 16 \
+                --resources mem_mb=30000 \
+                --printshellcmds
+        env:
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          PAT_GITHUB_DISPATCH: ${{ secrets.PAT_GITHUB_DISPATCH }}
+
+      - name: notify_pipeline_failed
+        if: ${{ failure() }}
+        run: ./bin/notify-on-job-fail

--- a/.github/workflows/ingest-genbank-branch.yml
+++ b/.github/workflows/ingest-genbank-branch.yml
@@ -1,0 +1,46 @@
+name: GenBank ingest (on branch)
+
+# Manually triggered using GitHub's UI
+on: workflow_dispatch
+
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
+
+      - name: run_pipeline
+        run: |
+          ./bin/write-envdir env.d \
+            AWS_DEFAULT_REGION \
+            GITHUB_RUN_ID
+
+          GITHUB_BRANCH=${GITHUB_REF#refs/heads/}
+          declare -a config
+          config+=(
+            s3_dst=s3://nextstrain-staging/files/ncov/open/branch/"${GITHUB_BRANCH}"
+            cloudfront_domain=staging.nextstrain.org
+          )
+
+          nextstrain build \
+            --aws-batch \
+            --detach \
+            --no-download \
+            --image nextstrain/ncov-ingest \
+            --cpus 16 \
+            --memory 64GiB \
+            --exec env \
+            . \
+              envdir env.d snakemake \
+                --configfile config/genbank.yaml \
+                --config "${config[@]}" \
+                --cores 16 \
+                --resources mem_mb=64000 \
+                --printshellcmds
+        env:
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_REF: ${{ github.ref }}

--- a/.github/workflows/nextclade-full-run-rki.yml
+++ b/.github/workflows/nextclade-full-run-rki.yml
@@ -1,0 +1,37 @@
+name: GenBank full Nextclade run
+
+on:
+  # Manually triggered using:
+  #  - ./bin/trigger genbank/nextclade-full-run   (only GenBank)
+  #  - ./bin/trigger nextclade-full-run           (GISAID and GenBank)
+  repository_dispatch:
+    types:
+      - rki/nextclade-full-run
+      - nextclade-full-run
+
+  # Manually triggered using GitHub's UI
+  workflow_dispatch:
+
+jobs:
+  GenBank-Full-Nextclade-Run:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_RUN_ID: ${{ github.run_id }}
+      SLACK_CHANNELS: ncov-genbank-updates
+      SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
+
+      - name: "./bin/run-nextclade-full-aws --database=rki"
+        run: |
+          ./bin/run-nextclade-full-aws --database=rki
+
+        env:
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: notify_pipeline_failed
+        if: ${{ failure() }}
+        run: ./bin/notify-on-job-fail

--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ biopython = "*"
 regex = "*"
 envdir = "*"
 xopen = "*"
+typer = "*"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9d6654a9615cf3274d62680e5da3f800ec491f62b5b8c554423068a0b1ba86f6"
+            "sha256": "da353454e0a53d66e32f4f7bf18f7462be9b55db22cbb1e1edeec577ec56590a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -163,6 +163,8 @@
         "biopython": {
             "hashes": [
                 "sha256:03ee5c72b3cc3f0675a8c22ce1c45fe99a32a60db18df059df479ae6cf619708",
+                "sha256:0ead3c2df8fc4012fc7b1a2751be93c8b0fae677934e78d30182411ed34991bb",
+                "sha256:1163ee42247d0ddb58838e5845de4b7b51012a48eb4b61e1f517edfeccab19db",
                 "sha256:131093d8a0b8075b692fe73d9a4684d4fc98ff5990f6dce1e1b9f929c58207f1",
                 "sha256:155c5b95857bca7ebd607210cb9d8ea459bb0b86b3ca37ea44ec47c26ede7e9a",
                 "sha256:1af4348c17e43f3c79a16af87424d8e3a32e2168ab9246106a085bbb2b8d3450",
@@ -174,7 +176,9 @@
                 "sha256:4b3d4eec2e348c3d97a7fde80ee0f2b8ebeed849d2bd64a616833a9be03b93c8",
                 "sha256:4be31815226052d86d4c2f6a103c40504e34bba3e25cc1b1d687a3203c42fb6e",
                 "sha256:51eb467a60c38820ad1e6c3a7d4cb10535606f559646e824cc65c96091d91ff7",
+                "sha256:535ca75060786a682e6572abdc42420fa8a54af388297da7c56d151c7cc63eec",
                 "sha256:5ae69c5e09769390643aa0f8064517665df6fb99c37433821d6664584d0ecb8c",
+                "sha256:6d1b8a63cb569209fb431d34dea0792d5c3ec0207aada3bdec3f8bf0c4a406fb",
                 "sha256:72a1477cf1701964c7224e506a54fd65d1cc5228da200b634a17992230aa1cbd",
                 "sha256:76988ed3d7383d566db1d7fc69c9cf136c6275813fb749fc6753c340f81f1a8f",
                 "sha256:83bfea8a19f9352c47b13965c4b73853e7aeef3c5aed8489895b0679e32c621b",
@@ -306,7 +310,7 @@
                 "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
                 "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "markers": "python_version >= '3.6'",
+            "markers": "python_full_version >= '3.6.0'",
             "version": "==2.1.1"
         },
         "click": {
@@ -327,34 +331,34 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:0297ffc478bdd237f5ca3a7dc96fc0d315670bfa099c04dc3a4a2172008a405a",
-                "sha256:10d1f29d6292fc95acb597bacefd5b9e812099d75a6469004fd38ba5471a977f",
-                "sha256:16fa61e7481f4b77ef53991075de29fc5bacb582a1244046d2e8b4bb72ef66d0",
-                "sha256:194044c6b89a2f9f169df475cc167f6157eb9151cc69af8a2a163481d45cc407",
-                "sha256:1db3d807a14931fa317f96435695d9ec386be7b84b618cc61cfa5d08b0ae33d7",
-                "sha256:3261725c0ef84e7592597606f6583385fed2a5ec3909f43bc475ade9729a41d6",
-                "sha256:3b72c360427889b40f36dc214630e688c2fe03e16c162ef0aa41da7ab1455153",
-                "sha256:3e3a2599e640927089f932295a9a247fc40a5bdf69b0484532f530471a382750",
-                "sha256:3fc26e22840b77326a764ceb5f02ca2d342305fba08f002a8c1f139540cdfaad",
-                "sha256:5067ee7f2bce36b11d0e334abcd1ccf8c541fc0bbdaf57cdd511fdee53e879b6",
-                "sha256:52e7bee800ec869b4031093875279f1ff2ed12c1e2f74923e8f49c916afd1d3b",
-                "sha256:64760ba5331e3f1794d0bcaabc0d0c39e8c60bf67d09c93dc0e54189dfd7cfe5",
-                "sha256:765fa194a0f3372d83005ab83ab35d7c5526c4e22951e46059b8ac678b44fa5a",
-                "sha256:79473cf8a5cbc471979bd9378c9f425384980fcf2ab6534b18ed7d0d9843987d",
-                "sha256:896dd3a66959d3a5ddcfc140a53391f69ff1e8f25d93f0e2e7830c6de90ceb9d",
-                "sha256:89ed49784ba88c221756ff4d4755dbc03b3c8d2c5103f6d6b4f83a0fb1e85294",
-                "sha256:ac7e48f7e7261207d750fa7e55eac2d45f720027d5703cd9007e9b37bbb59ac0",
-                "sha256:ad7353f6ddf285aeadfaf79e5a6829110106ff8189391704c1d8801aa0bae45a",
-                "sha256:b0163a849b6f315bf52815e238bc2b2346604413fa7c1601eea84bcddb5fb9ac",
-                "sha256:b6c9b706316d7b5a137c35e14f4103e2115b088c412140fdbd5f87c73284df61",
-                "sha256:c2e5856248a416767322c8668ef1845ad46ee62629266f84a8f007a317141013",
-                "sha256:ca9f6784ea96b55ff41708b92c3f6aeaebde4c560308e5fbbd3173fbc466e94e",
-                "sha256:d1a5bd52d684e49a36582193e0b89ff267704cd4025abefb9e26803adeb3e5fb",
-                "sha256:d3971e2749a723e9084dd507584e2a2761f78ad2c638aa31e80bc7a15c9db4f9",
-                "sha256:d4ef6cc305394ed669d4d9eebf10d3a101059bdcf2669c366ec1d14e4fb227bd",
-                "sha256:d9e69ae01f99abe6ad646947bba8941e896cb3aa805be2597a0400e0764b5818"
+                "sha256:068147f32fa662c81aebab95c74679b401b12b57494872886eb5c1139250ec5d",
+                "sha256:06fc3cc7b6f6cca87bd56ec80a580c88f1da5306f505876a71c8cfa7050257dd",
+                "sha256:25c1d1f19729fb09d42e06b4bf9895212292cb27bb50229f5aa64d039ab29146",
+                "sha256:402852a0aea73833d982cabb6d0c3bb582c15483d29fb7085ef2c42bfa7e38d7",
+                "sha256:4e269dcd9b102c5a3d72be3c45d8ce20377b8076a43cbed6f660a1afe365e436",
+                "sha256:5419a127426084933076132d317911e3c6eb77568a1ce23c3ac1e12d111e61e0",
+                "sha256:554bec92ee7d1e9d10ded2f7e92a5d70c1f74ba9524947c0ba0c850c7b011828",
+                "sha256:5e89468fbd2fcd733b5899333bc54d0d06c80e04cd23d8c6f3e0542358c6060b",
+                "sha256:65535bc550b70bd6271984d9863a37741352b4aad6fb1b3344a54e6950249b55",
+                "sha256:6ab9516b85bebe7aa83f309bacc5f44a61eeb90d0b4ec125d2d003ce41932d36",
+                "sha256:6addc3b6d593cd980989261dc1cce38263c76954d758c3c94de51f1e010c9a50",
+                "sha256:728f2694fa743a996d7784a6194da430f197d5c58e2f4e278612b359f455e4a2",
+                "sha256:785e4056b5a8b28f05a533fab69febf5004458e20dad7e2e13a3120d8ecec75a",
+                "sha256:78cf5eefac2b52c10398a42765bfa981ce2372cbc0457e6bf9658f41ec3c41d8",
+                "sha256:7f836217000342d448e1c9a342e9163149e45d5b5eca76a30e84503a5a96cab0",
+                "sha256:8d41a46251bf0634e21fac50ffd643216ccecfaf3701a063257fe0b2be1b6548",
+                "sha256:984fe150f350a3c91e84de405fe49e688aa6092b3525f407a18b9646f6612320",
+                "sha256:9b24bcff7853ed18a63cfb0c2b008936a9554af24af2fb146e16d8e1aed75748",
+                "sha256:b1b35d9d3a65542ed2e9d90115dfd16bbc027b3f07ee3304fc83580f26e43249",
+                "sha256:b1b52c9e5f8aa2b802d48bd693190341fae201ea51c7a167d69fc48b60e8a959",
+                "sha256:bbf203f1a814007ce24bd4d51362991d5cb90ba0c177a9c08825f2cc304d871f",
+                "sha256:be243c7e2bfcf6cc4cb350c0d5cdf15ca6383bbcb2a8ef51d3c9411a9d4386f0",
+                "sha256:bfbe6ee19615b07a98b1d2287d6a6073f734735b49ee45b11324d85efc4d5cbd",
+                "sha256:c46837ea467ed1efea562bbeb543994c2d1f6e800785bd5a2c98bc096f5cb220",
+                "sha256:dfb4f4dd568de1b6af9f4cda334adf7d72cf5bc052516e1b2608b683375dd95c",
+                "sha256:ed7b00096790213e09eb11c97cc6e2b757f15f3d2f85833cd2d3ec3fe37c1722"
             ],
-            "version": "==38.0.1"
+            "version": "==38.0.3"
         },
         "csv-diff": {
             "hashes": [
@@ -475,6 +479,14 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==3.4"
+        },
+        "importlib-resources": {
+            "hashes": [
+                "sha256:c01b1b94210d9849f286b86bb51bcea7cd56dde0600d8db721d7b81330711668",
+                "sha256:ee17ec648f85480d523596ce49eae8ead87d5631ae1551f913c0100b5edd3437"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==5.10.0"
         },
         "isal": {
             "hashes": [
@@ -600,11 +612,11 @@
         },
         "nextstrain-cli": {
             "hashes": [
-                "sha256:990403c22da287a66cdc219be3b7d7b470367847e43d4482ae5ed3c0afe5e7b8",
-                "sha256:c64274cee6409ca7b9da253629e9f752bc11d965e1f6114c4f9408b2258a4a21"
+                "sha256:262c99fa394fb5a112037ebb558ef788849f049efce312e7f2d7aaa54280491a",
+                "sha256:726f45415b7478ade1b1137a03992316900b887f7de5836937efcf99ad0de68f"
             ],
             "index": "pypi",
-            "version": "==4.2.0"
+            "version": "==5.0.1"
         },
         "numpy": {
             "hashes": [
@@ -711,11 +723,11 @@
                 "crypto"
             ],
             "hashes": [
-                "sha256:8d82e7087868e94dd8d7d418e5088ce64f7daab4b36db654cbaedb46f9d1ca80",
-                "sha256:e77ab89480905d86998442ac5788f35333fa85f65047a534adc38edf3c88fc3b"
+                "sha256:69285c7e31fc44f68a1feb309e948e0df53259d579295e6cfe2b1792329f05fd",
+                "sha256:d83c3d892a77bbb74d3e1a2cfa90afaadb60945205d1095d9221f04466f64c14"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.0"
+            "version": "==2.6.0"
         },
         "pyparsing": {
             "hashes": [
@@ -735,10 +747,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:335ab46900b1465e714b4fda4963d87363264eb662aab5e65da039c25f1f5b22",
-                "sha256:c4d88f472f54d615e9cd582a5004d1e5f624854a6a27a6211591c251f22a6914"
+                "sha256:222439474e9c98fced559f1709d89e6c9cbf8d79c794ff3eb9f8800064291427",
+                "sha256:e89512406b793ca39f5971bc999cc538ce125c0e51c27941bef4568b460095e2"
             ],
-            "version": "==2022.5"
+            "version": "==2022.6"
         },
         "pyyaml": {
             "hashes": [
@@ -777,97 +789,97 @@
         },
         "regex": {
             "hashes": [
-                "sha256:003a2e1449d425afc817b5f0b3d4c4aa9072dd5f3dfbf6c7631b8dc7b13233de",
-                "sha256:0385d66e73cdd4462f3cc42c76a6576ddcc12472c30e02a2ae82061bff132c32",
-                "sha256:0394265391a86e2bbaa7606e59ac71bd9f1edf8665a59e42771a9c9adbf6fd4f",
-                "sha256:03ff695518482b946a6d3d4ce9cbbd99a21320e20d94913080aa3841f880abcd",
-                "sha256:079c182f99c89524069b9cd96f5410d6af437e9dca576a7d59599a574972707e",
-                "sha256:091efcfdd4178a7e19a23776dc2b1fafb4f57f4d94daf340f98335817056f874",
-                "sha256:0b664a4d33ffc6be10996606dfc25fd3248c24cc589c0b139feb4c158053565e",
-                "sha256:14216ea15efc13f28d0ef1c463d86d93ca7158a79cd4aec0f9273f6d4c6bb047",
-                "sha256:14a7ab070fa3aec288076eed6ed828587b805ef83d37c9bfccc1a4a7cfbd8111",
-                "sha256:14c71437ffb89479c89cc7022a5ea2075a842b728f37205e47c824cc17b30a42",
-                "sha256:18e503b1e515a10282b3f14f1b3d856194ecece4250e850fad230842ed31227f",
-                "sha256:19a4da6f513045f5ba00e491215bd00122e5bd131847586522463e5a6b2bd65f",
-                "sha256:1a901ce5cd42658ab8f8eade51b71a6d26ad4b68c7cfc86b87efc577dfa95602",
-                "sha256:26df88c9636a0c3f3bd9189dd435850a0c49d0b7d6e932500db3f99a6dd604d1",
-                "sha256:2dda4b096a6f630d6531728a45bd12c67ec3badf44342046dc77d4897277d4f2",
-                "sha256:322bd5572bed36a5b39952d88e072738926759422498a96df138d93384934ff8",
-                "sha256:360ffbc9357794ae41336b681dff1c0463193199dfb91fcad3ec385ea4972f46",
-                "sha256:37e5a26e76c46f54b3baf56a6fdd56df9db89758694516413757b7d127d4c57b",
-                "sha256:3d64e1a7e6d98a4cdc8b29cb8d8ed38f73f49e55fbaa737bdb5933db99b9de22",
-                "sha256:3f3b4594d564ed0b2f54463a9f328cf6a5b2a32610a90cdff778d6e3e561d08b",
-                "sha256:4146cb7ae6029fc83b5c905ec6d806b7e5568dc14297c423e66b86294bad6c39",
-                "sha256:4318f69b79f9f7d84a7420e97d4bfe872dc767c72f891d4fea5fa721c74685f7",
-                "sha256:4cdbfa6d2befeaee0c899f19222e9b20fc5abbafe5e9c43a46ef819aeb7b75e5",
-                "sha256:50e764ffbd08b06aa8c4e86b8b568b6722c75d301b33b259099f237c46b2134e",
-                "sha256:518272f25da93e02af4f1e94985f5042cec21557ef3591027d0716f2adda5d0a",
-                "sha256:592b9e2e1862168e71d9e612bfdc22c451261967dbd46681f14e76dfba7105fd",
-                "sha256:59a786a55d00439d8fae4caaf71581f2aaef7297d04ee60345c3594efef5648a",
-                "sha256:59bac44b5a07b08a261537f652c26993af9b1bbe2a29624473968dd42fc29d56",
-                "sha256:5d0dd8b06896423211ce18fba0c75dacc49182a1d6514c004b535be7163dca0f",
-                "sha256:67a4c625361db04ae40ef7c49d3cbe2c1f5ff10b5a4491327ab20f19f2fb5d40",
-                "sha256:6adfe300848d61a470ec7547adc97b0ccf86de86a99e6830f1d8c8d19ecaf6b3",
-                "sha256:6b32b45433df1fad7fed738fe15200b6516da888e0bd1fdd6aa5e50cc16b76bc",
-                "sha256:6c57d50d4d5eb0c862569ca3c840eba2a73412f31d9ecc46ef0d6b2e621a592b",
-                "sha256:6d43bd402b27e0e7eae85c612725ba1ce7798f20f6fab4e8bc3de4f263294f03",
-                "sha256:6e521d9db006c5e4a0f8acfef738399f72b704913d4e083516774eb51645ad7c",
-                "sha256:6fe1dd1021e0f8f3f454ce2811f1b0b148f2d25bb38c712fec00316551e93650",
-                "sha256:73b985c9fc09a7896846e26d7b6f4d1fd5a20437055f4ef985d44729f9f928d0",
-                "sha256:7681c49da1a2d4b905b4f53d86c9ba4506e79fba50c4a664d9516056e0f7dfcc",
-                "sha256:77c2879d3ba51e5ca6c2b47f2dcf3d04a976a623a8fc8236010a16c9e0b0a3c7",
-                "sha256:7b0c5cc3d1744a67c3b433dce91e5ef7c527d612354c1f1e8576d9e86bc5c5e2",
-                "sha256:7fcf7f94ccad19186820ac67e2ec7e09e0ac2dac39689f11cf71eac580503296",
-                "sha256:83cc32a1a2fa5bac00f4abc0e6ce142e3c05d3a6d57e23bd0f187c59b4e1e43b",
-                "sha256:8418ee2cb857b83881b8f981e4c636bc50a0587b12d98cb9b947408a3c484fe7",
-                "sha256:86df2049b18745f3cd4b0f4c4ef672bfac4b80ca488e6ecfd2bbfe68d2423a2c",
-                "sha256:880dbeb6bdde7d926b4d8e41410b16ffcd4cb3b4c6d926280fea46e2615c7a01",
-                "sha256:8aba0d01e3dfd335f2cb107079b07fdddb4cd7fb2d8c8a1986f9cb8ce9246c24",
-                "sha256:8dcbcc9e72a791f622a32d17ff5011326a18996647509cac0609a7fc43adc229",
-                "sha256:944567bb08f52268d8600ee5bdf1798b2b62ea002cc692a39cec113244cbdd0d",
-                "sha256:995e70bb8c91d1b99ed2aaf8ec44863e06ad1dfbb45d7df95f76ef583ec323a9",
-                "sha256:99945ddb4f379bb9831c05e9f80f02f079ba361a0fb1fba1fc3b267639b6bb2e",
-                "sha256:9a165a05979e212b2c2d56a9f40b69c811c98a788964e669eb322de0a3e420b4",
-                "sha256:9bc8edc5f8ef0ebb46f3fa0d02bd825bbe9cc63d59e428ffb6981ff9672f6de1",
-                "sha256:a1aec4ae549fd7b3f52ceaf67e133010e2fba1538bf4d5fc5cd162a5e058d5df",
-                "sha256:a1c4d17879dd4c4432c08a1ca1ab379f12ab54af569e945b6fc1c4cf6a74ca45",
-                "sha256:a2b39ee3b280e15824298b97cec3f7cbbe6539d8282cc8a6047a455b9a72c598",
-                "sha256:a2effeaf50a6838f3dd4d3c5d265f06eabc748f476e8441892645ae3a697e273",
-                "sha256:a59d0377e58d96a6f11636e97992f5b51b7e1e89eb66332d1c01b35adbabfe8a",
-                "sha256:a926339356fe29595f8e37af71db37cd87ff764e15da8ad5129bbaff35bcc5a6",
-                "sha256:a9eb9558e1d0f78e07082d8a70d5c4d631c8dd75575fae92105df9e19c736730",
-                "sha256:ab07934725e6f25c6f87465976cc69aef1141e86987af49d8c839c3ffd367c72",
-                "sha256:ad75173349ad79f9d21e0d0896b27dcb37bfd233b09047bc0b4d226699cf5c87",
-                "sha256:b7b701dbc124558fd2b1b08005eeca6c9160e209108fbcbd00091fcfac641ac7",
-                "sha256:b7bee775ff05c9d519195bd9e8aaaccfe3971db60f89f89751ee0f234e8aeac5",
-                "sha256:b86548b8234b2be3985dbc0b385e35f5038f0f3e6251464b827b83ebf4ed90e5",
-                "sha256:b9d68eb704b24bc4d441b24e4a12653acd07d2c39940548761e0985a08bc1fff",
-                "sha256:c0b7cb9598795b01f9a3dd3f770ab540889259def28a3bf9b2fa24d52edecba3",
-                "sha256:cab548d6d972e1de584161487b2ac1aa82edd8430d1bde69587ba61698ad1cfb",
-                "sha256:ce331b076b2b013e7d7f07157f957974ef0b0881a808e8a4a4b3b5105aee5d04",
-                "sha256:cfa4c956ff0a977c4823cb3b930b0a4e82543b060733628fec7ab3eb9b1abe37",
-                "sha256:d23ac6b4bf9e32fcde5fcdb2e1fd5e7370d6693fcac51ee1d340f0e886f50d1f",
-                "sha256:d2885ec6eea629c648ecc9bde0837ec6b92208b7f36381689937fe5d64a517e8",
-                "sha256:d2a1371dc73e921f3c2e087c05359050f3525a9a34b476ebc8130e71bec55e97",
-                "sha256:d3102ab9bf16bf541ca228012d45d88d2a567c9682a805ae2c145a79d3141fdd",
-                "sha256:d5b003d248e6f292475cd24b04e5f72c48412231961a675edcb653c70730e79e",
-                "sha256:d5edd3eb877c9fc2e385173d4a4e1d792bf692d79e25c1ca391802d36ecfaa01",
-                "sha256:d7430f041755801b712ec804aaf3b094b9b5facbaa93a6339812a8e00d7bd53a",
-                "sha256:d837ccf3bd2474feabee96cd71144e991472e400ed26582edc8ca88ce259899c",
-                "sha256:dab81cc4d58026861445230cfba27f9825e9223557926e7ec22156a1a140d55c",
-                "sha256:db45016364eec9ddbb5af93c8740c5c92eb7f5fc8848d1ae04205a40a1a2efc6",
-                "sha256:df8fe00b60e4717662c7f80c810ba66dcc77309183c76b7754c0dff6f1d42054",
-                "sha256:e6e6e61e9a38b6cc60ca3e19caabc90261f070f23352e66307b3d21a24a34aaf",
-                "sha256:ee7045623a5ace70f3765e452528b4c1f2ce669ed31959c63f54de64fe2f6ff7",
-                "sha256:f06cc1190f3db3192ab8949e28f2c627e1809487e2cfc435b6524c1ce6a2f391",
-                "sha256:f07373b6e56a6f3a0df3d75b651a278ca7bd357a796078a26a958ea1ce0588fd",
-                "sha256:f6e0321921d2fdc082ef90c1fd0870f129c2e691bfdc4937dcb5cd308aba95c4",
-                "sha256:f6e167d1ccd41d27b7b6655bb7a2dcb1b1eb1e0d2d662043470bd3b4315d8b2b",
-                "sha256:fcbd1edff1473d90dc5cf4b52d355cf1f47b74eb7c85ba6e45f45d0116b8edbd",
-                "sha256:fe428822b7a8c486bcd90b334e9ab541ce6cc0d6106993d59f201853e5e14121"
+                "sha256:052b670fafbe30966bbe5d025e90b2a491f85dfe5b2583a163b5e60a85a321ad",
+                "sha256:0653d012b3bf45f194e5e6a41df9258811ac8fc395579fa82958a8b76286bea4",
+                "sha256:0a069c8483466806ab94ea9068c34b200b8bfc66b6762f45a831c4baaa9e8cdd",
+                "sha256:0cf0da36a212978be2c2e2e2d04bdff46f850108fccc1851332bcae51c8907cc",
+                "sha256:131d4be09bea7ce2577f9623e415cab287a3c8e0624f778c1d955ec7c281bd4d",
+                "sha256:144486e029793a733e43b2e37df16a16df4ceb62102636ff3db6033994711066",
+                "sha256:1ddf14031a3882f684b8642cb74eea3af93a2be68893901b2b387c5fd92a03ec",
+                "sha256:1eba476b1b242620c266edf6325b443a2e22b633217a9835a52d8da2b5c051f9",
+                "sha256:20f61c9944f0be2dc2b75689ba409938c14876c19d02f7585af4460b6a21403e",
+                "sha256:22960019a842777a9fa5134c2364efaed5fbf9610ddc5c904bd3a400973b0eb8",
+                "sha256:22e7ebc231d28393dfdc19b185d97e14a0f178bedd78e85aad660e93b646604e",
+                "sha256:23cbb932cc53a86ebde0fb72e7e645f9a5eec1a5af7aa9ce333e46286caef783",
+                "sha256:29c04741b9ae13d1e94cf93fca257730b97ce6ea64cfe1eba11cf9ac4e85afb6",
+                "sha256:2bde29cc44fa81c0a0c8686992c3080b37c488df167a371500b2a43ce9f026d1",
+                "sha256:2cdc55ca07b4e70dda898d2ab7150ecf17c990076d3acd7a5f3b25cb23a69f1c",
+                "sha256:370f6e97d02bf2dd20d7468ce4f38e173a124e769762d00beadec3bc2f4b3bc4",
+                "sha256:395161bbdbd04a8333b9ff9763a05e9ceb4fe210e3c7690f5e68cedd3d65d8e1",
+                "sha256:44136355e2f5e06bf6b23d337a75386371ba742ffa771440b85bed367c1318d1",
+                "sha256:44a6c2f6374e0033873e9ed577a54a3602b4f609867794c1a3ebba65e4c93ee7",
+                "sha256:4919899577ba37f505aaebdf6e7dc812d55e8f097331312db7f1aab18767cce8",
+                "sha256:4b4b1fe58cd102d75ef0552cf17242705ce0759f9695334a56644ad2d83903fe",
+                "sha256:4bdd56ee719a8f751cf5a593476a441c4e56c9b64dc1f0f30902858c4ef8771d",
+                "sha256:4bf41b8b0a80708f7e0384519795e80dcb44d7199a35d52c15cc674d10b3081b",
+                "sha256:4cac3405d8dda8bc6ed499557625585544dd5cbf32072dcc72b5a176cb1271c8",
+                "sha256:4fe7fda2fe7c8890d454f2cbc91d6c01baf206fbc96d89a80241a02985118c0c",
+                "sha256:50921c140561d3db2ab9f5b11c5184846cde686bb5a9dc64cae442926e86f3af",
+                "sha256:5217c25229b6a85049416a5c1e6451e9060a1edcf988641e309dbe3ab26d3e49",
+                "sha256:5352bea8a8f84b89d45ccc503f390a6be77917932b1c98c4cdc3565137acc714",
+                "sha256:542e3e306d1669b25936b64917285cdffcd4f5c6f0247636fec037187bd93542",
+                "sha256:543883e3496c8b6d58bd036c99486c3c8387c2fc01f7a342b760c1ea3158a318",
+                "sha256:586b36ebda81e6c1a9c5a5d0bfdc236399ba6595e1397842fd4a45648c30f35e",
+                "sha256:597f899f4ed42a38df7b0e46714880fb4e19a25c2f66e5c908805466721760f5",
+                "sha256:5a260758454580f11dd8743fa98319bb046037dfab4f7828008909d0aa5292bc",
+                "sha256:5aefb84a301327ad115e9d346c8e2760009131d9d4b4c6b213648d02e2abe144",
+                "sha256:5e6a5567078b3eaed93558842346c9d678e116ab0135e22eb72db8325e90b453",
+                "sha256:5ff525698de226c0ca743bfa71fc6b378cda2ddcf0d22d7c37b1cc925c9650a5",
+                "sha256:61edbca89aa3f5ef7ecac8c23d975fe7261c12665f1d90a6b1af527bba86ce61",
+                "sha256:659175b2144d199560d99a8d13b2228b85e6019b6e09e556209dfb8c37b78a11",
+                "sha256:6a9a19bea8495bb419dc5d38c4519567781cd8d571c72efc6aa959473d10221a",
+                "sha256:6b30bddd61d2a3261f025ad0f9ee2586988c6a00c780a2fb0a92cea2aa702c54",
+                "sha256:6ffd55b5aedc6f25fd8d9f905c9376ca44fcf768673ffb9d160dd6f409bfda73",
+                "sha256:702d8fc6f25bbf412ee706bd73019da5e44a8400861dfff7ff31eb5b4a1276dc",
+                "sha256:74bcab50a13960f2a610cdcd066e25f1fd59e23b69637c92ad470784a51b1347",
+                "sha256:75f591b2055523fc02a4bbe598aa867df9e953255f0b7f7715d2a36a9c30065c",
+                "sha256:763b64853b0a8f4f9cfb41a76a4a85a9bcda7fdda5cb057016e7706fde928e66",
+                "sha256:76c598ca73ec73a2f568e2a72ba46c3b6c8690ad9a07092b18e48ceb936e9f0c",
+                "sha256:78d680ef3e4d405f36f0d6d1ea54e740366f061645930072d39bca16a10d8c93",
+                "sha256:7b280948d00bd3973c1998f92e22aa3ecb76682e3a4255f33e1020bd32adf443",
+                "sha256:7db345956ecce0c99b97b042b4ca7326feeec6b75facd8390af73b18e2650ffc",
+                "sha256:7dbdce0c534bbf52274b94768b3498abdf675a691fec5f751b6057b3030f34c1",
+                "sha256:7ef6b5942e6bfc5706301a18a62300c60db9af7f6368042227ccb7eeb22d0892",
+                "sha256:7f5a3ffc731494f1a57bd91c47dc483a1e10048131ffb52d901bfe2beb6102e8",
+                "sha256:8a45b6514861916c429e6059a55cf7db74670eaed2052a648e3e4d04f070e001",
+                "sha256:8ad241da7fac963d7573cc67a064c57c58766b62a9a20c452ca1f21050868dfa",
+                "sha256:8b0886885f7323beea6f552c28bff62cbe0983b9fbb94126531693ea6c5ebb90",
+                "sha256:8ca88da1bd78990b536c4a7765f719803eb4f8f9971cc22d6ca965c10a7f2c4c",
+                "sha256:8e0caeff18b96ea90fc0eb6e3bdb2b10ab5b01a95128dfeccb64a7238decf5f0",
+                "sha256:957403a978e10fb3ca42572a23e6f7badff39aa1ce2f4ade68ee452dc6807692",
+                "sha256:9af69f6746120998cd9c355e9c3c6aec7dff70d47247188feb4f829502be8ab4",
+                "sha256:9c94f7cc91ab16b36ba5ce476f1904c91d6c92441f01cd61a8e2729442d6fcf5",
+                "sha256:a37d51fa9a00d265cf73f3de3930fa9c41548177ba4f0faf76e61d512c774690",
+                "sha256:a3a98921da9a1bf8457aeee6a551948a83601689e5ecdd736894ea9bbec77e83",
+                "sha256:a3c1ebd4ed8e76e886507c9eddb1a891673686c813adf889b864a17fafcf6d66",
+                "sha256:a5f9505efd574d1e5b4a76ac9dd92a12acb2b309551e9aa874c13c11caefbe4f",
+                "sha256:a8ff454ef0bb061e37df03557afda9d785c905dab15584860f982e88be73015f",
+                "sha256:a9d0b68ac1743964755ae2d89772c7e6fb0118acd4d0b7464eaf3921c6b49dd4",
+                "sha256:aa62a07ac93b7cb6b7d0389d8ef57ffc321d78f60c037b19dfa78d6b17c928ee",
+                "sha256:ac741bf78b9bb432e2d314439275235f41656e189856b11fb4e774d9f7246d81",
+                "sha256:ae1e96785696b543394a4e3f15f3f225d44f3c55dafe3f206493031419fedf95",
+                "sha256:b683e5fd7f74fb66e89a1ed16076dbab3f8e9f34c18b1979ded614fe10cdc4d9",
+                "sha256:b7a8b43ee64ca8f4befa2bea4083f7c52c92864d8518244bfa6e88c751fa8fff",
+                "sha256:b8e38472739028e5f2c3a4aded0ab7eadc447f0d84f310c7a8bb697ec417229e",
+                "sha256:bfff48c7bd23c6e2aec6454aaf6edc44444b229e94743b34bdcdda2e35126cf5",
+                "sha256:c14b63c9d7bab795d17392c7c1f9aaabbffd4cf4387725a0ac69109fb3b550c6",
+                "sha256:c27cc1e4b197092e50ddbf0118c788d9977f3f8f35bfbbd3e76c1846a3443df7",
+                "sha256:c28d3309ebd6d6b2cf82969b5179bed5fefe6142c70f354ece94324fa11bf6a1",
+                "sha256:c670f4773f2f6f1957ff8a3962c7dd12e4be54d05839b216cb7fd70b5a1df394",
+                "sha256:ce6910b56b700bea7be82c54ddf2e0ed792a577dfaa4a76b9af07d550af435c6",
+                "sha256:d0213671691e341f6849bf33cd9fad21f7b1cb88b89e024f33370733fec58742",
+                "sha256:d03fe67b2325cb3f09be029fd5da8df9e6974f0cde2c2ac6a79d2634e791dd57",
+                "sha256:d0e5af9a9effb88535a472e19169e09ce750c3d442fb222254a276d77808620b",
+                "sha256:d243b36fbf3d73c25e48014961e83c19c9cc92530516ce3c43050ea6276a2ab7",
+                "sha256:d26166acf62f731f50bdd885b04b38828436d74e8e362bfcb8df221d868b5d9b",
+                "sha256:d403d781b0e06d2922435ce3b8d2376579f0c217ae491e273bab8d092727d244",
+                "sha256:d8716f82502997b3d0895d1c64c3b834181b1eaca28f3f6336a71777e437c2af",
+                "sha256:e4f781ffedd17b0b834c8731b75cce2639d5a8afe961c1e58ee7f1f20b3af185",
+                "sha256:e613a98ead2005c4ce037c7b061f2409a1a4e45099edb0ef3200ee26ed2a69a8",
+                "sha256:ef4163770525257876f10e8ece1cf25b71468316f61451ded1a6f44273eedeb5"
             ],
             "index": "pypi",
-            "version": "==2022.9.13"
+            "version": "==2022.10.31"
         },
         "requests": {
             "hashes": [
@@ -911,6 +923,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
+        },
+        "typer": {
+            "hashes": [
+                "sha256:b5e704f4e48ec263de1c0b3a2387cd405a13767d2f907f44c1a08cbad96f606d",
+                "sha256:ff797846578a9f2a201b53442aedeb543319466870fbe1c701eab66dd7681165"
+            ],
+            "index": "pypi",
+            "version": "==0.7.0"
         },
         "types-cryptography": {
             "hashes": [
@@ -1015,11 +1035,11 @@
         },
         "xopen": {
             "hashes": [
-                "sha256:72219a4d690e9c90ad445c45d2119ae2a6d5d38912255631e227aceac6294353",
-                "sha256:a23913c5263c1567562a77a15260e5d933ea5ef27d5ce95df7be8f637636fd7c"
+                "sha256:901f9c8298e95ed74767a4bd76d9f4cf71d8de27b8cf296ac3e7bc1c11520d9f",
+                "sha256:c4c6c978bb5f6f2a4364438da09f4f8fde078b6df4de18e3f72fccc472d1ee33"
             ],
             "index": "pypi",
-            "version": "==1.6.0"
+            "version": "==1.7.0"
         },
         "yarl": {
             "hashes": [

--- a/Snakefile
+++ b/Snakefile
@@ -5,9 +5,9 @@ import os
 ####################### general setup ###########################
 #################################################################
 
-database=config.get("database_name", "")
-if database != "gisaid" and database != "genbank":
-    print(f"[Fatal] An unknown database \"{database}\" was specified")
+database = config.get("database_name", "")
+if database not in ["gisaid", "genbank", "rki"]:
+    print(f'[Fatal] An unknown database "{database}" was specified')
     sys.exit(1)
 
 send_notifications = "SLACK_CHANNELS" in os.environ and "SLACK_TOKEN" in os.environ
@@ -37,32 +37,43 @@ if config.get("s3_dst"):
 # and the `s3_src` is provided in config since some notify scripts depend
 # do diffs with files on S3 from previous runs
 if send_notifications and config.get("s3_src"):
-    all_targets.extend([
-        f"data/{database}/notify-on-record-change.done",
-        f"data/{database}/notify.done"
-    ])
+    all_targets.extend(
+        [
+            f"data/{database}/notify-on-record-change.done",
+            f"data/{database}/notify.done",
+        ]
+    )
+
 
 rule all:
-    input: all_targets
+    input:
+        all_targets,
+
 
 #################################################################
 ###################### rule definitions #########################
 #################################################################
 
+
 include: "workflow/snakemake_rules/fetch_sequences.smk"
-
 include: "workflow/snakemake_rules/curate.smk"
-
 include: "workflow/snakemake_rules/nextclade.smk"
 
+
 if send_notifications and config.get("s3_src"):
+
     include: "workflow/snakemake_rules/slack_notifications.smk"
 
+
 if config.get("s3_dst"):
+
     include: "workflow/snakemake_rules/upload.smk"
-    # Only include rules for trigger if uploading files since the trigger
-    # rules depend on the outputs from upload.
-    include: "workflow/snakemake_rules/trigger.smk"
+
+
+# Only include rules for trigger if uploading files since the trigger
+# rules depend on the outputs from upload.
+include: "workflow/snakemake_rules/trigger.smk"
+
 
 ################################################################
 ################################################################
@@ -77,30 +88,43 @@ env_variables = {
     "SLACK_CHANNELS": "Required for sending slack notifications",
     "PAT_GITHUB_DISPATCH": "Required for triggering GitHub actions (e.g. to rebuild nextstrain/ncov)",
     "GISAID_API_ENDPOINT": "Required for GISAID API access",
-    "GISAID_USERNAME_AND_PASSWORD": "Required for GISAID API access"
+    "GISAID_USERNAME_AND_PASSWORD": "Required for GISAID API access",
 }
+
 
 onstart:
     print(f"Pipeline starting.")
-    print(f"Source s3 bucket: {config.get('s3_src', 'N/A')}, destination: {config.get('s3_dst', 'N/A')}")
+    print(
+        f"Source s3 bucket: {config.get('s3_src', 'N/A')}, destination: {config.get('s3_dst', 'N/A')}"
+    )
     print("Environment variables present:")
     for var, description in env_variables.items():
-        print(f"\t${{{var}}}: " + ("YES" if os.environ.get(var, "") else "NO") + f"({description})")
+        print(
+            f"\t${{{var}}}: "
+            + ("YES" if os.environ.get(var, "") else "NO")
+            + f"({description})"
+        )
     if send_notifications:
-        message="🥗 GISAID ingest" if database=="gisaid" else "🥣 GenBank ingest"
-        shell(f"./bin/notify-on-job-start \"{message}\"")
+        message = "🥗 GISAID ingest" if database == "gisaid" else "🥣 GenBank ingest"
+        shell(f'./bin/notify-on-job-start "{message}"')
+
 
 onsuccess:
     message = "✅ This pipeline has successfully finished 🎉"
     print(message)
     if not config.get("keep_all_files", False):
-        print("Removing intermediate files (set config option keep_all_files to skip this)")
+        print(
+            "Removing intermediate files (set config option keep_all_files to skip this)"
+        )
         shell("./bin/clean")
+
 
 onerror:
     print("Pipeline failed.")
     if send_notifications:
         shell("./bin/notify-on-job-fail")
     if not config.get("keep_all_files", False):
-        print("Removing intermediate files (set config option keep_all_files to skip this)")
+        print(
+            "Removing intermediate files (set config option keep_all_files to skip this)"
+        )
         shell("./bin/clean")

--- a/bin/clean
+++ b/bin/clean
@@ -6,6 +6,7 @@ find data/ \
     -mindepth 1 \
     -not -path data/genbank \
     -not -path data/gisaid \
+    -not -path data/rki \
     -not -name .gitignore \
     -print \
     -delete

--- a/bin/fetch-from-rki-lineages
+++ b/bin/fetch-from-rki-lineages
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+curl "https://raw.githubusercontent.com/robert-koch-institut/SARS-CoV-2-Sequenzdaten_aus_Deutschland/master/SARS-CoV-2-Entwicklungslinien_Deutschland.csv.xz" \
+    --fail --silent --show-error --http1.1 \
+    --header 'User-Agent: https://github.com/nextstrain/ncov-ingest (hello@nextstrain.org)'

--- a/bin/fetch-from-rki-metadata
+++ b/bin/fetch-from-rki-metadata
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+curl "https://raw.githubusercontent.com/robert-koch-institut/SARS-CoV-2-Sequenzdaten_aus_Deutschland/master/SARS-CoV-2-Sequenzdaten_Deutschland.csv.xz" \
+    --fail --silent --show-error --http1.1 \
+    --header 'User-Agent: https://github.com/nextstrain/ncov-ingest (hello@nextstrain.org)'

--- a/bin/fetch-from-rki-sequences
+++ b/bin/fetch-from-rki-sequences
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+curl "https://raw.githubusercontent.com/robert-koch-institut/SARS-CoV-2-Sequenzdaten_aus_Deutschland/master/SARS-CoV-2-Sequenzdaten_Deutschland.fasta.xz" \
+    --fail --silent --show-error --http1.1 \
+    --header 'User-Agent: https://github.com/nextstrain/ncov-ingest (hello@nextstrain.org)'

--- a/bin/run-nextclade
+++ b/bin/run-nextclade
@@ -26,15 +26,16 @@ GENES="${7}"
 
 NEXTCLADE_THREADS=""
 if [ $# -eq 8 ]; then
-    echo "[ INFO] ${0}:${LINENO}: Nextclade will be limited to ${8} threads"
-    NEXTCLADE_THREADS="--jobs ${8}"
+  echo "[ INFO] ${0}:${LINENO}: Nextclade will be limited to ${8} threads"
+  NEXTCLADE_THREADS="--jobs ${8}"
 elif [ $# -gt 8 ]; then
-    echo "[ INFO] ${0}:${LINENO}: Too many arguments provided"
-    exit 1
+  echo "[ INFO] ${0}:${LINENO}: Too many arguments provided"
+  exit 1
 fi
 
 echo "[ INFO] ${0}:${LINENO}: Downloading latest Nextclade version"
-curl -fsSL "https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-x86_64-unknown-linux-gnu" -o "nextclade"
+# curl -fsSL "https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-x86_64-unknown-linux-gnu" -o "nextclade"
+curl -fSL "https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-aarch64-apple-darwin" -o "nextclade"
 chmod +x nextclade
 
 if ! command -v ./nextclade &>/dev/null; then
@@ -47,7 +48,6 @@ echo "[ INFO] ${0}:${LINENO}: Nextclade version: ${NEXTCLADE_VERSION}"
 
 echo "[ INFO] ${0}:${LINENO}: Downloading Nextclade dataset \"sars-cov-2\""
 ./nextclade dataset get --name=sars-cov-2 --output-dir="${NEXTCLADE_DATASET_DIR}" --verbose
-
 
 echo "[ INFO] ${0}:${LINENO}: Running Nextclade"
 ./nextclade run \

--- a/bin/run-nextclade
+++ b/bin/run-nextclade
@@ -34,8 +34,12 @@ elif [ $# -gt 8 ]; then
 fi
 
 echo "[ INFO] ${0}:${LINENO}: Downloading latest Nextclade version"
-# curl -fsSL "https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-x86_64-unknown-linux-gnu" -o "nextclade"
-curl -fSL "https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-aarch64-apple-darwin" -o "nextclade"
+if [ "$(uname)" = "Darwin" ]; then
+  curl -fsSL "https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-x86_64-apple-darwin" -o "nextclade"
+else
+  curl -fsSL "https://github.com/nextstrain/nextclade/releases/latest/download/nextclade-x86_64-unknown-linux-gnu" -o "nextclade"
+fi
+
 chmod +x nextclade
 
 if ! command -v ./nextclade &>/dev/null; then

--- a/bin/run-nextclade-full
+++ b/bin/run-nextclade-full
@@ -70,7 +70,7 @@ main() {
   DATE_UTC=$(date -u "+%Y-%m-%d--%H-%M-%S--%Z")
   S3_DST="$S3_SRC/nextclade-full-run-${DATE_UTC}"
 
-  INPUT_FASTA="data/${DATABASE}/sequences.fasta.xz"
+  INPUT_FASTA="data/${DATABASE}/sequences.fasta.zst"
   OUTPUT_FASTA="data/${DATABASE}/aligned.fasta"
   OUTPUT_TSV="data/${DATABASE}/nextclade.tsv"
 
@@ -105,7 +105,7 @@ main() {
     exit 1
   fi
 
-  echo "[ INFO] ${0}:${LINENO}: Downloading '${S3_SRC}/sequences.fasta.xz' to '${INPUT_FASTA}'"
+  echo "[ INFO] ${0}:${LINENO}: Downloading '${S3_SRC}/sequences.fasta.zst' to '${INPUT_FASTA}'"
   aws s3 cp --no-progress "${S3_SRC}/sequences.fasta.xz" "${INPUT_FASTA}"
 
   NEXTCLADE_VERSION="$(./${NEXTCLADE_BIN} --version)"

--- a/bin/run-nextclade-full
+++ b/bin/run-nextclade-full
@@ -24,7 +24,7 @@ disk_info() {
   lsblk -o MOUNTPOINT,FSSIZE,FSAVAIL,TYPE,NAME,ROTA,SIZE,MODEL || true
 
   echo "[ INFO] ${0}:${LINENO}: Summary of disk space usage:"
-  df -Th  || true | awk 'NR == 1; NR > 1 {print $0 | "sort -n"}'
+  df -Th || true | awk 'NR == 1; NR > 1 {print $0 | "sort -n"}'
 
   echo "[ INFO] ${0}:${LINENO}: Summary of occupied disk space:"
   du -bsch ./* 2>/dev/null || true | sort -h
@@ -60,6 +60,8 @@ main() {
     S3_SRC="s3://nextstrain-ncov-private"
   elif [ "${DATABASE}" == "genbank" ]; then
     S3_SRC="s3://nextstrain-data/files/ncov/open"
+  elif [ "${DATABASE}" == "rki" ]; then
+    S3_SRC="s3://nextstrain-data/files/ncov/rki"
   else
     echo "[ERROR] ${0}:${LINENO}: Unknown database: The '--database' flag should be set to either 'gisaid' or 'genbank'"
     exit 1
@@ -126,7 +128,7 @@ main() {
     --input-dataset="${TMP_DIR_NEXTCLADE_DATASET}" \
     --genes="${GENES}" \
     --output-tsv="${OUTPUT_TSV}" \
-    --output-fasta="${OUTPUT_FASTA}" \
+    --output-fasta="${OUTPUT_FASTA}"
 
   echo "[ INFO] ${0}:${LINENO}: Upload results"
   ./bin/upload-to-s3 ${silent:+--quiet} "${OUTPUT_TSV}" "$S3_DST/nextclade.tsv.gz"

--- a/bin/run-nextclade-full-aws
+++ b/bin/run-nextclade-full-aws
@@ -35,7 +35,6 @@ main() {
   DATABASE=
   N_PROCESSORS=
 
-
   AWS_BATCH_CPUS=96
   AWS_BATCH_MEMORY=180GiB
 
@@ -64,7 +63,7 @@ main() {
     esac
   done
 
-  if [ "${DATABASE}" != "gisaid" ] && [ "${DATABASE}" != "genbank" ]; then
+  if [ "${DATABASE}" != "gisaid" ] && [ "${DATABASE}" != "genbank" ] && [ "${DATABASE}" != "rki"]; then
     echo "[ERROR] ${0}:${LINENO}: Unknown database: The '--database' flag should be set to either 'gisaid' or 'genbank'"
     exit 1
   fi
@@ -74,7 +73,7 @@ main() {
     AWS_ACCESS_KEY_ID \
     AWS_SECRET_ACCESS_KEY \
     SLACK_TOKEN \
-    SLACK_CHANNELS \
+    SLACK_CHANNELS
 
   echo "[ INFO] ${0}:${LINENO}: Submitting Nextclade full run on AWS Batch"
   echo "[ INFO] ${0}:${LINENO}:   DATABASE=${DATABASE}"
@@ -92,8 +91,8 @@ main() {
     --exec env \
     . \
     envdir env.d run-nextclade-full \
-      --database="${DATABASE}" \
-      ${N_PROCESSORS:+--jobs=$N_PROCESSORS} \
+    --database="${DATABASE}" \
+    ${N_PROCESSORS:+--jobs=$N_PROCESSORS}
 
 }
 

--- a/bin/transform-rki
+++ b/bin/transform-rki
@@ -10,7 +10,7 @@ from pathlib import Path
 from collections import defaultdict
 import pandas as pd
 from xopen import xopen
-from tqdm import tqdm
+# from tqdm import tqdm
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 sys.path.insert(0, str(Path(__file__).parent.parent) + "/lib")
@@ -131,10 +131,10 @@ if __name__ == '__main__':
                 print("WARNING: couldn't parse annotations file " + args.annotations)
 
     with xopen(args.rki_data, "r") as rki_fh:
-        with tqdm() as pbar:
+        # with tqdm() as pbar:
             pipeline = (
                 LineToJsonDataSource(rki_fh)
-                | UpdateProgress(pbar)
+                # | UpdateProgress(pbar)
                 | RenameAndAddColumns(column_map=COLUMN_MAP)
                 | StandardizeDataRki()
                 | SequenceLengthFilter(15000)
@@ -194,7 +194,7 @@ if __name__ == '__main__':
                 metadata_csv.writerow(entry)
 
     with xopen(args.rki_data, "r") as genbank_IN, xopen(args.output_fasta, "wt", newline=args.newline) as fasta_OUT:
-        for entry in tqdm(
+        for entry in (
                 LineToJsonDataSource(genbank_IN)
                 | RenameAndAddColumns(column_map=COLUMN_MAP)
                 | StandardizeDataRki()

--- a/bin/transform-rki
+++ b/bin/transform-rki
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Parse RKI NDJSON, turn into metadata.tsv and a sequences.fasta file
+"""
+import os
+import argparse
+import csv
+import sys
+from pathlib import Path
+from collections import defaultdict
+import pandas as pd
+from xopen import xopen
+from tqdm import tqdm
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent) + "/lib")
+
+from lib.utils.transformpipeline.transforms import AddHardcodedMetadataRki, RkiZipToGeography, SetStrainNameRki, StandardizeDataRki, UpdateProgress
+
+from lib.utils.transform import (
+    METADATA_COLUMNS,
+)
+from lib.utils.transformpipeline import LINE_NUMBER_KEY
+from lib.utils.transformpipeline.datasource import LineToJsonDataSource
+from lib.utils.transformpipeline.filters import SequenceLengthFilter, LineNumberFilter, GenbankProblematicFilter
+from lib.utils.transformpipeline.transforms import (
+    AbbreviateAuthors,
+    ApplyUserGeoLocationSubstitutionRules,
+    AddHardcodedMetadataGenbank,
+    DropSequenceData,
+    FillDefaultLocationData,
+    FixLabs,
+    MaskBadCollectionDate,
+    MergeBiosampleMetadata,
+    MergeUserAnnotatedMetadata,
+    ParseGeographicColumnsGenbank,
+    ParsePatientAge,
+    ParseSex,
+    RenameAndAddColumns,
+    StandardizeData,
+    StandardizeGenbankStrainNames,
+    Tracker,
+    UserProvidedAnnotations,
+    UserProvidedGeoLocationSubstitutionRules,
+    patchUKData
+)
+
+COLUMN_MAP = {'DATE_DRAW': 'date',
+              'RECEIVE_DATE': 'date_submitted',
+              'PROCESSING_DATE': 'date_released',
+              'SENDING_LAB_PC': 'originating_lab',
+              'SEQUENCING_LAB_PC': 'submitting_lab',
+              'GISAID_ACCESSION': 'strain_gisaid',
+              'lineage': 'pango_lineage',
+              'lineage_y': 'pango_lineage',
+              'SEQ_REASON': 'sampling_strategy',
+              }
+
+
+assert 'sequence' not in METADATA_COLUMNS, "Sequences should not appear in metadata!"
+
+
+if __name__ == '__main__':
+    base = Path(__file__).resolve().parent.parent
+
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument("rki_data",
+                        default="s3://nextstrain-data/files/ncov/open/rki.ndjson.zst",
+                        nargs="?",
+                        help="Newline-delimited RKI JSON data")
+    parser.add_argument("--annotations",
+                        default=base / "source-data/rki_annotations.tsv",
+                        help="Optional manually curated annotations TSV.\n"
+                        "The TSV file should have no header and exactly three columns which contain:\n\t"
+                        "1. the RKI accession ID \n\t"
+                        "2. the column name to replace from the generated `metadata.tsv` file\n\t"
+                        "3. the replacement data\n"
+                        "Lines or parts of lines starting with '#' are treated as comments.\n"
+                        "e.g.\n\t"
+                        "MT039888	location    Boston\n\t"
+                        "# First Californian sample\n\t"
+                        "MN994467	country_exposure	China\n\t"
+                        "MN908947	collection_date 2019-12-26 # Manually corrected date")
+    parser.add_argument("--accessions",
+                        default=base / "source-data/rki_accessions.tsv",
+                        help="Optional manually curated TSV cross-referencing accessions between databases (e.g. GISAID and GenBank/INSDC).")
+    parser.add_argument("--output-metadata",
+                        default=base / "data/rki/metadata.tsv",
+                        help="Output location of generated metadata tsv. Defaults to `data/rki/metadata.tsv`")
+    parser.add_argument("--output-fasta",
+                        default=base / "data/rki/sequences.fasta",
+                        help="Output location of generated FASTA file. Defaults to `data/rki/sequences.fasta`")
+    parser.add_argument("--problem-data",
+                        default=base / "data/rki/problem_data.tsv",
+                        help="Output location of generated tsv of problem records missing geography region or country")
+    parser.add_argument(
+        "--output-unix-newline",
+        dest="newline",
+        action="store_const",
+        const="\n",
+        default=os.linesep,
+        help="When specified, always use unix newlines in output files."
+    )
+    args = parser.parse_args()
+
+    # parsing curated annotations
+    annotations = UserProvidedAnnotations()
+    if args.annotations:
+        # Use the curated annotations tsv to update any column values
+        with open(args.annotations, "r") as gisaid_fh:
+            try:
+                csvreader = csv.reader(gisaid_fh, delimiter='\t')
+            
+                for row in csvreader:
+                    if row[0].lstrip()[0] == '#':
+                        continue
+                    elif len(row) != 3:
+                        print("WARNING: couldn't decode annotation line " +
+                            "\t".join(row))
+                        continue
+                    strainId, key, value = row
+                    annotations.add_user_annotation(
+                        strainId,
+                        key,
+                        # remove the comment and the extra ws from the value
+                        value.split('#')[0].rstrip(),
+                    )
+            except:
+                print("WARNING: couldn't parse annotations file " + args.annotations)
+
+    with xopen(args.rki_data, "r") as rki_fh:
+        with tqdm() as pbar:
+            pipeline = (
+                LineToJsonDataSource(rki_fh)
+                | UpdateProgress(pbar)
+                | RenameAndAddColumns(column_map=COLUMN_MAP)
+                | StandardizeDataRki()
+                | SequenceLengthFilter(15000)
+            )
+
+            pipeline = pipeline | DropSequenceData()
+
+            pipeline = (pipeline | AddHardcodedMetadataRki()
+                        | MaskBadCollectionDate()
+                        | SetStrainNameRki()
+                        | RkiZipToGeography()  # ( base / 'source-data/us-state-codes.tsv' )
+                        | MergeUserAnnotatedMetadata(annotations, idKey='rki_accession')
+                        | FillDefaultLocationData()
+                        )
+
+            sorted_metadata = sorted(
+                pipeline,
+                key=lambda obj: (
+                    obj['strain'],
+                    -obj['length'],
+                    obj['rki_accession'],
+                    obj[LINE_NUMBER_KEY]
+                )
+            )
+
+    # this should be moved further down
+    # dedup by strain and compile a list of relevant line numbers.
+    seen_strains = set()
+    line_numbers = set()
+    updated_strain_names_by_line_no = {}
+
+    for entry in sorted_metadata:
+
+        if entry['strain'] in seen_strains:
+            continue
+
+        seen_strains.add(entry['strain'])
+        line_numbers.add(entry[LINE_NUMBER_KEY])
+        updated_strain_names_by_line_no[entry[LINE_NUMBER_KEY]
+                                        ] = entry['strain']
+
+    with xopen(args.output_metadata, 'wt') as metadata_OUT:
+        dict_writer_kwargs = {'lineterminator': args.newline}
+
+        metadata_csv = csv.DictWriter(
+            metadata_OUT,
+            METADATA_COLUMNS,
+            restval="",
+            extrasaction='ignore',
+            delimiter='\t',
+            **dict_writer_kwargs
+        )
+        metadata_csv.writeheader()
+
+        for entry in sorted_metadata:
+            if entry[LINE_NUMBER_KEY] in line_numbers:
+                metadata_csv.writerow(entry)
+
+    with xopen(args.rki_data, "r") as genbank_IN, xopen(args.output_fasta, "wt", newline=args.newline) as fasta_OUT:
+        for entry in tqdm(
+                LineToJsonDataSource(genbank_IN)
+                | RenameAndAddColumns(column_map=COLUMN_MAP)
+                | StandardizeDataRki()
+                | SetStrainNameRki()
+                | LineNumberFilter(line_numbers)
+        ):
+            strain_name = updated_strain_names_by_line_no[entry[LINE_NUMBER_KEY]]
+            print('>', strain_name, sep='', file=fasta_OUT)
+            print(entry['sequence'], file=fasta_OUT)

--- a/bin/transform-rki-data-to-ndjson
+++ b/bin/transform-rki-data-to-ndjson
@@ -21,6 +21,8 @@ def main(
 
     with xopen(input_rki_metadata, "r") as fin:
         metadata = pd.read_csv(fin, low_memory=False, index_col="IMS_ID")
+        # Yes there are duplicate lines
+        metadata = metadata[~metadata.index.duplicated(keep='first')]
 
     with xopen(input_rki_lineages, "r") as fin:
         lineages = pd.read_csv(fin, low_memory=False, index_col="IMS_ID")
@@ -40,6 +42,8 @@ def main(
                 **metadata.loc[record.id].to_dict(),
                 "sequence": str(record.seq),
             }
+            # if type(output["lineage"]) == dict:
+            #     import ipdb; ipdb.set_trace()
             fout.write(json.dumps(output) + "\n")
 
 

--- a/bin/transform-rki-data-to-ndjson
+++ b/bin/transform-rki-data-to-ndjson
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""
+Turn RKI files into ndjson format
+"""
+
+import typer
+
+def main(
+    input_rki_sequences: str = typer.Option(..., help="Input file"),
+    input_rki_metadata: str = typer.Option(..., help="Input file"),
+    input_rki_lineages: str = typer.Option(..., help="Input file"),
+    output_ndjson: str = typer.Option(..., help="Output file"),
+):
+    """
+    Turn RKI files into ndjson format
+    """
+    import json
+    import pandas as pd
+    from xopen import xopen
+    from Bio import SeqIO
+
+    with xopen(input_rki_metadata, "r") as fin:
+        metadata = pd.read_csv(fin, low_memory=False, index_col="IMS_ID")
+
+    with xopen(input_rki_lineages, "r") as fin:
+        lineages = pd.read_csv(fin, low_memory=False, index_col="IMS_ID")
+
+    metadata = pd.merge(
+        metadata,
+        lineages["lineage"],
+        how="left",
+        left_index=True,
+        right_index=True,
+    )
+
+    with xopen(output_ndjson, "w") as fout:
+        for record in SeqIO.parse(xopen(input_rki_sequences), "fasta"):
+            output = {
+                "rki_accession": record.id,
+                **metadata.loc[record.id].to_dict(),
+                "sequence": str(record.seq),
+            }
+            fout.write(json.dumps(output) + "\n")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/config/local_rki.yaml
+++ b/config/local_rki.yaml
@@ -1,0 +1,8 @@
+# All the config parameters needed to run ncov-ingest for GenBank sequences
+# without all the bells and whistles used by internal Nextstrain runs that
+# involve AWS S3, Slack notifications, and GitHub Action triggers.
+database_name: "rki"
+
+fetch_from_database: True
+keep_all_files: True
+subsampled: True

--- a/config/rki.yaml
+++ b/config/rki.yaml
@@ -1,6 +1,6 @@
 database_name: "rki"
 
-fetch_from_database: true
+fetch_from_database: false
 trigger_rebuild: false
 trigger_counts: false
 

--- a/config/rki.yaml
+++ b/config/rki.yaml
@@ -1,0 +1,11 @@
+database_name: "rki"
+
+fetch_from_database: true
+trigger_rebuild: false
+trigger_counts: false
+
+s3_src: "s3://nextstrain-data/files/ncov/rki"
+s3_dst: "s3://nextstrain-data/files/ncov/rki"
+cloudfront_domain: "data.nextstrain.org"
+
+keep_all_files: False

--- a/workflow/snakemake_rules/curate.smk
+++ b/workflow/snakemake_rules/curate.smk
@@ -8,7 +8,7 @@ Expects different inputs for GISAID vs GenBank:
         ndjson = "data/genbank.ndjson"
         biosample = "data/biosample.ndjson"
 
-Produces different output files for GISAID vs GenBank:
+Produces different output files for GISAID vs GenBank vs RKI:
     GISAID:
         fasta = "data/gisaid/sequences.fasta"
         metadata = "data/gisaid/metadata_transformed.tsv"
@@ -20,41 +20,10 @@ Produces different output files for GISAID vs GenBank:
         metadata = "data/genbank/metadata_transformed.tsv"
         flagged_annotations = temp("data/genbank/flagged-annotations")
         duplicate_biosample = "data/genbank/duplicate_biosample.txt"
+    RKI:
+        fasta = "data/rki/sequences.fasta"
+        metadata = "data/rki/metadata_transformed.tsv"
 """
-
-
-rule transform_rki_data_to_ndjson:
-    input:
-        rki_sequences="data/rki_sequences.fasta.xz",
-        rki_metadata="data/rki_metadata.csv.xz",
-        rki_lineages="data/rki_lineages.csv.xz",
-    output:
-        ndjson="data/rki.ndjson.zst",
-    shell:
-        """
-        ./bin/transform-rki-data-to-ndjson \
-            --input-rki-sequences {input.rki_sequences} \
-            --input-rki-metadata {input.rki_metadata} \
-            --input-rki-lineages {input.rki_lineages} \
-            --output-ndjson {output.ndjson}
-        """
-
-
-rule unzstd_ndjson:
-    input:
-        ndjson="data/rki.ndjson.zst",
-    output:
-        ndjson="data/rki.ndjson",
-    params:
-        subsampled=config.get("subsampled", False),
-    shell:
-        """
-        if [ {params.subsampled} = True ]; then
-            (zstdcat {input.ndjson} | head -1000 > {output.ndjson}) || true
-        else
-            zstdcat {input.ndjson} >{output.ndjson}
-        fi
-        """
 
 
 rule transform_rki_data:

--- a/workflow/snakemake_rules/curate.smk
+++ b/workflow/snakemake_rules/curate.smk
@@ -22,28 +22,47 @@ Produces different output files for GISAID vs GenBank:
         duplicate_biosample = "data/genbank/duplicate_biosample.txt"
 """
 
+
+rule transform_rki_data_to_ndjson:
+    input:
+        rki_sequences="data/rki_sequences.fasta.xz",
+        rki_metadata="data/rki_metadata.csv.xz",
+        rki_lineages="data/rki_lineages.csv.xz",
+    output:
+        ndjson="data/rki.ndjson.zst",
+    shell:
+        """
+        ./bin/transform-rki-data-to-ndjson \
+            --input-rki-sequences {input.rki_sequences} \
+            --input-rki-metadata {input.rki_metadata} \
+            --input-rki-lineages {input.rki_lineages} \
+            --output-ndjson {output.ndjson}
+        """
+
+
 rule transform_biosample:
     input:
-        biosample = "data/biosample.ndjson"
+        biosample="data/biosample.ndjson",
     output:
-        biosample = "data/genbank/biosample.tsv"
+        biosample="data/genbank/biosample.tsv",
     shell:
         """
         ./bin/transform-biosample {input.biosample} \
             --output {output.biosample}
         """
 
+
 rule transform_genbank_data:
     input:
-        biosample = "data/genbank/biosample.tsv",
-        ndjson = "data/genbank.ndjson",
-        cog_uk_accessions = "data/cog_uk_accessions.tsv",
-        cog_uk_metadata = "data/cog_uk_metadata.csv.gz"
+        biosample="data/genbank/biosample.tsv",
+        ndjson="data/genbank.ndjson",
+        cog_uk_accessions="data/cog_uk_accessions.tsv",
+        cog_uk_metadata="data/cog_uk_metadata.csv.gz",
     output:
-        fasta = "data/genbank/sequences.fasta",
-        metadata = "data/genbank/metadata_transformed.tsv",
-        flagged_annotations = temp("data/genbank/flagged-annotations"),
-        duplicate_biosample = "data/genbank/duplicate_biosample.txt"
+        fasta="data/genbank/sequences.fasta",
+        metadata="data/genbank/metadata_transformed.tsv",
+        flagged_annotations=temp("data/genbank/flagged-annotations"),
+        duplicate_biosample="data/genbank/duplicate_biosample.txt",
     shell:
         """
         ./bin/transform-genbank {input.ndjson} \
@@ -55,14 +74,15 @@ rule transform_genbank_data:
             --output-fasta {output.fasta} > {output.flagged_annotations}
         """
 
+
 rule transform_gisaid_data:
     input:
-        ndjson = "data/gisaid.ndjson"
+        ndjson="data/gisaid.ndjson",
     output:
-        fasta = "data/gisaid/sequences.fasta",
-        metadata = "data/gisaid/metadata_transformed.tsv",
-        flagged_annotations = temp("data/gisaid/flagged-annotations"),
-        additional_info = "data/gisaid/additional_info.tsv"
+        fasta="data/gisaid/sequences.fasta",
+        metadata="data/gisaid/metadata_transformed.tsv",
+        flagged_annotations=temp("data/gisaid/flagged-annotations"),
+        additional_info="data/gisaid/additional_info.tsv",
     shell:
         """
         ./bin/transform-gisaid {input.ndjson} \
@@ -72,15 +92,16 @@ rule transform_gisaid_data:
             --output-unix-newline > {output.flagged_annotations};
         """
 
+
 rule flag_metadata:
     ### only applicable for GISAID
     input:
-        metadata = "data/gisaid/metadata.tsv"
+        metadata="data/gisaid/metadata.tsv",
     output:
-        metadata = "data/gisaid/flagged_metadata.txt"
+        metadata="data/gisaid/flagged_metadata.txt",
     resources:
         # Memory use scales primarily with the size of the metadata file.
-        mem_mb=20000
+        mem_mb=20000,
     shell:
         """
         ./bin/flag-metadata {input.metadata} > {output.metadata}

--- a/workflow/snakemake_rules/curate.smk
+++ b/workflow/snakemake_rules/curate.smk
@@ -40,6 +40,20 @@ rule transform_rki_data_to_ndjson:
         """
 
 
+rule transform_genbank_data:
+    input:
+        ndjson="data/rki.ndjson.zst",
+    output:
+        fasta="data/rki/sequences.fasta.zst",
+        metadata="data/genbank/metadata_transformed.tsv.zst",
+    shell:
+        """
+        ./bin/transform-rki {input.ndjson} \
+            --output-metadata {output.metadata} \
+            --output-fasta {output.fasta} > {output.flagged_annotations}
+        """
+
+
 rule transform_biosample:
     input:
         biosample="data/biosample.ndjson",

--- a/workflow/snakemake_rules/fetch_sequences.smk
+++ b/workflow/snakemake_rules/fetch_sequences.smk
@@ -192,8 +192,8 @@ if config.get("s3_dst") and config.get("s3_src"):
         message:
             """Fetching main NDJSON from AWS S3"""
         params:
-            file_on_s3_dst=f"{config['s3_dst']}/{database}.ndjson.xz",
-            file_on_s3_src=f"{config['s3_src']}/{database}.ndjson.xz",
+            file_on_s3_dst=f"{config['s3_dst']}/{database}.ndjson.zst",
+            file_on_s3_src=f"{config['s3_src']}/{database}.ndjson.zst",
         output:
             ndjson=temp(f"data/{database}.ndjson"),
         shell:

--- a/workflow/snakemake_rules/fetch_sequences.smk
+++ b/workflow/snakemake_rules/fetch_sequences.smk
@@ -166,6 +166,7 @@ rule unzstd_ndjson:
 
 # Make sure ndjson is always fetched correctly for RKI
 ruleorder: unzstd_ndjson > fetch_main_ndjson
+ruleorder: unzstd_ndjson > fetch_main_ndjson_from_s3
 
 
 # Only include rules to fetch from S3 if S3 config params are provided
@@ -179,6 +180,7 @@ if config.get("s3_dst") and config.get("s3_src"):
         ruleorder: fetch_main_ndjson > fetch_main_ndjson_from_s3
         ruleorder: fetch_biosample > fetch_biosample_from_s3
         ruleorder: unzstd_ndjson > fetch_main_ndjson_from_s3
+        ruleorder: unzstd_ndjson > fetch_main_ndjson
 
 
     else:

--- a/workflow/snakemake_rules/fetch_sequences.smk
+++ b/workflow/snakemake_rules/fetch_sequences.smk
@@ -96,7 +96,7 @@ rule fetch_rki_sequences:
     message:
         """Fetching RKI sequences (GenBank only)"""
     output:
-        rki_sequences=temp("data/rki_sequences.fasta.xz"),
+        rki_sequences="data/rki_sequences.fasta.xz",
     run:
         run_shell_command_n_times(
             f"./bin/fetch-from-rki-sequences > {output.rki_sequences}",
@@ -109,7 +109,7 @@ rule fetch_rki_metadata:
     message:
         """Fetching RKI metadata (GenBank only)"""
     output:
-        rki_metadata=temp("data/rki_metadata.csv.xz"),
+        rki_metadata="data/rki_metadata.csv.xz",
     run:
         run_shell_command_n_times(
             f"./bin/fetch-from-rki-metadata > {output.rki_metadata}",
@@ -122,13 +122,17 @@ rule fetch_rki_lineages:
     message:
         """Fetching RKI lineages (GenBank only)"""
     output:
-        rki_lineages=temp("data/rki_lineages.csv.xz"),
+        rki_lineages="data/rki_lineages.csv.xz",
     run:
         run_shell_command_n_times(
             f"./bin/fetch-from-rki-lineages > {output.rki_lineages}",
             "Fetch RKI lineages",
             f"rm {output.rki_lineages}",
         )
+
+
+# Make sure ndjson is always fetched correctly for RKI
+ruleorder: unzstd_ndjson > fetch_main_ndjson
 
 
 # Only include rules to fetch from S3 if S3 config params are provided
@@ -141,6 +145,7 @@ if config.get("s3_dst") and config.get("s3_src"):
 
         ruleorder: fetch_main_ndjson > fetch_main_ndjson_from_s3
         ruleorder: fetch_biosample > fetch_biosample_from_s3
+        ruleorder: unzstd_ndjson > fetch_main_ndjson_from_s3
 
 
     else:

--- a/workflow/snakemake_rules/fetch_sequences.smk
+++ b/workflow/snakemake_rules/fetch_sequences.smk
@@ -15,7 +15,11 @@ Produces different final outputs for GISAID vs GenBank:
         biosample = "data/biosample.ndjson"
         cog_uk_accessions = "data/cog_uk_accessions.tsv"
         cog_uk_metadata = "data/cog_uk_metadata.csv.gz"
+        rki_sequences = "data/rki_sequences.fasta.xz"
+        rki_metadata = "data/rki_metadata.csv.xz"
+        rki_lineages = "data/rki_lineages.csv.xz"
 """
+
 
 def run_shell_command_n_times(cmd, msg, cleanup_failed_cmd, retry_num=5):
     attempt = 0
@@ -26,17 +30,18 @@ def run_shell_command_n_times(cmd, msg, cleanup_failed_cmd, retry_num=5):
             break
         except CalledProcessError:
             print("...FAILED")
-            attempt+=1
+            attempt += 1
             shell("{cleanup_failed_cmd} && sleep 10")
     else:
         print(msg + f" has FAILED {retry_num} times. Exiting.")
         raise Exception("function run_shell_command_n_times has failed")
 
+
 rule fetch_main_ndjson:
     message:
         """Fetching data using the database API"""
     output:
-        ndjson = temp(f"data/{database}.ndjson")
+        ndjson=temp(f"data/{database}.ndjson"),
     run:
         if database == "gisaid":
             cmd = f"./bin/fetch-from-gisaid {output.ndjson}"
@@ -44,46 +49,87 @@ rule fetch_main_ndjson:
             cmd = f"./bin/fetch-from-genbank > {output.ndjson}"
 
         run_shell_command_n_times(
-            cmd,
-            f"Fetching from {database}",
-            f"rm {output.ndjson}"
+            cmd, f"Fetching from {database}", f"rm {output.ndjson}"
         )
+
 
 rule fetch_biosample:
     message:
         """Fetching BioSample data (GenBank only)"""
     output:
-        biosample = temp("data/biosample.ndjson")
+        biosample=temp("data/biosample.ndjson"),
     run:
         run_shell_command_n_times(
             f"./bin/fetch-from-biosample > {output.biosample}",
             "Fetch BioSample",
-            f"rm {output.biosample}"
+            f"rm {output.biosample}",
         )
+
 
 rule fetch_cog_uk_accessions:
     message:
         """Fetching COG-UK sample accesions (GenBank only)"""
     output:
-        cog_uk_accessions = temp("data/cog_uk_accessions.tsv")
+        cog_uk_accessions=temp("data/cog_uk_accessions.tsv"),
     run:
         run_shell_command_n_times(
             f"./bin/fetch-from-cog-uk-accessions > {output.cog_uk_accessions}",
             "Fetch COG-UK sample accessions",
-            f"rm {output.cog_uk_accessions}"
+            f"rm {output.cog_uk_accessions}",
         )
+
 
 rule fetch_cog_uk_metadata:
     message:
         """Fetching COG-UK metadata (GenBank only)"""
     output:
-        cog_uk_metadata = temp("data/cog_uk_metadata.csv.gz")
+        cog_uk_metadata=temp("data/cog_uk_metadata.csv.gz"),
     run:
         run_shell_command_n_times(
             f"./bin/fetch-from-cog-uk-metadata > {output.cog_uk_metadata}",
             "Fetch COG-UK metadata",
-            f"rm {output.cog_uk_metadata}"
+            f"rm {output.cog_uk_metadata}",
         )
+
+
+rule fetch_rki_sequences:
+    message:
+        """Fetching RKI sequences (GenBank only)"""
+    output:
+        rki_sequences=temp("data/rki_sequences.fasta.xz"),
+    run:
+        run_shell_command_n_times(
+            f"./bin/fetch-from-rki-sequences > {output.rki_sequences}",
+            "Fetch RKI sequences",
+            f"rm {output.rki_sequences}",
+        )
+
+
+rule fetch_rki_metadata:
+    message:
+        """Fetching RKI metadata (GenBank only)"""
+    output:
+        rki_metadata=temp("data/rki_metadata.csv.xz"),
+    run:
+        run_shell_command_n_times(
+            f"./bin/fetch-from-rki-metadata > {output.rki_metadata}",
+            "Fetch RKI metadata",
+            f"rm {output.rki_metadata}",
+        )
+
+
+rule fetch_rki_lineages:
+    message:
+        """Fetching RKI lineages (GenBank only)"""
+    output:
+        rki_lineages=temp("data/rki_lineages.csv.xz"),
+    run:
+        run_shell_command_n_times(
+            f"./bin/fetch-from-rki-lineages > {output.rki_lineages}",
+            "Fetch RKI lineages",
+            f"rm {output.rki_lineages}",
+        )
+
 
 # Only include rules to fetch from S3 if S3 config params are provided
 if config.get("s3_dst") and config.get("s3_src"):
@@ -92,20 +138,24 @@ if config.get("s3_dst") and config.get("s3_src"):
     # Fetch directly from databases when `fetch_from_database=True`
     # or else fetch files from AWS S3 buckets
     if config.get("fetch_from_database", False):
+
         ruleorder: fetch_main_ndjson > fetch_main_ndjson_from_s3
         ruleorder: fetch_biosample > fetch_biosample_from_s3
+
+
     else:
+
         ruleorder: fetch_main_ndjson_from_s3 > fetch_main_ndjson
-        ruleorder:  fetch_biosample_from_s3 > fetch_biosample
+        ruleorder: fetch_biosample_from_s3 > fetch_biosample
 
     rule fetch_main_ndjson_from_s3:
         message:
             """Fetching main NDJSON from AWS S3"""
         params:
-            file_on_s3_dst= f"{config['s3_dst']}/{database}.ndjson.xz",
-            file_on_s3_src= f"{config['s3_src']}/{database}.ndjson.xz"
+            file_on_s3_dst=f"{config['s3_dst']}/{database}.ndjson.xz",
+            file_on_s3_src=f"{config['s3_src']}/{database}.ndjson.xz",
         output:
-            ndjson = temp(f"data/{database}.ndjson")
+            ndjson=temp(f"data/{database}.ndjson"),
         shell:
             """
             ./bin/download-from-s3 {params.file_on_s3_dst} {output.ndjson} ||  \
@@ -116,10 +166,10 @@ if config.get("s3_dst") and config.get("s3_src"):
         message:
             """Fetching BioSample NDJSON from AWS S3"""
         params:
-            file_on_s3_dst= f"{config['s3_dst']}/biosample.ndjson.gz",
-            file_on_s3_src= f"{config['s3_src']}/biosample.ndjson.gz"
+            file_on_s3_dst=f"{config['s3_dst']}/biosample.ndjson.gz",
+            file_on_s3_src=f"{config['s3_src']}/biosample.ndjson.gz",
         output:
-            biosample = temp("data/biosample.ndjson")
+            biosample=temp("data/biosample.ndjson"),
         shell:
             """
             ./bin/download-from-s3 {params.file_on_s3_dst} {output.biosample} ||  \

--- a/workflow/snakemake_rules/nextclade.smk
+++ b/workflow/snakemake_rules/nextclade.smk
@@ -38,7 +38,7 @@ rule create_empty_nextclade_aligned:
 
 
 # Only include rules to fetch from S3 if S3 config params are provided
-if config.get("s3_dst") and config.get("s3_src") and not config["fetch_from_database"]:
+if config.get("s3_dst") and config.get("s3_src"):
 
     # Set ruleorder since these rules have the same output
     # Allows us to only download the NextClade cache from S3 only if the
@@ -95,6 +95,18 @@ rule get_sequences_without_nextclade_annotations:
         else
             cp {input.fasta} {output.fasta}
         fi
+        """
+
+
+rule print_number_of_sequences_without_nextclade_annotations:
+    """Print number of sequences in FASTA which don't have clades assigned yet"""
+    input:
+        fasta=f"data/{database}/nextclade.sequences.fasta",
+    output:
+        touch(f"data/{database}/nextclade.sequences.fasta.count"),
+    shell:
+        """
+        echo "[ INFO] Number of sequences to run Nextclade on: $(grep -c '^>' {input.fasta})"
         """
 
 
@@ -182,6 +194,7 @@ rule generate_metadata:
         nextclade_tsv=f"data/{database}/nextclade.tsv",
         aligned_fasta=f"data/{database}/aligned.fasta",
         existing_metadata=f"data/{database}/metadata_transformed.tsv",
+        trigger_count=f"data/{database}/nextclade.sequences.fasta.count",
     output:
         metadata=f"data/{database}/metadata.tsv",
     # note: the shell scripts which predated this snakemake workflow

--- a/workflow/snakemake_rules/nextclade.smk
+++ b/workflow/snakemake_rules/nextclade.smk
@@ -48,8 +48,8 @@ if config.get("s3_dst") and config.get("s3_src"):
 
     rule download_nextclade:
         params:
-            dst_source=config["s3_dst"] + "/nextclade.tsv.xz",
-            src_source=config["s3_src"] + "/nextclade.tsv.xz",
+            dst_source=config["s3_dst"] + "/nextclade.tsv.zst",
+            src_source=config["s3_src"] + "/nextclade.tsv.zst",
         output:
             nextclade=f"data/{database}/nextclade_old.tsv",
         shell:
@@ -60,8 +60,8 @@ if config.get("s3_dst") and config.get("s3_src"):
 
     rule download_previous_alignment:
         params:
-            dst_source=config["s3_dst"] + "/aligned.fasta.xz",
-            src_source=config["s3_src"] + "/aligned.fasta.xz",
+            dst_source=config["s3_dst"] + "/aligned.fasta.zst",
+            src_source=config["s3_src"] + "/aligned.fasta.zst",
         output:
             alignment=temp(f"data/{database}/nextclade.aligned.old.fasta"),
         shell:

--- a/workflow/snakemake_rules/slack_notifications.smk
+++ b/workflow/snakemake_rules/slack_notifications.smk
@@ -27,7 +27,7 @@ rule notify_on_record_change:
     input:
         ndjson = f"data/{database}.ndjson"
     params:
-        ndjson_on_s3 = f"{config['s3_src']}/{database}.ndjson.xz"
+        ndjson_on_s3 = f"{config['s3_src']}/{database}.ndjson.zst"
     output:
         touch(f"data/{database}/notify-on-record-change.done")
     shell:


### PR DESCRIPTION
Adapts the existing ingest workflow to additionally ingest RKI data from https://github.com/robert-koch-institut/SARS-CoV-2-Sequenzdaten_aus_Deutschland

So far, the ingest is completely separate from the existing `gisaid` and `genbank/open` ingests. Output ends up in `s3://nextstrain-data/files/ncov/rki`

The transform pipeline is bare bones, to get something going.

The next step will be to merge with `genbank`. Some deduplication will be necessary as `genbank` contains about 500k German sequences. `rki` has about 1.1m. Thankfully, `rki` has submitted their internal id to `genbank` so deduplication shouldn't be too difficult.

### Testing

I've tested this thoroughly for the RKI side of things.

The changes that impact things other than RKI are minor but I'll test nonetheless, running gisaid and genbank on branch to make sure nothing fails.

### Next steps

- Figure out how to merge output with genbank so that data can be used by covSpectrum and for builds without any change in downstream code.
- Turn zip codes into states/location
- Come up with decent strain names that arent 30 characters long
