### PR TITLE
Add RKI data to open (genbank) data

### DIFF
--- a/bin/fetch-from-rki-lineages
+++ b/bin/fetch-from-rki-lineages
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+curl "https://raw.githubusercontent.com/robert-koch-institut/SARS-CoV-2-Sequenzdaten_aus_Deutschland/master/SARS-CoV-2-Entwicklungslinien_Deutschland.csv.xz" \
+    --fail --silent --show-error --http1.1 \
+    --header 'User-Agent: https://github.com/nextstrain/ncov-ingest (hello@nextstrain.org)'

--- a/bin/fetch-from-rki-metadata
+++ b/bin/fetch-from-rki-metadata
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+curl "https://raw.githubusercontent.com/robert-koch-institut/SARS-CoV-2-Sequenzdaten_aus_Deutschland/master/SARS-CoV-2-Sequenzdaten_Deutschland.csv.xz" \
+    --fail --silent --show-error --http1.1 \
+    --header 'User-Agent: https://github.com/nextstrain/ncov-ingest (hello@nextstrain.org)'

--- a/bin/fetch-from-rki-sequences
+++ b/bin/fetch-from-rki-sequences
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+curl "https://raw.githubusercontent.com/robert-koch-institut/SARS-CoV-2-Sequenzdaten_aus_Deutschland/master/SARS-CoV-2-Sequenzdaten_Deutschland.fasta.xz" \
+    --fail --silent --show-error --http1.1 \
+    --header 'User-Agent: https://github.com/nextstrain/ncov-ingest (hello@nextstrain.org)'

