### PR TITLE
Pin shellcheck ubuntu to 20.04

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -2,12 +2,13 @@ name: shellcheck
 
 on:
   push:
+  workflow_dispatch:
 
 jobs:
   shellcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: install
         run: sudo snap install --channel=edge shellcheck


### PR DESCRIPTION
@tsibley correctly identified that the recent shellcheck failures was due to us using ubuntu-latest which caused an implicit upgrade to 22.04 which caused a failure.

Pinning to 20.04 seems to fix it.