### PR TITLE
Add `genbank_accession_rev` to output metadata

### DIFF
--- a/lib/utils/transform.py
+++ b/lib/utils/transform.py
@@ -6,7 +6,7 @@ from typing import Optional, Set, Union
 
 # Note: 'sequence' should NEVER appear in these lists!
 METADATA_COLUMNS = [  # Ordering of columns in the existing metadata.tsv in the ncov repo
-    'strain', 'virus', 'gisaid_epi_isl', 'genbank_accession', 'sra_accession', 'date', 'region',
+    'strain', 'virus', 'gisaid_epi_isl', 'genbank_accession', 'genbank_accession_rev', 'sra_accession', 'date', 'region',
     'country', 'division', 'location', 'region_exposure', 'country_exposure',
     'division_exposure', 'segment', 'length', 'host', 'age', 'sex', 'pango_lineage', 'GISAID_clade',
     'originating_lab', 'submitting_lab', 'authors', 'url', 'title', 'paper_url',


### PR DESCRIPTION
Best practice to include sequence revision - Genbank provides this so lets use it.

As a result, genbank revision metadata will also appear in gisaid as a `?` but I don't think that's so terrible.

This also reminds users that we still don't have GISAID revision numbers which would be really good to have.

Resolves #359

Test build output here: s3://nextstrain-staging/files/ncov/open/branch/add-genbank-accession-rev