--- a/bin/merge-open
+++ b/bin/merge-open
@@ -43,6 +43,7 @@ def main(
 
     # Select rki rows that are not in the genbank internal_ids -> not already in Genbank
     new_rki = rki[~rki.index.isin(internal_ids)]
+    print(f"All RKI sequences: {len(rki)}, already in Genbank and hence removed: {len(rki) - len(new_rki)}")
 
     # Add source database column to metadata
     genbank.loc[:, "database"] = "genbank"

--- a/bin/merge-open
+++ b/bin/merge-open
@@ -10,7 +10,6 @@ def main(
     input_rki_sequences: str = typer.Option(...),
     input_rki_metadata: str = typer.Option(...),
     input_genbank_sequences: str = typer.Option(...),
-    input_genbank_biosample: str = typer.Option(...),
     input_genbank_metadata: str = typer.Option(...),
     output_sequences: str = typer.Option(...),
     output_metadata: str = typer.Option(...),
@@ -28,30 +27,20 @@ def main(
             fin, index_col="strain", low_memory=True, sep="\t"
         )
 
-    with xopen(input_genbank_biosample, "r") as fin:
-        biosample = pd.read_csv(
-            fin, index_col="biosample_accession", low_memory=False, sep="\t"
-        )
-
-    # Get biosample accessions that are in genbank metadata
-    biosample_accessions = genbank["biosample_accession"].dropna().tolist()
+    # Add source database column to metadata
+    genbank.loc[:, "database"] = "genbank"
+    rki.loc[:, "database"] = "rki"
 
     # Get internal_ids from the biosample accessions that are in genbank metadata
-    internal_ids = biosample[
-        biosample.index.isin(biosample_accessions)
-    ]["internal_id"].dropna()
+    internal_ids = genbank["internal_id"].dropna()
 
     # Select rki rows that are not in the genbank internal_ids -> not already in Genbank
     new_rki = rki[~rki.index.isin(internal_ids)]
     print(f"All RKI sequences: {len(rki)}, already in Genbank and hence removed: {len(rki) - len(new_rki)}")
 
-    # Add source database column to metadata
-    genbank.loc[:, "database"] = "genbank"
-    new_rki.loc[:, "database"] = "rki"
-
     # Create new merged open data dataframe
     open = pd.concat(
-        [genbank.drop("biosample_accession", axis=1), new_rki],
+        [genbank.drop("internal_id", axis=1), new_rki],
         ignore_index=False,
         sort=False,
     )

--- a/bin/merge-open
+++ b/bin/merge-open
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Turn Genbank and RKI metadata & sequences into merged open data
+"""
+
+import typer
+
+
+def main(
+    input_rki_sequences: str = typer.Option(...),
+    input_rki_metadata: str = typer.Option(...),
+    input_genbank_sequences: str = typer.Option(...),
+    input_genbank_biosample: str = typer.Option(...),
+    input_genbank_metadata: str = typer.Option(...),
+    output_sequences: str = typer.Option(...),
+    output_metadata: str = typer.Option(...),
+):
+    import pandas as pd
+    from Bio import SeqIO
+    from xopen import xopen
+
+    # Load metadata files
+    with xopen(input_rki_metadata, "r") as fin:
+        rki = pd.read_csv(fin, index_col="strain", low_memory=False, sep="\t")
+
+    with xopen(input_genbank_metadata, "r") as fin:
+        genbank = pd.read_csv(
+            fin, index_col="strain", low_memory=False, sep="\t"
+        )
+
+    with xopen(input_genbank_biosample, "r") as fin:
+        biosample = pd.read_csv(
+            fin, index_col="biosample_accession", low_memory=False, sep="\t"
+        )
+
+    # Get biosample accessions that are in genbank metadata
+    biosample_accessions = genbank["biosample_accession"].dropna().tolist()
+
+    # Get internal_ids from the biosample accessions that are in genbank metadata
+    internal_ids = biosample[
+        biosample.index.isin(biosample_accessions)
+    ]["internal_id"].dropna()
+
+    # Select rki rows that are not in the genbank internal_ids -> not already in Genbank
+    new_rki = rki[~rki.index.isin(internal_ids)]
+
+    # Add source database column to metadata
+    genbank.loc[:, "database"] = "genbank"
+    new_rki.loc[:, "database"] = "rki"
+
+    # Create new merged open data dataframe
+    open = pd.concat(
+        [genbank.drop("biosample_accession", axis=1), new_rki],
+        ignore_index=False,
+        sort=False,
+    )
+
+    # Output merged metadata
+    with xopen(output_metadata, "w") as fout:
+        open.to_csv(fout, sep="\t")
+
+    # Output merged sequences
+    with xopen(output_sequences, "wt") as sequences_out:
+        for input_path in [input_genbank_sequences, input_rki_sequences]:
+            for record in SeqIO.parse(xopen(input_path, "r"), "fasta"):
+                if record.id in open.index:
+                    sequences_out.write(f">{record.id}\n")
+                    sequences_out.write(f"{str(record.seq)}\n")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/bin/merge-open
+++ b/bin/merge-open
@@ -62,9 +62,11 @@ def main(
 
     # Output merged sequences
     with xopen(output_sequences, "wt") as sequences_out:
+        output_ids = set()
         for input_path in [input_genbank_sequences, input_rki_sequences]:
             for record in SeqIO.parse(xopen(input_path, "r"), "fasta"):
-                if record.id in open.index:
+                if record.id in open.index and record.id not in output_ids:
+                    output_ids.add(record.id)
                     sequences_out.write(f">{record.id}\n")
                     sequences_out.write(f"{str(record.seq)}\n")
 

--- a/bin/merge-open
+++ b/bin/merge-open
@@ -25,7 +25,7 @@ def main(
 
     with xopen(input_genbank_metadata, "r") as fin:
         genbank = pd.read_csv(
-            fin, index_col="strain", low_memory=False, sep="\t"
+            fin, index_col="strain", low_memory=True, sep="\t"
         )
 
     with xopen(input_genbank_biosample, "r") as fin:

--- a/bin/transform-biosample
+++ b/bin/transform-biosample
@@ -23,6 +23,7 @@ BIOSAMPLE_COLUMNS = [
     'location',
     'age',
     'sex',
+    'internal_id',
 ]
 
 

--- a/bin/transform-genbank
+++ b/bin/transform-genbank
@@ -42,6 +42,10 @@ from utils.transformpipeline.transforms import (
 
 assert 'sequence' not in METADATA_COLUMNS, "Sequences should not appear in metadata!"
 
+# Include `internal_id` for RKI deduplication
+# This column is removed in merge-open
+METADATA_COLUMNS.append('internal_id')
+
 
 if __name__ == '__main__':
     base = Path(__file__).resolve().parent.parent

--- a/bin/transform-rki
+++ b/bin/transform-rki
@@ -24,7 +24,6 @@ from lib.utils.transformpipeline.transforms import (AddHardcodedMetadataRki,
                                                     MaskBadCollectionDate,
                                                     MergeUserAnnotatedMetadata,
                                                     RenameAndAddColumns,
-                                                    RkiZipToGeography,
                                                     SetStrainNameRki,
                                                     StandardizeDataRki,
                                                     UserProvidedAnnotations)
@@ -134,7 +133,6 @@ if __name__ == "__main__":
                 )
 
     with xopen(args.rki_data, "r") as rki_fh:
-        # with tqdm() as pbar:
         pipeline = (
             LineToJsonDataSource(rki_fh)
             | RenameAndAddColumns(column_map=COLUMN_MAP)
@@ -149,7 +147,6 @@ if __name__ == "__main__":
             | AddHardcodedMetadataRki()
             | MaskBadCollectionDate()
             | SetStrainNameRki()
-            | RkiZipToGeography()
             | MergeUserAnnotatedMetadata(annotations, idKey="rki_accession")
             | FillDefaultLocationData()
         )

--- a/bin/transform-rki
+++ b/bin/transform-rki
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+Parse RKI NDJSON, turn into metadata.tsv and a sequences.fasta file
+"""
+import argparse
+import csv
+import os
+import sys
+from pathlib import Path
+
+from xopen import xopen
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent) + "/lib")
+
+from lib.utils.transform import METADATA_COLUMNS
+from lib.utils.transformpipeline import LINE_NUMBER_KEY
+from lib.utils.transformpipeline.datasource import LineToJsonDataSource
+from lib.utils.transformpipeline.filters import (LineNumberFilter,
+                                                 SequenceLengthFilter)
+from lib.utils.transformpipeline.transforms import (AddHardcodedMetadataRki,
+                                                    DropSequenceData,
+                                                    FillDefaultLocationData,
+                                                    MaskBadCollectionDate,
+                                                    MergeUserAnnotatedMetadata,
+                                                    RenameAndAddColumns,
+                                                    RkiZipToGeography,
+                                                    SetStrainNameRki,
+                                                    StandardizeDataRki,
+                                                    UserProvidedAnnotations)
+
+COLUMN_MAP = {
+    "DATE_DRAW": "date",
+    "RECEIVE_DATE": "date_submitted",
+    "PROCESSING_DATE": "date_released",
+    "SENDING_LAB_PC": "originating_lab",
+    "SEQUENCING_LAB_PC": "submitting_lab",
+    "GISAID_ACCESSION": "strain_gisaid",
+    "lineage": "pango_lineage",
+    "SEQ_REASON": "sampling_strategy",
+}
+
+
+assert (
+    "sequence" not in METADATA_COLUMNS
+), "Sequences should not appear in metadata!"
+
+
+if __name__ == "__main__":
+    base = Path(__file__).resolve().parent.parent
+
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter
+    )
+    parser.add_argument(
+        "rki_data",
+        default="s3://nextstrain-data/files/ncov/open/rki.ndjson.zst",
+        nargs="?",
+        help="Newline-delimited RKI JSON data",
+    )
+    parser.add_argument(
+        "--annotations",
+        default=base / "source-data/rki_annotations.tsv",
+        help="Optional manually curated annotations TSV.\n"
+        "The TSV file should have no header and exactly three columns which contain:\n\t"
+        "1. the RKI accession ID \n\t"
+        "2. the column name to replace from the generated `metadata.tsv` file\n\t"
+        "3. the replacement data\n"
+        "Lines or parts of lines starting with '#' are treated as comments.\n"
+        "e.g.\n\t"
+        "MT039888	location    Boston\n\t"
+        "# First Californian sample\n\t"
+        "MN994467	country_exposure	China\n\t"
+        "MN908947	collection_date 2019-12-26 # Manually corrected date",
+    )
+    parser.add_argument(
+        "--accessions",
+        default=base / "source-data/rki_accessions.tsv",
+        help="Optional manually curated TSV cross-referencing accessions between databases (e.g. GISAID and GenBank/INSDC).",
+    )
+    parser.add_argument(
+        "--output-metadata",
+        default=base / "data/rki/metadata.tsv",
+        help="Output location of generated metadata tsv. Defaults to `data/rki/metadata.tsv`",
+    )
+    parser.add_argument(
+        "--output-fasta",
+        default=base / "data/rki/sequences.fasta",
+        help="Output location of generated FASTA file. Defaults to `data/rki/sequences.fasta`",
+    )
+    parser.add_argument(
+        "--problem-data",
+        default=base / "data/rki/problem_data.tsv",
+        help="Output location of generated tsv of problem records missing geography region or country",
+    )
+    parser.add_argument(
+        "--output-unix-newline",
+        dest="newline",
+        action="store_const",
+        const="\n",
+        default=os.linesep,
+        help="When specified, always use unix newlines in output files.",
+    )
+    args = parser.parse_args()
+
+    # parsing curated annotations
+    annotations = UserProvidedAnnotations()
+    if args.annotations:
+        # Use the curated annotations tsv to update any column values
+        with open(args.annotations, "r") as gisaid_fh:
+            try:
+                csvreader = csv.reader(gisaid_fh, delimiter="\t")
+
+                for row in csvreader:
+                    if row[0].lstrip()[0] == "#":
+                        continue
+                    elif len(row) != 3:
+                        print(
+                            "WARNING: couldn't decode annotation line "
+                            + "\t".join(row)
+                        )
+                        continue
+                    strainId, key, value = row
+                    annotations.add_user_annotation(
+                        strainId,
+                        key,
+                        # remove the comment and the extra ws from the value
+                        value.split("#")[0].rstrip(),
+                    )
+            except:
+                print(
+                    "WARNING: couldn't parse annotations file "
+                    + args.annotations
+                )
+
+    with xopen(args.rki_data, "r") as rki_fh:
+        # with tqdm() as pbar:
+        pipeline = (
+            LineToJsonDataSource(rki_fh)
+            | RenameAndAddColumns(column_map=COLUMN_MAP)
+            | StandardizeDataRki()
+            | SequenceLengthFilter(15000)
+        )
+
+        pipeline = pipeline | DropSequenceData()
+
+        pipeline = (
+            pipeline
+            | AddHardcodedMetadataRki()
+            | MaskBadCollectionDate()
+            | SetStrainNameRki()
+            | RkiZipToGeography()
+            | MergeUserAnnotatedMetadata(annotations, idKey="rki_accession")
+            | FillDefaultLocationData()
+        )
+
+        sorted_metadata = sorted(
+            pipeline,
+            key=lambda obj: (
+                obj["strain"],
+                -obj["length"],
+                obj["rki_accession"],
+                obj[LINE_NUMBER_KEY],
+            ),
+        )
+
+    # this should be moved further down
+    # dedup by strain and compile a list of relevant line numbers.
+    seen_strains = set()
+    line_numbers = set()
+    updated_strain_names_by_line_no = {}
+
+    for entry in sorted_metadata:
+
+        if entry["strain"] in seen_strains:
+            continue
+
+        seen_strains.add(entry["strain"])
+        line_numbers.add(entry[LINE_NUMBER_KEY])
+        updated_strain_names_by_line_no[entry[LINE_NUMBER_KEY]] = entry[
+            "strain"
+        ]
+
+    with xopen(args.output_metadata, "wt") as metadata_OUT:
+        dict_writer_kwargs = {"lineterminator": args.newline}
+
+        metadata_csv = csv.DictWriter(
+            metadata_OUT,
+            METADATA_COLUMNS,
+            restval="",
+            extrasaction="ignore",
+            delimiter="\t",
+            **dict_writer_kwargs,
+        )
+        metadata_csv.writeheader()
+
+        for entry in sorted_metadata:
+            if entry[LINE_NUMBER_KEY] in line_numbers:
+                metadata_csv.writerow(entry)
+
+    with xopen(args.rki_data, "r") as genbank_IN, xopen(
+        args.output_fasta, "wt", newline=args.newline
+    ) as fasta_OUT:
+        for entry in (
+            LineToJsonDataSource(genbank_IN)
+            | RenameAndAddColumns(column_map=COLUMN_MAP)
+            | StandardizeDataRki()
+            | SetStrainNameRki()
+            | LineNumberFilter(line_numbers)
+        ):
+            strain_name = updated_strain_names_by_line_no[
+                entry[LINE_NUMBER_KEY]
+            ]
+            print(">", strain_name, sep="", file=fasta_OUT)
+            print(entry["sequence"], file=fasta_OUT)

