### PR TITLE
chore: bump action versions for node update from 12->16

### DIFF
--- a/.github/workflows/fetch-and-ingest-genbank-branch.yml
+++ b/.github/workflows/fetch-and-ingest-genbank-branch.yml
@@ -7,7 +7,7 @@ jobs:
   ingest:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
 
     - name: run_pipeline

--- a/.github/workflows/fetch-and-ingest-genbank-master.yml
+++ b/.github/workflows/fetch-and-ingest-genbank-master.yml
@@ -40,7 +40,7 @@ jobs:
       SLACK_CHANNELS: ncov-genbank-updates
       SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
 
     - name: run_pipeline

--- a/.github/workflows/fetch-and-ingest-gisaid-branch.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-branch.yml
@@ -7,7 +7,7 @@ jobs:
   ingest:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
 
     - name: run_pipeline

--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -39,7 +39,7 @@ jobs:
       SLACK_CHANNELS: ncov-gisaid-updates
       SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
 
     - name: run_pipeline

--- a/.github/workflows/fetch-and-ingest-rki-branch.yml
+++ b/.github/workflows/fetch-and-ingest-rki-branch.yml
@@ -7,7 +7,7 @@ jobs:
   ingest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
 
       - name: run_pipeline

--- a/.github/workflows/ingest-genbank-branch.yml
+++ b/.github/workflows/ingest-genbank-branch.yml
@@ -7,7 +7,7 @@ jobs:
   ingest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
 
       - name: run_pipeline

--- a/.github/workflows/ingest-genbank-master.yml
+++ b/.github/workflows/ingest-genbank-master.yml
@@ -19,7 +19,7 @@ jobs:
       SLACK_CHANNELS: ncov-genbank-updates
       SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
 
     - name: run_pipeline

--- a/.github/workflows/ingest-gisaid-master.yml
+++ b/.github/workflows/ingest-gisaid-master.yml
@@ -19,7 +19,7 @@ jobs:
       SLACK_CHANNELS: ncov-gisaid-updates
       SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
 
     - name: run_pipeline

--- a/.github/workflows/nextclade-full-run-genbank.yml
+++ b/.github/workflows/nextclade-full-run-genbank.yml
@@ -20,7 +20,7 @@ jobs:
       SLACK_CHANNELS: ncov-genbank-updates
       SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
 
       - name: "./bin/run-nextclade-full-aws --database=genbank"

--- a/.github/workflows/nextclade-full-run-gisaid.yml
+++ b/.github/workflows/nextclade-full-run-gisaid.yml
@@ -20,7 +20,7 @@ jobs:
       SLACK_CHANNELS: ncov-gisaid-updates
       SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
 
       - name: "./bin/run-nextclade-full-aws --database=gisaid"

--- a/.github/workflows/rebuild-gisaid.yml
+++ b/.github/workflows/rebuild-gisaid.yml
@@ -19,7 +19,7 @@ jobs:
       SLACK_CHANNELS: ncov-gisaid-updates
       SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
 
     - name: rebuild

--- a/.github/workflows/rebuild-open.yml
+++ b/.github/workflows/rebuild-open.yml
@@ -22,7 +22,7 @@ jobs:
       SLACK_CHANNELS: ncov-genbank-updates
       SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
 
     - name: rebuild

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -7,7 +7,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: install
         run: sudo snap install --channel=edge shellcheck

--- a/.github/workflows/update-image.yml
+++ b/.github/workflows/update-image.yml
@@ -26,7 +26,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v1
       - uses: docker/login-action@v1
         with:

--- a/.github/workflows/update-image.yml
+++ b/.github/workflows/update-image.yml
@@ -46,7 +46,7 @@ jobs:
           fi
           echo "IMAGE_TAG=$IMAGE_TAG" | tee -a "$GITHUB_ENV"
 
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v3
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/update-image.yml
+++ b/.github/workflows/update-image.yml
@@ -27,8 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: docker/setup-buildx-action@v1
-      - uses: docker/login-action@v1
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
         with:
           username: nextstrainbot
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
- chore: bump gh actions/checkout@v2 to v3
- chore: bump docker actions from v1 to v2
- chore: bump docker/build-push-action from v2 to v3

Migration necessary due to Github requiring all actions to use node 16 by summer 2023

Things should continue to work.

We may want to do this in an automated fashion on all repos. But let's start here.