### PR TITLE
Only trigger ncov builds with new data 

### DIFF
--- a/bin/trigger-on-new-data
+++ b/bin/trigger-on-new-data
@@ -5,9 +5,11 @@ set -euo pipefail
 
 bin="$(dirname "$0")"
 
-metadata="${1:?A metadata upload output file is required as the first argument.}"
-sequences="${2:?An sequence FASTA upload output file is required as the second argument.}"
-identical_file_message="${3:-files are identical}"
+repo="${1:?A repository name is required as the first argument.}"
+event_type="${2:?An event type is required as the second argument.}"
+metadata="${3:?A metadata upload output file is required as the third argument.}"
+sequences="${4:?An sequence FASTA upload output file is required as the fourth argument.}"
+identical_file_message="${5:-files are identical}"
 
 new_metadata=$(grep "$identical_file_message" "$metadata" >/dev/null; echo $?)
 new_sequences=$(grep "$identical_file_message" "$sequences" >/dev/null; echo $?)
@@ -17,7 +19,7 @@ slack_message=""
 # grep exit status 0 for found match, 1 for no match, 2 if an error occurred
 if [[ $new_metadata -eq 1 || $new_sequences -eq 1 ]]; then
     slack_message="Triggering new builds due to updated metadata and/or sequences"
-    "$bin"/trigger "monkeypox" "rebuild"
+    "$bin"/trigger "$repo" "$event_type"
 elif [[ $new_metadata -eq 0 && $new_sequences -eq 0 ]]; then
     slack_message="Skipping trigger of rebuild: Both metadata TSV and sequences FASTA are identical to S3 files."
 else

--- a/bin/trigger-on-new-data
+++ b/bin/trigger-on-new-data
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+: "${PAT_GITHUB_DISPATCH:?The PAT_GITHUB_DISPATCH environment variable is required.}"
+
+bin="$(dirname "$0")"
+
+metadata="${1:?A metadata upload output file is required as the first argument.}"
+sequences="${2:?An sequence FASTA upload output file is required as the second argument.}"
+identical_file_message="${3:-files are identical}"
+
+new_metadata=$(grep "$identical_file_message" "$metadata" >/dev/null; echo $?)
+new_sequences=$(grep "$identical_file_message" "$sequences" >/dev/null; echo $?)
+
+slack_message=""
+
+# grep exit status 0 for found match, 1 for no match, 2 if an error occurred
+if [[ $new_metadata -eq 1 || $new_sequences -eq 1 ]]; then
+    slack_message="Triggering new builds due to updated metadata and/or sequences"
+    "$bin"/trigger "monkeypox" "rebuild"
+elif [[ $new_metadata -eq 0 && $new_sequences -eq 0 ]]; then
+    slack_message="Skipping trigger of rebuild: Both metadata TSV and sequences FASTA are identical to S3 files."
+else
+    slack_message="Skipping trigger of rebuild: Unable to determine if data has been updated."
+fi
+
+
+if ! "$bin"/notify-slack "$slack_message"; then
+    echo "Notifying Slack failed, but exiting with success anyway."
+fi

--- a/workflow/snakemake_rules/trigger.smk
+++ b/workflow/snakemake_rules/trigger.smk
@@ -14,14 +14,19 @@ These output files are empty flag files to force Snakemake to run the trigger ru
 rule trigger_rebuild_pipeline:
     message: "Triggering nextstrain/ncov rebuild action (via repository dispatch)"
     input:
-        f"data/{database}/upload.done"
+        metadata_upload = f"data/{database}/metadata.tsv.gz.upload",
+        fasta_upload = f"data/{database}/sequences.fasta.xz.upload",
     output:
         touch(f"data/{database}/trigger-rebuild.done")
     params:
         dispatch_type = f"{database}/rebuild"
     shell:
         """
-        ./bin/trigger ncov {params.dispatch_type}
+        ./bin/trigger-on-new-data \
+            ncov \
+            {params.dispatch_type} \
+            {input.metadata_upload} \
+            {input.fasta_upload}
         """
 
 rule trigger_counts_pipeline:

--- a/workflow/snakemake_rules/upload.smk
+++ b/workflow/snakemake_rules/upload.smk
@@ -74,7 +74,7 @@ def files_to_upload(wildcards):
 rule upload_single:
     input: lambda wildcards: compute_files_to_upload(wildcards)[wildcards.remote_filename]
     output:
-        touch("data/{database}/{remote_filename}.upload")
+        "data/{database}/{remote_filename}.upload"
     params:
         quiet = "" if send_notifications else "--quiet",
         s3_bucket = config.get("s3_dst",""),
@@ -85,7 +85,7 @@ rule upload_single:
             {params.quiet} \
             {input:q} \
             {params.s3_bucket:q}/{wildcards.remote_filename:q} \
-            {params.cloudfront_domain}
+            {params.cloudfront_domain} 2>&1 | tee {output}
         """
 
 rule upload:

--- a/workflow/snakemake_rules/upload.smk
+++ b/workflow/snakemake_rules/upload.smk
@@ -80,7 +80,13 @@ rule upload_single:
         s3_bucket = config.get("s3_dst",""),
         cloudfront_domain = config.get("cloudfront_domain", ""),
     shell:
-        "./bin/upload-to-s3 {params.quiet} {input:q} {params.s3_bucket:q}/{wildcards.remote_filename:q} {params.cloudfront_domain}"
+        """
+        ./bin/upload-to-s3 \
+            {params.quiet} \
+            {input:q} \
+            {params.s3_bucket:q}/{wildcards.remote_filename:q} \
+            {params.cloudfront_domain}
+        """
 
 rule upload:
     """


### PR DESCRIPTION
### Description of proposed changes

We do not want to waste time and resources to run rebuilds when the
ncov-ingest outputs have not changed. This commit updates the pipeline
to check the outputs from the uploads of the metadata TSV and sequences
FASTA files to verify they have been updated on S3. If the output
includes the message "files are identical" then we skip the trigger
for rebuilds.

Prompted by internal conversation on [Slack](https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1669678401065859). 

### Testing

- [x] Modified trigger-on-new-data script worked as expected locally
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