--- a/bin/transform-rki-data-to-ndjson
+++ b/bin/transform-rki-data-to-ndjson
@@ -20,31 +20,32 @@ def main(
     from Bio import SeqIO
 
     with xopen(input_rki_metadata, "r") as fin:
-        metadata = pd.read_csv(fin, low_memory=False, index_col="IMS_ID")
-        # Yes there are duplicate lines
+        metadata = pd.read_csv(fin, low_memory=False, dtype=str, na_values="NaN", index_col="IMS_ID")
+        # Yes there are duplicate lines, TODO: check if duplicates are identical or not
         metadata = metadata[~metadata.index.duplicated(keep='first')]
 
     with xopen(input_rki_lineages, "r") as fin:
-        lineages = pd.read_csv(fin, low_memory=False, index_col="IMS_ID").fillna("?")
-
+        # Not all IMS_IDs are in the lineages file!
+        # We only read in the pango lineage (probably Usher), not confidence etc.
+        lineages = pd.read_csv(fin, usecols=["IMS_ID", "lineage"], dtype=str, na_values="NaN", index_col="IMS_ID").fillna("?")
+    
     metadata = pd.merge(
         metadata,
         lineages["lineage"],
         how="left",
         left_index=True,
         right_index=True,
-    )
+    ).fillna("?")
 
     with xopen(output_ndjson, "w") as fout:
         for record in SeqIO.parse(xopen(input_rki_sequences), "fasta"):
