### PR TITLE
NCBI Datasets: switch to "host-name" field

### DIFF
--- a/bin/transform-genbank
+++ b/bin/transform-genbank
@@ -61,7 +61,7 @@ NCBI_COLUMN_MAP = {
     "Update date": "date_updated",
     "Virus Pangolin Classification": "pango_lineage",
     "Length": "length",
-    "Host Common Name": "host",
+    "Host Name": "host",
     "Isolate Lineage source": "isolation_source",
     "BioSample accession": "biosample_accession",
     "Submitter Names": "authors",

--- a/workflow/snakemake_rules/fetch_sequences.smk
+++ b/workflow/snakemake_rules/fetch_sequences.smk
@@ -90,7 +90,7 @@ def _get_ncbi_dataset_field_mnemonics(wildcard):
         "update-date",
         "virus-pangolin",
         "length",
-        "host-common-name",
+        "host-name",
         "isolate-lineage-source",
         "biosample-acc",
         "submitter-names",


### PR DESCRIPTION
### Description of proposed changes

Previously used the "host-common-name" field to pull in the common names of hosts (e.g. "human"), however this field is empty in recent downloads. This commit switches to the other host field, "host-name", which has the scientific name of the host.

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->
Resolves #383 

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Test run ([GH Action](https://github.com/nextstrain/ncov-ingest/actions/runs/3943510619) - AWS Batch job `89cd19a7-4c18-4a2e-9b29-d9590adcec62`)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
