### PR TITLE
Parallelize raw uploads analogous to non-raw uploads

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -22,10 +22,6 @@ all_targets = [f"data/{database}/metadata.tsv", f"data/{database}/sequences.fast
 if config.get("s3_dst"):
     all_targets.append(f"data/{database}/upload.done")
 
-    # Include upload of raw NDJSON if we are fetching new sequences from database
-    if config.get("fetch_from_database", False):
-        all_targets.append(f"data/{database}/raw.upload.done")
-
     # Only check for trigger config if `s3_dst` is provided because we only
     # want to trigger builds if we've uploaded the output files to S3.
     if config.get("trigger_rebuild", False):

--- a/workflow/snakemake_rules/fetch_sequences.smk
+++ b/workflow/snakemake_rules/fetch_sequences.smk
@@ -144,8 +144,8 @@ if config.get("s3_dst") and config.get("s3_src"):
 
     rule fetch_cog_uk_accessions_from_s3:
         params:
-            file_on_s3_dst=f"{config['s3_dst']}/cog_uk_accessions.tsv",
-            file_on_s3_src=f"{config['s3_src']}/cog_uk_accessions.tsv",
+            file_on_s3_dst=f"{config['s3_dst']}/cog_uk_accessions.tsv.zst",
+            file_on_s3_src=f"{config['s3_src']}/cog_uk_accessions.tsv.zst",
             lines = config.get("subsample",{}).get("cog_uk_accessions", 0)
         output:
             biosample = "data/cog_uk_accessions.tsv" if config.get("keep_temp",False) else temp("data/cog_uk_accessions.tsv")
@@ -157,8 +157,8 @@ if config.get("s3_dst") and config.get("s3_src"):
 
     rule fetch_cog_uk_metadata_from_s3:
         params:
-            file_on_s3_dst=f"{config['s3_dst']}/cog_uk_metadata.csv.gz",
-            file_on_s3_src=f"{config['s3_src']}/cog_uk_metadata.csv.gz",
+            file_on_s3_dst=f"{config['s3_dst']}/cog_uk_metadata.csv.zst",
+            file_on_s3_src=f"{config['s3_src']}/cog_uk_metadata.csv.zst",
             lines = config.get("subsample",{}).get("cog_uk_metadata", 0)
         output:
             biosample = temp("data/cog_uk_metadata.csv")

--- a/workflow/snakemake_rules/upload.smk
+++ b/workflow/snakemake_rules/upload.smk
@@ -58,6 +58,12 @@ def compute_files_to_upload():
             files_to_upload.update({
                 "biosample.ndjson.gz": f"data/biosample.ndjson",
                 "biosample.ndjson.zst": f"data/biosample.ndjson",
+
+                "cog_uk_accessions.tsv.gz": f"data/cog_uk_accessions.tsv",
+                "cog_uk_accessions.tsv.zst": f"data/cog_uk_accessions.tsv",
+
+                "cog_uk_metadata.csv.gz": f"data/cog_uk_metadata.csv",
+                "cog_uk_metadata.csv.zst": f"data/cog_uk_metadata.csv",
             })
     return files_to_upload
 

--- a/workflow/snakemake_rules/upload.smk
+++ b/workflow/snakemake_rules/upload.smk
@@ -2,40 +2,23 @@
 This part of the workflow handles uploading files to AWS S3.
 Depends on the main Snakefile to define the variable `database`, which is NOT a wildcard.
 
-See `raw_files_to_upload` and `compute_files_to_upload` for the list of
+See `files_to_upload` for the list of
 expected inputs.
 
 Produces the following outputs:
-    "data/{database}/raw.upload.done"
     "data/{database}/upload.done"
 These output files are empty flag files to force Snakemake to run the upload rules.
 
 Note: we are doing parallel uploads of zstd compressed files to slowly make the transition to this format.
 """
 
-raw_files_to_upload = {
-    f"{database}.ndjson.xz": f"data/{database}.ndjson",
-    f"{database}.ndjson.zst": f"data/{database}.ndjson",
-}
+def compute_files_to_upload():
+    """
+    Compute files to upload
+    The keys are the name of the file once uploaded to S3
+    The values are the local paths to the file to be uploaded
+    """
 
-if database=="genbank":
-    raw_files_to_upload["biosample.ndjson.gz"] = f"data/biosample.ndjson"
-    raw_files_to_upload["biosample.ndjson.zst"] = f"data/biosample.ndjson"
-
-rule upload_raw_ndjson:
-    input:
-        **raw_files_to_upload
-    output:
-        touch(f"data/{database}/raw.upload.done")
-    params:
-        quiet = "" if send_notifications else "--quiet",
-        s3_bucket = config.get("s3_dst",""),
-        cloudfront_domain = config.get("cloudfront_domain", "")
-    run:
-        for remote, local in input.items():
-            shell("./bin/upload-to-s3 {params.quiet} {local:q} {params.s3_bucket:q}/{remote:q} {params.cloudfront_domain}")
-
-def compute_files_to_upload(wildcards):
     files_to_upload = {
                         "metadata.tsv.gz":              f"data/{database}/metadata.tsv",
                         "sequences.fasta.xz":           f"data/{database}/sequences.fasta",
@@ -57,24 +40,34 @@ def compute_files_to_upload(wildcards):
 
         files_to_upload["biosample.tsv.zst"] =           f"data/{database}/biosample.tsv"
         files_to_upload["duplicate_biosample.txt.zst"] = f"data/{database}/duplicate_biosample.txt"
+
     elif database=="gisaid":
         files_to_upload["additional_info.tsv.gz"] =     f"data/{database}/additional_info.tsv"
         files_to_upload["flagged_metadata.txt.gz"] =    f"data/{database}/flagged_metadata.txt"
 
         files_to_upload["additional_info.tsv.zst"] =     f"data/{database}/additional_info.tsv"
         files_to_upload["flagged_metadata.txt.zst"] =    f"data/{database}/flagged_metadata.txt"
-
+        
+    # Include upload of raw NDJSON if we are fetching new sequences from database
+    if config.get("fetch_from_database", False):
+        files_to_upload.update({
+            f"{database}.ndjson.xz": f"data/{database}.ndjson",
+            f"{database}.ndjson.zst": f"data/{database}.ndjson",
+        })
+        if database=="genbank":
+            files_to_upload.update({
+                "biosample.ndjson.gz": f"data/biosample.ndjson",
+                "biosample.ndjson.zst": f"data/biosample.ndjson",
+            })
     return files_to_upload
 
-def files_to_upload(wildcards):
-    files_to_upload_dict = compute_files_to_upload(wildcards)
-    return [f"data/{database}/{remote_file}.upload" for remote_file in files_to_upload_dict.keys()]
+files_to_upload = compute_files_to_upload()
 
 
 rule upload_single:
-    input: lambda wildcards: compute_files_to_upload(wildcards)[wildcards.remote_filename]
+    input: lambda w: files_to_upload[w.remote_filename]
     output:
-        "data/{database}/{remote_filename}.upload"
+        "data/{database}/{remote_filename}.upload",
     params:
         quiet = "" if send_notifications else "--quiet",
         s3_bucket = config.get("s3_dst",""),
@@ -93,7 +86,6 @@ rule upload:
     Requests one touch file for each uploaded remote file
     Dynamically determines that list of files
     """
-    input:
-        files_to_upload
+    input: [f"data/{database}/{remote_file}.upload" for remote_file in files_to_upload.keys()]
     output:
         touch(f"data/{database}/upload.done")


### PR DESCRIPTION
I noticed we don't do raw uploads in parallel - in contrast to how we now do non-raw uploads.

I've refactored raw uploads to fit the new paradigm, this actually makes it easier to follow (in my view).

Test runs:
- [ ] GISAID fetch and ingest: `8a026939-3a83-4b0e-9205-4f8cbb60b41d`
- [ ] Genbank fetch and ingest: `61cf1e0f-0e8b-43e0-96e7-f93fde518719`