-            output = {
-                "rki_accession": record.id,
-                **metadata.loc[record.id].to_dict(),
-                "sequence": str(record.seq),
-            }
-            # if type(output["lineage"]) == dict:
-            #     import ipdb; ipdb.set_trace()
-            fout.write(json.dumps(output) + "\n")
+            if record.id in metadata.index:
+                output = {
+                    "rki_accession": record.id,
+                    **metadata.loc[record.id].to_dict(),
+                    "sequence": str(record.seq),
+                }
+                fout.write(json.dumps(output) + "\n")
 
 
 if __name__ == "__main__":

--- a/bin/transform-rki-data-to-ndjson
+++ b/bin/transform-rki-data-to-ndjson
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+Turn RKI files into ndjson format
+"""
+
+import typer
+
+def main(
+    input_rki_sequences: str = typer.Option(..., help="Input file"),
+    input_rki_metadata: str = typer.Option(..., help="Input file"),
+    input_rki_lineages: str = typer.Option(..., help="Input file"),
+    output_ndjson: str = typer.Option(..., help="Output file"),
+):
+    """
+    Turn RKI files into ndjson format
+    """
+    import json
+    import pandas as pd
+    from xopen import xopen
+    from Bio import SeqIO
+
+    with xopen(input_rki_metadata, "r") as fin:
+        metadata = pd.read_csv(fin, low_memory=False, index_col="IMS_ID")
+        # Yes there are duplicate lines
+        metadata = metadata[~metadata.index.duplicated(keep='first')]
+
+    with xopen(input_rki_lineages, "r") as fin:
+        lineages = pd.read_csv(fin, low_memory=False, index_col="IMS_ID").fillna("?")
+
+    metadata = pd.merge(
+        metadata,
+        lineages["lineage"],
+        how="left",
+        left_index=True,
+        right_index=True,
+    )
+
+    with xopen(output_ndjson, "w") as fout:
+        for record in SeqIO.parse(xopen(input_rki_sequences), "fasta"):
+            output = {
+                "rki_accession": record.id,
+                **metadata.loc[record.id].to_dict(),
+                "sequence": str(record.seq),
+            }
+            # if type(output["lineage"]) == dict:
+            #     import ipdb; ipdb.set_trace()
+            fout.write(json.dumps(output) + "\n")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/lib/utils/transform.py
+++ b/lib/utils/transform.py
@@ -6,7 +6,7 @@ from typing import Optional, Set, Union
 
 # Note: 'sequence' should NEVER appear in these lists!
 METADATA_COLUMNS = [  # Ordering of columns in the existing metadata.tsv in the ncov repo
-    'strain', 'virus', 'gisaid_epi_isl', 'genbank_accession', 'genbank_accession_rev', 'sra_accession', 'date', 'region',
+    'strain', 'virus', 'gisaid_epi_isl', 'genbank_accession', 'genbank_accession_rev', 'sra_accession', 'biosample_accession', 'date', 'region',
     'country', 'division', 'location', 'region_exposure', 'country_exposure',
     'division_exposure', 'segment', 'length', 'host', 'age', 'sex', 'pango_lineage', 'GISAID_clade',
     'originating_lab', 'submitting_lab', 'authors', 'url', 'title', 'paper_url',

--- a/lib/utils/transform.py
+++ b/lib/utils/transform.py
@@ -6,7 +6,7 @@ from typing import Optional, Set, Union
 
 # Note: 'sequence' should NEVER appear in these lists!
 METADATA_COLUMNS = [  # Ordering of columns in the existing metadata.tsv in the ncov repo
-    'strain', 'virus', 'gisaid_epi_isl', 'genbank_accession', 'genbank_accession_rev', 'sra_accession', 'biosample_accession', 'date', 'region',
+    'strain', 'virus', 'gisaid_epi_isl', 'genbank_accession', 'genbank_accession_rev', 'sra_accession', 'internal_id', 'date', 'region',
     'country', 'division', 'location', 'region_exposure', 'country_exposure',
     'division_exposure', 'segment', 'length', 'host', 'age', 'sex', 'pango_lineage', 'GISAID_clade',
     'originating_lab', 'submitting_lab', 'authors', 'url', 'title', 'paper_url',

--- a/lib/utils/transform.py
+++ b/lib/utils/transform.py
@@ -6,7 +6,7 @@ from typing import Optional, Set, Union
 
 # Note: 'sequence' should NEVER appear in these lists!
 METADATA_COLUMNS = [  # Ordering of columns in the existing metadata.tsv in the ncov repo
-    'strain', 'virus', 'gisaid_epi_isl', 'genbank_accession', 'genbank_accession_rev', 'sra_accession', 'internal_id', 'date', 'region',
+    'strain', 'virus', 'gisaid_epi_isl', 'genbank_accession', 'genbank_accession_rev', 'sra_accession', 'date', 'region',
     'country', 'division', 'location', 'region_exposure', 'country_exposure',
     'division_exposure', 'segment', 'length', 'host', 'age', 'sex', 'pango_lineage', 'GISAID_clade',
     'originating_lab', 'submitting_lab', 'authors', 'url', 'title', 'paper_url',

--- a/lib/utils/transformpipeline/transforms.py
+++ b/lib/utils/transformpipeline/transforms.py
@@ -967,6 +967,7 @@ class ParseBiosample(Transformer):
         new_entry['age'] = attributes.get('host_age')
         new_entry['sex'] = attributes.get('host_sex')
         new_entry['date'] = attributes.get('collection_date')
+        new_entry['internal_id'] = attributes.get('sample_name')
 
         new_entry['location'] = self.parse_location({ attr: attributes.get(attr) for attr in ParseBiosample.LOCATION_ATTR })
 

--- a/lib/utils/transformpipeline/transforms.py
+++ b/lib/utils/transformpipeline/transforms.py
@@ -676,60 +676,6 @@ class ParseGeographicColumnsGenbank(Transformer):
 
         return entry
 
-class RkiZipToGeography(Transformer):
-    """
-    Turns German zip code in the column named `postcode_sending`
-    into division and location using a mapping file
-    of known German zip codes
-    """
-    # def __init__(self, us_state_code_file_name ):
-    #     # Create dict of US state codes and their full names
-    #     self.us_states = pd.read_csv( us_state_code_file_name , header=None, sep='\t', comment="#")
-    #     self.us_states = dict(zip(self.us_states[0], self.us_states[1]))
-
-
-    def transform_value(self, entry : dict) -> dict :
-
-        # geographic_data = entry['location'].split(':')
-
-        # country = geographic_data[0].strip()
-        division = '?'
-        location = '?'
-
-        # if len(geographic_data) == 2 :
-        #     division , j , location = geographic_data[1].partition(',')
-
-        # elif len(geographic_data) > 2:
-        #     assert False, f"Found unknown format for geographic data: {value}"
-
-
-        # # Special parsing for US locations because the format varies
-        # if country == 'USA' and division:
-        #     # Switch location & division if location is a US state
-        #     if location and any(location.strip() in s for s in self.us_states.items()):
-        #         state = location
-        #         location = division
-        #         division = state
-        #     # Convert US state codes to full names
-        #     if self.us_states.get(division.strip().upper()):
-        #         division = self.us_states[division.strip().upper()]
-
-
-        # location = location.strip().lower().title() if location else ''
-        # division = division.strip().lower().title() if division else ''
-
-        # # fix German divisions
-        # for stripstr in ['Europe/', 'Germany/']:
-        #     if division.startswith(stripstr):
-        #         division = division[len(stripstr):]
-
-        # #print(entry , '->' , geographic_data , country, division, location)
-        # entry['country']     = country
-        entry['division']    = division
-        entry['location']    = location
-
-        return entry
-
 
 class AddHardcodedMetadataGenbank(Transformer):
     """
