### PR TITLE
Add subsampled ingest config.yml for faster feedback loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ tmp/
 
 # Editor config
 .vscode/
+
+# Nextclade executable
+nextclade

--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ Relies on data from <https://simplemaps.com/data/us-cities>.
 
 > NOTE: The full set of sequences from GISAID/GenBank will most likely require more compute resources than what is available on your local computer.
 
+To debug all rules on a subset of the data, you can use the `config/debug_sample_genbank.yaml` and `config/debug_sample_gisaid.yaml` config files.
+These will download raw data from AWS s3, randomly keeping only a subset of lines of the input files (configurable in the config file).
+This way, the pipeline completes in a matter of minutes and acceptable storage requirements for local compute.
+However, the output data should not be trusted, as biosample and cog-uk input lines are randomly selected independently of the main ndjson.
+
+To get started, you can run the following:
+
+```sh
+snakemake -j all --configfile config/debug_sample_genbank.yaml  -pF --ri --nt
+```
+
 > **Warning**
 > If you are running the pipeline without a Nextclade cache, it will do a full Nextclade run that aligns _all_ sequences,
 > which will take significant time and resources!

--- a/bin/download-from-s3
+++ b/bin/download-from-s3
@@ -6,6 +6,7 @@ bin="$(dirname "$0")"
 main() {
     local src="${1:?A source s3:// URL is required as the first argument.}"
     local dst="${2:?A destination file path is required as the second argument.}"
+    local n="${3:-0}" # How many lines to subsample to. 0 means no subsampling. Optional.
 
     local s3path="${src#s3://}"
     local bucket="${s3path%%/*}"
@@ -26,7 +27,12 @@ main() {
             zstd -T0 -dcq
         else
             cat
-        fi > "$dst"
+        fi |
+        if [[ "$n" -gt 0 ]]; then
+            tsv-sample -H -i -n "$n"
+        else
+            cat
+        fi >"$dst"
     else
         echo "[ INFO] Files are identical, skipping download"
     fi

--- a/bin/fetch-from-cog-uk-accessions
+++ b/bin/fetch-from-cog-uk-accessions
@@ -3,4 +3,5 @@ set -euo pipefail
 
 curl "https://cog-uk.s3.climb.ac.uk/accessions/latest.tsv" \
     --fail --silent --show-error --http1.1 \
-    --header 'User-Agent: https://github.com/nextstrain/ncov-ingest (hello@nextstrain.org)'
+    --header 'User-Agent: https://github.com/nextstrain/ncov-ingest (hello@nextstrain.org)' | \
+dos2unix

--- a/config/debug_sample_genbank.yaml
+++ b/config/debug_sample_genbank.yaml
@@ -1,0 +1,22 @@
+# Running ingest using raw data from s3 and subsampling
+# This is useful for debugging and testing 
+# Data output should not be trusted, though
+database_name: "genbank"
+
+s3_src: "s3://nextstrain-data/files/ncov/open"
+s3_dst: "s3://nextstrain-data/files/ncov/open/branch/subsample"
+
+keep_all_files: True
+fetch_from_database: false
+trigger_rebuild: false
+trigger_counts: false
+
+# Use --nt flag to keep all temp files as snakemake 
+keep_temp: true
+
+# How many lines to extract from s3 fetch
+subsample:
+  main_ndjson: 1000
+  biosample: 30000
+  nextclade: 1000
+  rki_ndjson: 1000

--- a/config/debug_sample_genbank.yaml
+++ b/config/debug_sample_genbank.yaml
@@ -20,3 +20,5 @@ subsample:
   biosample: 30000
   nextclade: 1000
   rki_ndjson: 1000
+  cog_uk_accessions: 1000
+  cog_uk_metadata: 1000

--- a/config/debug_sample_gisaid.yaml
+++ b/config/debug_sample_gisaid.yaml
@@ -1,0 +1,20 @@
+# Running ingest using raw data from s3 and subsampling
+# This is useful for debugging and testing 
+# Data output should not be trusted, though
+database_name: "gisaid"
+
+s3_src: "s3://nextstrain-ncov-private"
+s3_dst: "s3://nextstrain-ncov-private/branch/subsample"
+
+keep_all_files: True
+fetch_from_database: false
+trigger_rebuild: false
+trigger_counts: false
+
+# Use --nt flag to keep all temp files as snakemake 
+keep_temp: true
+
+# How many lines to extract from s3 fetch
+subsample:
+  main_ndjson: 1000
+  nextclade: 1000

--- a/workflow/snakemake_rules/fetch_sequences.smk
+++ b/workflow/snakemake_rules/fetch_sequences.smk
@@ -104,12 +104,13 @@ if config.get("s3_dst") and config.get("s3_src"):
         params:
             file_on_s3_dst=f"{config['s3_dst']}/{database}.ndjson.zst",
             file_on_s3_src=f"{config['s3_src']}/{database}.ndjson.zst",
+            lines = config.get("subsample",{}).get("main_ndjson", 0)
         output:
             ndjson = temp(f"data/{database}.ndjson")
         shell:
             """
-            ./bin/download-from-s3 {params.file_on_s3_dst} {output.ndjson} ||  \
-            ./bin/download-from-s3 {params.file_on_s3_src} {output.ndjson}
+            ./bin/download-from-s3 {params.file_on_s3_dst} {output.ndjson} {params.lines} ||  \
+            ./bin/download-from-s3 {params.file_on_s3_src} {output.ndjson} {params.lines}
             """
 
     rule fetch_biosample_from_s3:
@@ -118,10 +119,11 @@ if config.get("s3_dst") and config.get("s3_src"):
         params:
             file_on_s3_dst=f"{config['s3_dst']}/biosample.ndjson.zst",
             file_on_s3_src=f"{config['s3_src']}/biosample.ndjson.zst",
+            lines = config.get("subsample",{}).get("biosample", 0)
         output:
             biosample = temp("data/biosample.ndjson")
         shell:
             """
-            ./bin/download-from-s3 {params.file_on_s3_dst} {output.biosample} ||  \
-            ./bin/download-from-s3 {params.file_on_s3_src} {output.biosample}
+            ./bin/download-from-s3 {params.file_on_s3_dst} {output.biosample} {params.lines} ||  \
+            ./bin/download-from-s3 {params.file_on_s3_src} {output.biosample} {params.lines}
             """

--- a/workflow/snakemake_rules/fetch_sequences.smk
+++ b/workflow/snakemake_rules/fetch_sequences.smk
@@ -85,6 +85,14 @@ rule fetch_cog_uk_metadata:
             f"rm {output.cog_uk_metadata}"
         )
 
+rule uncompress_cog_uk_metadata:
+    input:
+        "data/cog_uk_metadata.csv.gz"
+    output:
+        cog_uk_metadata = temp("data/cog_uk_metadata.csv")
+    shell:
+        "gunzip -c {input} > {output}"
+
 # Only include rules to fetch from S3 if S3 config params are provided
 if config.get("s3_dst") and config.get("s3_src"):
 
@@ -94,9 +102,15 @@ if config.get("s3_dst") and config.get("s3_src"):
     if config.get("fetch_from_database", False):
         ruleorder: fetch_main_ndjson > fetch_main_ndjson_from_s3
         ruleorder: fetch_biosample > fetch_biosample_from_s3
+        ruleorder: fetch_cog_uk_accessions > fetch_cog_uk_accessions_from_s3
+        ruleorder: fetch_cog_uk_metadata > compress_cog_uk_metadata
+        ruleorder: uncompress_cog_uk_metadata > fetch_cog_uk_metadata_from_s3
     else:
         ruleorder: fetch_main_ndjson_from_s3 > fetch_main_ndjson
-        ruleorder:  fetch_biosample_from_s3 > fetch_biosample
+        ruleorder: fetch_biosample_from_s3 > fetch_biosample
+        ruleorder: fetch_cog_uk_accessions_from_s3 > fetch_cog_uk_accessions
+        ruleorder: fetch_cog_uk_metadata_from_s3 > uncompress_cog_uk_metadata
+        ruleorder: compress_cog_uk_metadata > fetch_cog_uk_metadata
 
     rule fetch_main_ndjson_from_s3:
         message:
@@ -127,3 +141,37 @@ if config.get("s3_dst") and config.get("s3_src"):
             ./bin/download-from-s3 {params.file_on_s3_dst} {output.biosample} {params.lines} ||  \
             ./bin/download-from-s3 {params.file_on_s3_src} {output.biosample} {params.lines}
             """
+
+    rule fetch_cog_uk_accessions_from_s3:
+        params:
+            file_on_s3_dst=f"{config['s3_dst']}/cog_uk_accessions.tsv",
+            file_on_s3_src=f"{config['s3_src']}/cog_uk_accessions.tsv",
+            lines = config.get("subsample",{}).get("cog_uk_accessions", 0)
+        output:
+            biosample = "data/cog_uk_accessions.tsv" if config.get("keep_temp",False) else temp("data/cog_uk_accessions.tsv")
+        shell:
+            """
+            ./bin/download-from-s3 {params.file_on_s3_dst} {output.biosample} {params.lines} ||  \
+            ./bin/download-from-s3 {params.file_on_s3_src} {output.biosample} {params.lines}
+            """
+
+    rule fetch_cog_uk_metadata_from_s3:
+        params:
+            file_on_s3_dst=f"{config['s3_dst']}/cog_uk_metadata.csv.gz",
+            file_on_s3_src=f"{config['s3_src']}/cog_uk_metadata.csv.gz",
+            lines = config.get("subsample",{}).get("cog_uk_metadata", 0)
+        output:
+            biosample = temp("data/cog_uk_metadata.csv")
+        shell:
+            """
+            ./bin/download-from-s3 {params.file_on_s3_dst} {output.biosample} {params.lines} ||  \
+            ./bin/download-from-s3 {params.file_on_s3_src} {output.biosample} {params.lines}
+            """
+    
+    rule compress_cog_uk_metadata:
+        input:
+            "data/cog_uk_metadata.csv"
+        output:
+            cog_uk_metadata = "data/cog_uk_metadata.csv.gz" if config.get("keep_temp",False) else temp("data/cog_uk_metadata.csv.gz")
+        shell:
+            "gzip -c {input} > {output}"

--- a/workflow/snakemake_rules/nextclade.smk
+++ b/workflow/snakemake_rules/nextclade.smk
@@ -166,6 +166,8 @@ rule combine_alignments:
         new_alignment = f"data/{database}/nextclade.aligned.upd.fasta"
     output:
         alignment = f"data/{database}/aligned.fasta"
+    params:
+        keep_temp=config.get("keep_temp","false")
     shell:
         """
         if [[ -s {input.old_alignment} ]]; then
@@ -175,6 +177,8 @@ rule combine_alignments:
                 mv {input.old_alignment} {output.alignment}
             fi
             cat {input.new_alignment} >> {output.alignment}
+        elif [[ "{params.keep_temp}" == "True" ]]; then
+            cp {input.new_alignment} {output.alignment}
         else
             mv {input.new_alignment} {output.alignment}
         fi

--- a/workflow/snakemake_rules/nextclade.smk
+++ b/workflow/snakemake_rules/nextclade.smk
@@ -45,12 +45,13 @@ if config.get("s3_dst") and config.get("s3_src"):
         params:
             dst_source=config["s3_dst"] + "/nextclade.tsv.zst",
             src_source=config["s3_src"] + "/nextclade.tsv.zst",
+            lines=config.get("subsample",{}).get("nextclade", 0),
         output:
             nextclade = f"data/{database}/nextclade_old.tsv"
         shell:
             """
-            ./bin/download-from-s3 {params.dst_source} {output.nextclade} ||  \
-            ./bin/download-from-s3 {params.src_source} {output.nextclade}
+            ./bin/download-from-s3 {params.dst_source} {output.nextclade} {params.lines} ||  \
+            ./bin/download-from-s3 {params.src_source} {output.nextclade} {params.lines}
             """
 
     rule download_previous_alignment:
@@ -60,12 +61,13 @@ if config.get("s3_dst") and config.get("s3_src"):
         params:
             dst_source=config["s3_dst"] + "/aligned.fasta.zst",
             src_source=config["s3_src"] + "/aligned.fasta.zst",
+            lines=config.get("subsample",{}).get("nextclade", 0),
         output:
             alignment = temp(f"data/{database}/nextclade.aligned.old.fasta")
         shell:
             """
-            ./bin/download-from-s3 {params.dst_source} {output.alignment} ||  \
-            ./bin/download-from-s3 {params.src_source} {output.alignment}
+            ./bin/download-from-s3 {params.dst_source} {output.alignment} {params.lines} ||  \
+            ./bin/download-from-s3 {params.src_source} {output.alignment} {params.lines}
             """
 
 
@@ -167,7 +169,11 @@ rule combine_alignments:
     shell:
         """
         if [[ -s {input.old_alignment} ]]; then
-            mv {input.old_alignment} {output.alignment}
+            if [[ "{params.keep_temp}" == "True" ]]; then
+                cp {input.old_alignment} {output.alignment}
+            else
+                mv {input.old_alignment} {output.alignment}
+            fi
             cat {input.new_alignment} >> {output.alignment}
         else
             mv {input.new_alignment} {output.alignment}


### PR DESCRIPTION
Right now, ingests even without fetch take hours due to the massive amount of data being piped through pandas and the like.

This PR allows fast CI checks by subsampling whatever arrives from s3 (ndjson, biosample, nextclade alignments etc.), that way, ingest doesn't require 300GB disk space and can live with < 1GB and run in ~5-10 minutes depending on speed of internet connection.

Of course, because we don't load the whole biosample.tsv, there will be differences to a real ingest, so don't take the output data as correct. This is still useful for debugging though. And one could simply not subsample biosample.tsv if we need to test correctness. It's only 10GB so should be ok locally, albeit inconvenient.

To speed up local testing, I'd probably take the various ndjsons out of the snakemake `temp` state - so that once downloaded they don't get deleted - otherwise transforms are hard to debug without changing the pipeline manually to un-temp.

### Testing

- [x] Check that all other configs still work correctly and are not negatively impacted

Test runs:
- [x] GISAID ingest on branch: `750ab0fe-a2e0-48b6-bd94-2eb0002eb842`	https://us-east-1.console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/750ab0fe-a2e0-48b6-bd94-2eb0002eb842	
- [x] Genbank ingest on branch: `ddf38426-1865-473c-9f99-564e4c126e8b` https://us-east-1.console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/ddf38426-1865-473c-9f99-564e4c126e8b