### PR TITLE
Run Nextclade 2nd time on 21L dataset for immune_escape/ace2

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -16,7 +16,11 @@ send_notifications = "SLACK_CHANNELS" in os.environ and "SLACK_TOKEN" in os.envi
 ################ work out what steps to run #####################
 #################################################################
 
-all_targets = [f"data/{database}/metadata.tsv", f"data/{database}/sequences.fasta"]
+all_targets = [
+    f"data/{database}/metadata.tsv",
+    f"data/{database}/sequences.fasta",
+    f"data/{database}/aligned.fasta",
+]
 
 # Include targets for uploading to S3 if `s3_dst` is provided in config
 if config.get("s3_dst"):

--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -16,6 +16,8 @@ reference_day = datetime(2020,1,1).toordinal()
 column_map = {
     "clade": "Nextstrain_clade",
     "Nextclade_pango": "Nextclade_pango",
+    "immune_escape": "immune_escape",
+    "ace2_binding": "ace2_binding",
     "totalMissing": "missing_data",
     "totalSubstitutions": "divergence",
     "totalNonACGTNs": "nonACGTN",
@@ -63,6 +65,7 @@ def parse_args():
     )
     parser.add_argument("first_file")
     parser.add_argument("second_file")
+    parser.add_argument("nextclade_21L")
     parser.add_argument("-o", default=sys.stdout)
     return parser.parse_args()
 
@@ -89,6 +92,21 @@ def main():
     clades = pd.read_csv(args.second_file, index_col=NEXTCLADE_JOIN_COLUMN_NAME,
                          sep='\t', low_memory=False, na_filter = False) \
             .rename(columns=column_map)
+
+    clades_21L = pd.read_csv(args.nextclade_21L, index_col=NEXTCLADE_JOIN_COLUMN_NAME,
+                         sep='\t', low_memory=False,
+                         usecols=[NEXTCLADE_JOIN_COLUMN_NAME,"immune_escape","ace2_binding"],
+                         dtype={"immune_escape":float, "ace2_binding":float}) \
+            .rename(columns=column_map)
+    
+    # Reduce false precision in immune_escape and ace2_binding
+    clades_21L = clades_21L.round(3)
+    
+    clades = pd.merge(clades, clades_21L, left_index=True, right_index=True, how='left')
+
+    # Remove immune_escape and ace2_binding when clade <21L and not recombinant
+    clades.loc[clades.Nextstrain_clade < "21L",["immune_escape","ace2_binding"]] = float('nan')
+
 
     clades = clades[list(column_map.values())]
 

--- a/bin/run-nextclade
+++ b/bin/run-nextclade
@@ -14,7 +14,8 @@ trap "exit" INT
 : "${5:?\"[ERROR] ${0}: Output fasta filename as the 5th argument is required.\"}"
 : "${6:?\"[ERROR] ${0}: Output insertions csv filename as the 6th argument is required.\"}"
 : "${7:?\"[ERROR] ${0}: List of genes as 7th argument is required.\"}"
-# Note: 8th argument is the (max) number of threads for nextclade and is optional
+: "${8:?\"[ERROR] ${0}: Dataset as the 8th argument is required.\"}"
+# Note: 9th argument is the (max) number of threads for nextclade and is optional
 
 INPUT_FASTA="${1}"
 OUTPUT_TSV="${2}"
@@ -23,12 +24,13 @@ NEXTCLADE_OUTPUTS_DIR="${4}" # files other than TSV will be written by Nextclade
 OUTPUT_FASTA="${5}"
 OUTPUT_INSERTIONS="${6}"
 GENES="${7}"
+NEXTCLADE_DATASET_NAME="${8}"
 
 NEXTCLADE_THREADS=""
-if [ $# -eq 8 ]; then
-    echo "[ INFO] ${0}:${LINENO}: Nextclade will be limited to ${8} threads"
-    NEXTCLADE_THREADS="--jobs ${8}"
-elif [ $# -gt 8 ]; then
+if [ $# -eq 9 ]; then
+    echo "[ INFO] ${0}:${LINENO}: Nextclade will be limited to ${9} threads"
+    NEXTCLADE_THREADS="--jobs ${9}"
+elif [ $# -gt 9 ]; then
     echo "[ INFO] ${0}:${LINENO}: Too many arguments provided"
     exit 1
 fi
@@ -51,7 +53,7 @@ NEXTCLADE_VERSION="$(./nextclade --version)"
 echo "[ INFO] ${0}:${LINENO}: Nextclade version: ${NEXTCLADE_VERSION}"
 
 echo "[ INFO] ${0}:${LINENO}: Downloading Nextclade dataset \"sars-cov-2\""
-./nextclade dataset get --name=sars-cov-2 --output-dir="${NEXTCLADE_DATASET_DIR}" --verbose
+./nextclade dataset get --name="${NEXTCLADE_DATASET_NAME}" --output-dir="${NEXTCLADE_DATASET_DIR}" --verbose
 
 
 echo "[ INFO] ${0}:${LINENO}: Running Nextclade"

--- a/workflow/snakemake_rules/upload.smk
+++ b/workflow/snakemake_rules/upload.smk
@@ -32,6 +32,7 @@ def compute_files_to_upload():
 
                         "nextclade.tsv.zst":           f"data/{database}/nextclade.tsv",
                         "aligned.fasta.zst":           f"data/{database}/aligned.fasta",
+                        "nextclade_21L.tsv.zst":       f"data/{database}/nextclade_21L.tsv",
                     }
 
     if database=="genbank":


### PR DESCRIPTION
### Description of proposed changes

To add `immune_escape` and `ace2_binding` scores, we run all sequences through the `sars-cov-2-21L` dataset (in addition to the normal `sars-cov-2` dataset.

Results are cached as usual.

Only 2 new columns are added to the `metadata.tsv`. 

### Testing

- [ ] Genbank ingest on branch
- [ ] GISAID ingest on branch