@@ -775,6 +721,8 @@ class AddHardcodedMetadataRki(Transformer):
         entry['url']               = "?"
         entry['region']            = "Europe"
         entry['country']           = "Germany"
+        entry['division']          = "?"
+        entry['location']          = "?"
         return entry
 
 class Tracker(Transformer):

--- a/lib/utils/transformpipeline/transforms.py
+++ b/lib/utils/transformpipeline/transforms.py
@@ -236,7 +236,7 @@ class StandardizeData(Transformer):
     1. Removes newlines from the sequence and measures its length.
     2. Strip whitespace and convert to Unicode Normalization Form C for all strings.
     3. Standardize date formats.
-    4. Abbreviate and remove whitespace from strain names3
+    4. Abbreviate and remove whitespace from strain names
     5. Add a line number.
     """
 
@@ -265,6 +265,42 @@ class StandardizeData(Transformer):
         # Abbreviate strain names by removing the prefix. Strip spaces, too.
         entry['strain'] = re.sub(
             r'(^[hn]CoV-19/)|\s+', '', entry['strain'], flags=re.IGNORECASE)
+
+        entry[LINE_NUMBER_KEY] = self.line_count
+        self.line_count += 1
+
+        return entry
+
+class StandardizeDataRki(Transformer):
+    """This transformer standardizes the data format:
+
+    1. Removes newlines from the sequence and measures its length.
+    2. Strip whitespace and convert to Unicode Normalization Form C for all strings.
+    3. Standardize date formats.
+    4. Add a line number.
+    """
+
+    def __init__(self):
+        self.line_count = 1
+
+    def transform_value(self, entry: dict) -> dict:
+        entry['sequence'] = entry['sequence'].replace('\n', '')
+        entry['length'] = len(entry['sequence'])
+
+        # Normalize all string data to Unicode Normalization Form C, for
+        # consistent, predictable string comparisons.
+        str_kvs = {
+            key: unicodedata.normalize('NFC', value).strip()
+            for key, value in entry.items()
+            if isinstance(value, str)
+        }
+        entry.update(str_kvs)
+
+        # Standardize date format to ISO 8601 date
+        date_columns = {'date', 'date_submitted'}
+        date_formats = {'%Y-%m-%d', '%Y-%m-%dT%H:%M:%SZ'}
+        for column in date_columns:
+            entry[column] = format_date(entry[column], date_formats)
 
         entry[LINE_NUMBER_KEY] = self.line_count
         self.line_count += 1
@@ -571,6 +607,15 @@ class StandardizeGenbankStrainNames(Transformer):
 
         return entry
 
+class SetStrainNameRki(Transformer):
+    """
+    Set the strain name to the value of the `rki_strain_name` field if it is not
+    empty.
+    """
+    def transform_value(self, entry: dict) -> dict:
+        entry['strain'] = entry['rki_accession']
+        return entry
+
 class ParseGeographicColumnsGenbank(Transformer):
     """
     Expands string found in the column named `location` in the given
@@ -631,6 +676,61 @@ class ParseGeographicColumnsGenbank(Transformer):
 
         return entry
 
+class RkiZipToGeography(Transformer):
+    """
+    Turns German zip code in the column named `postcode_sending`
+    into division and location using a mapping file
+    of known German zip codes
+    """
+    # def __init__(self, us_state_code_file_name ):
+    #     # Create dict of US state codes and their full names
+    #     self.us_states = pd.read_csv( us_state_code_file_name , header=None, sep='\t', comment="#")
+    #     self.us_states = dict(zip(self.us_states[0], self.us_states[1]))
+
+
+    def transform_value(self, entry : dict) -> dict :
+
+        # geographic_data = entry['location'].split(':')
+
+        # country = geographic_data[0].strip()
+        division = '?'
+        location = '?'
+
+        # if len(geographic_data) == 2 :
+        #     division , j , location = geographic_data[1].partition(',')
+
+        # elif len(geographic_data) > 2:
+        #     assert False, f"Found unknown format for geographic data: {value}"
+
+
+        # # Special parsing for US locations because the format varies
+        # if country == 'USA' and division:
+        #     # Switch location & division if location is a US state
+        #     if location and any(location.strip() in s for s in self.us_states.items()):
+        #         state = location
+        #         location = division
+        #         division = state
+        #     # Convert US state codes to full names
+        #     if self.us_states.get(division.strip().upper()):
+        #         division = self.us_states[division.strip().upper()]
+
+
+        # location = location.strip().lower().title() if location else ''
+        # division = division.strip().lower().title() if division else ''
+
+        # # fix German divisions
+        # for stripstr in ['Europe/', 'Germany/']:
+        #     if division.startswith(stripstr):
+        #         division = division[len(stripstr):]
+
+        # #print(entry , '->' , geographic_data , country, division, location)
+        # entry['country']     = country
+        entry['division']    = division
+        entry['location']    = location
+
+        return entry
+
+
 class AddHardcodedMetadataGenbank(Transformer):
     """
     Adds a key-value for strain ID plus additional key-values containing harcoded
@@ -652,6 +752,30 @@ class AddHardcodedMetadataGenbank(Transformer):
         entry['url'] = "https://www.ncbi.nlm.nih.gov/nuccore/" + entry['genbank_accession']
         return entry
 
+class AddHardcodedMetadataRki(Transformer):
+    """
+    Adds a key-value for strain ID plus additional key-values containing harcoded
+    metadata.
+    """
+    def transform_value(self, entry: dict) -> dict:
+        entry['strain']            = '?'
+        entry['virus']             = 'ncov'
+        entry['gisaid_epi_isl']    = '?'
+        entry['genbank_accession'] = '?'
+        entry['sra_accession']     = '?'
+        entry['segment']           = 'genome'
+        entry['age']               = '?'
+        entry['sex']               = '?'
+        entry['host']              = '?'
+        entry['authors']           = '?'
+        entry['GISAID_clade']      = '?'
+        entry['originating_lab']   = '?'
+        entry['submitting_lab']    = '?'
+        entry['paper_url']         = '?'
+        entry['url']               = "?"
+        entry['region']            = "Europe"
+        entry['country']           = "Germany"
+        return entry
 
 class Tracker(Transformer):
     """

--- a/workflow/snakemake_rules/curate.smk
+++ b/workflow/snakemake_rules/curate.smk
@@ -58,8 +58,8 @@ rule transform_genbank_data:
         cog_uk_accessions = "data/cog_uk_accessions.tsv",
         cog_uk_metadata = "data/cog_uk_metadata.csv.gz"
     output:
-        fasta = "data/genbank/sequences.fasta",
-        metadata = "data/genbank/metadata_transformed.tsv",
+        fasta = "data/genbank_sequences.fasta",
+        metadata = "data/genbank_metadata_transformed.tsv",
         flagged_annotations = temp("data/genbank/flagged-annotations"),
         duplicate_biosample = "data/genbank/duplicate_biosample.txt"
     shell:
@@ -72,6 +72,30 @@ rule transform_genbank_data:
             --output-metadata {output.metadata} \
             --output-fasta {output.fasta} > {output.flagged_annotations}
         """
+
+
+rule merge_open_data:
+    input:
+        biosample="data/genbank/biosample.tsv",
+        genbank_metadata="data/genbank_metadata_transformed.tsv",
+        rki_metadata="data/rki_metadata_transformed.tsv",
+        rki_sequences="data/rki_sequences.fasta",
+        genbank_sequences="data/genbank_sequences.fasta",
+    output:
+        metadata="data/genbank/metadata_transformed.tsv",
+        sequences="data/genbank/sequences.fasta",
+    shell:
+        """
+        ./bin/merge-open \
+            --input-genbank-biosample {input.biosample} \
+            --input-genbank-metadata {input.genbank_metadata} \
+            --input-rki-metadata {input.rki_metadata} \
+            --input-genbank-sequences {input.genbank_sequences} \
+            --input-rki-sequences {input.rki_sequences} \
+            --output-metadata {output.metadata} \
+            --output-sequences {output.sequences}
+        """
+
 
 rule transform_gisaid_data:
     input:

--- a/workflow/snakemake_rules/curate.smk
+++ b/workflow/snakemake_rules/curate.smk
@@ -76,7 +76,6 @@ rule transform_genbank_data:
 
 rule merge_open_data:
     input:
-        biosample="data/genbank/biosample.tsv",
         genbank_metadata="data/genbank_metadata_transformed.tsv",
         rki_metadata="data/rki_metadata_transformed.tsv",
         rki_sequences="data/rki_sequences.fasta",
@@ -87,7 +86,6 @@ rule merge_open_data:
     shell:
         """
         ./bin/merge-open \
-            --input-genbank-biosample {input.biosample} \
             --input-genbank-metadata {input.genbank_metadata} \
             --input-rki-metadata {input.rki_metadata} \
             --input-genbank-sequences {input.genbank_sequences} \

--- a/workflow/snakemake_rules/curate.smk
+++ b/workflow/snakemake_rules/curate.smk
@@ -22,6 +22,24 @@ Produces different output files for GISAID vs GenBank:
         duplicate_biosample = "data/genbank/duplicate_biosample.txt"
 """
 
+
+rule transform_rki_data:
+    input:
+        ndjson="data/rki.ndjson",
+    output:
+        fasta="data/rki_sequences.fasta",
+        metadata="data/rki_metadata_transformed.tsv",
+    params:
+        subsampled=config.get("subsampled", False),
+    shell:
+        """
+        ./bin/transform-rki \
+            {input.ndjson} \
+            --output-fasta {output.fasta} \
+            --output-metadata {output.metadata}
+        """
+
+
 rule transform_biosample:
     input:
         biosample = "data/biosample.ndjson"

--- a/workflow/snakemake_rules/fetch_sequences.smk
+++ b/workflow/snakemake_rules/fetch_sequences.smk
@@ -200,12 +200,13 @@ if config.get("s3_dst") and config.get("s3_src"):
         params:
             file_on_s3_dst=f"{config['s3_dst']}/rki.ndjson.zst",
             file_on_s3_src=f"{config['s3_src']}/rki.ndjson.zst",
+            lines = config.get("subsample",{}).get("rki_ndjson", 0)
         output:
             rki_ndjson = temp("data/rki.ndjson")
         shell:
             """
-            ./bin/download-from-s3 {params.file_on_s3_dst} {output.rki_ndjson} ||  \
-            ./bin/download-from-s3 {params.file_on_s3_src} {output.rki_ndjson}
+            ./bin/download-from-s3 {params.file_on_s3_dst} {output.rki_ndjson} {params.lines} ||  \
+            ./bin/download-from-s3 {params.file_on_s3_src} {output.rki_ndjson} {params.lines}
             """
     rule fetch_cog_uk_accessions_from_s3:
         params:

--- a/workflow/snakemake_rules/fetch_sequences.smk
+++ b/workflow/snakemake_rules/fetch_sequences.smk
@@ -86,6 +86,14 @@ rule fetch_cog_uk_metadata:
             f"rm {output.cog_uk_metadata}"
         )
 
+rule uncompress_cog_uk_metadata:
+    input:
+        "data/cog_uk_metadata.csv.gz"
+    output:
+        cog_uk_metadata = temp("data/cog_uk_metadata.csv")
+    shell:
+        "gunzip -c {input} > {output}"
+
 
 rule fetch_rki_sequences:
     output:
@@ -147,14 +155,11 @@ if config.get("s3_dst") and config.get("s3_src"):
         ruleorder: fetch_main_ndjson > fetch_main_ndjson_from_s3
         ruleorder: fetch_biosample > fetch_biosample_from_s3
         ruleorder: transform_rki_data_to_ndjson > fetch_rki_ndjson_from_s3
-    else:
-        ruleorder: fetch_main_ndjson_from_s3 > fetch_main_ndjson
-        ruleorder: fetch_biosample_from_s3 > fetch_biosample
-        ruleorder: fetch_rki_ndjson_from_s3 > transform_rki_data_to_ndjson 
         ruleorder: fetch_cog_uk_accessions > fetch_cog_uk_accessions_from_s3
         ruleorder: fetch_cog_uk_metadata > compress_cog_uk_metadata
         ruleorder: uncompress_cog_uk_metadata > fetch_cog_uk_metadata_from_s3
     else:
+        ruleorder: fetch_rki_ndjson_from_s3 > transform_rki_data_to_ndjson 
         ruleorder: fetch_main_ndjson_from_s3 > fetch_main_ndjson
         ruleorder: fetch_biosample_from_s3 > fetch_biosample
         ruleorder: fetch_cog_uk_accessions_from_s3 > fetch_cog_uk_accessions

--- a/workflow/snakemake_rules/fetch_sequences.smk
+++ b/workflow/snakemake_rules/fetch_sequences.smk
@@ -7,7 +7,7 @@ If the config contains `s3_dst`,`s3_src`, and `fetch_from_database=False`,
 then files will be fetched from the AWS S3 bucket. Or else, the data is fetched
 directly from the databases.
 
-Produces different final outputs for GISAID vs GenBank:
+Produces different final outputs for GISAID vs GenBank/RKI:
     GISAID:
         ndjson = "data/gisaid.ndjson"
     GenBank:
@@ -15,6 +15,7 @@ Produces different final outputs for GISAID vs GenBank:
         biosample = "data/biosample.ndjson"
         cog_uk_accessions = "data/cog_uk_accessions.tsv"
         cog_uk_metadata = "data/cog_uk_metadata.csv.gz"
+        rki_ndjson = "data/rki.ndjson"
 """
 
 def run_shell_command_n_times(cmd, msg, cleanup_failed_cmd, retry_num=5):
@@ -85,13 +86,56 @@ rule fetch_cog_uk_metadata:
             f"rm {output.cog_uk_metadata}"
         )
 
-rule uncompress_cog_uk_metadata:
-    input:
-        "data/cog_uk_metadata.csv.gz"
+
+rule fetch_rki_sequences:
     output:
-        cog_uk_metadata = temp("data/cog_uk_metadata.csv")
+        rki_sequences=temp("data/rki_sequences.fasta.xz"),
+    run:
+        run_shell_command_n_times(
+            f"./bin/fetch-from-rki-sequences > {output.rki_sequences}",
+            "Fetch RKI sequences",
+            f"rm {output.rki_sequences}",
+        )
+
+
+rule fetch_rki_metadata:
+    output:
+        rki_metadata=temp("data/rki_metadata.csv.xz"),
+    run:
+        run_shell_command_n_times(
+            f"./bin/fetch-from-rki-metadata > {output.rki_metadata}",
+            "Fetch RKI metadata",
+            f"rm {output.rki_metadata}",
+        )
+
+
+rule fetch_rki_lineages:
+    output:
+        rki_lineages=temp("data/rki_lineages.csv.xz"),
+    run:
+        run_shell_command_n_times(
+            f"./bin/fetch-from-rki-lineages > {output.rki_lineages}",
+            "Fetch RKI lineages",
+            f"rm {output.rki_lineages}",
+        )
+
+
+rule transform_rki_data_to_ndjson:
+    input:
+        rki_sequences="data/rki_sequences.fasta.xz",
+        rki_metadata="data/rki_metadata.csv.xz",
+        rki_lineages="data/rki_lineages.csv.xz",
+    output:
+        ndjson="data/rki.ndjson",
     shell:
-        "gunzip -c {input} > {output}"
+        """
+        ./bin/transform-rki-data-to-ndjson \
+            --input-rki-sequences {input.rki_sequences} \
+            --input-rki-metadata {input.rki_metadata} \
+            --input-rki-lineages {input.rki_lineages} \
+            --output-ndjson {output.ndjson}
+        """
+
 
 # Only include rules to fetch from S3 if S3 config params are provided
 if config.get("s3_dst") and config.get("s3_src"):
@@ -102,6 +146,11 @@ if config.get("s3_dst") and config.get("s3_src"):
     if config.get("fetch_from_database", False):
         ruleorder: fetch_main_ndjson > fetch_main_ndjson_from_s3
         ruleorder: fetch_biosample > fetch_biosample_from_s3
+        ruleorder: transform_rki_data_to_ndjson > fetch_rki_ndjson_from_s3
+    else:
+        ruleorder: fetch_main_ndjson_from_s3 > fetch_main_ndjson
+        ruleorder: fetch_biosample_from_s3 > fetch_biosample
+        ruleorder: fetch_rki_ndjson_from_s3 > transform_rki_data_to_ndjson 
         ruleorder: fetch_cog_uk_accessions > fetch_cog_uk_accessions_from_s3
         ruleorder: fetch_cog_uk_metadata > compress_cog_uk_metadata
         ruleorder: uncompress_cog_uk_metadata > fetch_cog_uk_metadata_from_s3
@@ -142,6 +191,17 @@ if config.get("s3_dst") and config.get("s3_src"):
             ./bin/download-from-s3 {params.file_on_s3_src} {output.biosample} {params.lines}
             """
 
+    rule fetch_rki_ndjson_from_s3:
+        params:
+            file_on_s3_dst=f"{config['s3_dst']}/rki.ndjson.zst",
+            file_on_s3_src=f"{config['s3_src']}/rki.ndjson.zst",
+        output:
+            rki_ndjson = temp("data/rki.ndjson")
+        shell:
+            """
+            ./bin/download-from-s3 {params.file_on_s3_dst} {output.rki_ndjson} ||  \
+            ./bin/download-from-s3 {params.file_on_s3_src} {output.rki_ndjson}
+            """
     rule fetch_cog_uk_accessions_from_s3:
         params:
             file_on_s3_dst=f"{config['s3_dst']}/cog_uk_accessions.tsv.zst",

--- a/workflow/snakemake_rules/upload.smk
+++ b/workflow/snakemake_rules/upload.smk
@@ -59,6 +59,8 @@ def compute_files_to_upload():
                 "biosample.ndjson.gz": f"data/biosample.ndjson",
                 "biosample.ndjson.zst": f"data/biosample.ndjson",
 
+                "rki.ndjson.zst": f"data/rki.ndjson",
+
                 "cog_uk_accessions.tsv.gz": f"data/cog_uk_accessions.tsv",
                 "cog_uk_accessions.tsv.zst": f"data/cog_uk_accessions.tsv",
 


### PR DESCRIPTION
Adapts the existing ingest workflow to additionally ingest RKI data from https://github.com/robert-koch-institut/SARS-CoV-2-Sequenzdaten_aus_Deutschland

RKI data is ingested as part of the existing genbank/open path. Fetch and curate happen in parallel to genbank.

The resulting `data/genbank_metadata_transformed.tsv` and `data/rki_metadata_transformed.tsv` are then merged and deduplicated on the internal_id uploaded by RKI to genbank and accessed via biosample.tsv

Nextclade then runs on the resulting merged sequences - so no changes from there onwards.

Testing
- [x] Deduplication works as expected (interestingly RKI does not seem to submit many bad/mediocre sequences to genbank, these could still be useful for genotyping/stats purposes so we include them in open data - they will be dropped due to QC for phylo builds)
- [ ] GISAID ingest works: `nextstrain build --aws-batch --attach 23083dd0-c2f6-491a-a0d2-5222b1ec6523 --no-download .`
- [x] Open ingest works: `nextstrain build --aws-batch --attach 7053fef7-9ad8-480e-83c1-b4448e8000d7
 --no-download .`
- [ ] Open fetch and ingest works: `nextstrain build --aws-batch --attach 28d7d9f0-367a-44a6-8c67-39bd53d66f6d  --no-download .`

Potential further steps
- [ ] Turn zip codes into states/location
- [ ] Come up with decent strain names that aren't 30 characters long