### PR TITLE
Full Nextclade updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,10 @@ Whenever the underlying nextclade dataset (reference tree, QC rules) and/or next
 In order to tell ingest to not use the cached `nextclade.tsv`/`aligned.fasta` and instead perform a full rerun, you need to add an (empty) touchfile to the s3 bucket:
 
 ```bash
-touch nextclade.tsv.zst.renew
-aws s3 cp nextclade.tsv.zst.renew s3://nextstrain-ncov-private/nextclade.tsv.zst.renew
-aws s3 cp nextclade.tsv.zst.renew s3://nextstrain-ncov-private/aligned.fasta.zst.renew
-aws s3 cp nextclade.tsv.zst.renew s3://nextstrain-data/files/ncov/open/nextclade.tsv.zst.renew
-aws s3 cp nextclade.tsv.zst.renew s3://nextstrain-data/files/ncov/open/aligned.fasta.zst.renew
+aws s3 cp - s3://nextstrain-ncov-private/nextclade.tsv.zst.renew < /dev/null
+aws s3 cp - s3://nextstrain-ncov-private/aligned.fasta.zst.renew < /dev/null
+aws s3 cp - s3://nextstrain-data/files/ncov/open/nextclade.tsv.zst.renew < /dev/null
+aws s3 cp - s3://nextstrain-data/files/ncov/open/aligned.fasta.zst.renew < /dev/null
 ```
 
 Ingest will automatically remove the touchfiles after it has completed the rerun.
@@ -147,9 +146,8 @@ Ingest will automatically remove the touchfiles after it has completed the rerun
 To rerun Nextclade using the `sars-cov-2-21L` dataset - which is only necessary when the calculation of `immune_escape` and `ace2_binding` changes - you need to add an (empty) touchfile to the s3 bucket:
 
 ```bash
-touch nextclade.tsv.zst.renew
-aws s3 cp nextclade.tsv.zst.renew s3://nextstrain-ncov-private/nextclade_21L.tsv.zst.renew
-aws s3 cp nextclade.tsv.zst.renew s3://nextstrain-data/files/ncov/open/nextclade_21L.tsv.zst.renew
+aws s3 cp - s3://nextstrain-ncov-private/nextclade_21L.tsv.zst.renew < /dev/null
+aws s3 cp - s3://nextstrain-data/files/ncov/open/nextclade_21L.tsv.zst.renew < /dev/null
 ```
 
 ## Required environment variables

--- a/README.md
+++ b/README.md
@@ -132,12 +132,14 @@ Enter this into the `slack_member_id` field of your alert configuration.
 Clade assignments and other QC metadata output by Nextclade are currently cached in `nextclade.tsv` in the S3 bucket and only incremental additions for the new sequences are performed during the daily ingests.
 Whenever the underlying nextclade dataset (reference tree, QC rules) and/or nextclade software are updated, it is necessary to perform a full update of `nextclade.tsv`, rerunning for all of the GISAID and GenBank sequences all over again, to account for changes in the data and Nextclade algorithms.
 
-In order to tell ingest to not use the cached `nextclade.tsv` and instead perform a full rerun, you need to add an (empty) touchfile to the s3 bucket:
+In order to tell ingest to not use the cached `nextclade.tsv`/`aligned.fasta` and instead perform a full rerun, you need to add an (empty) touchfile to the s3 bucket:
 
 ```bash
 touch nextclade.tsv.zst.renew
 aws s3 cp nextclade.tsv.zst.renew s3://nextstrain-ncov-private/nextclade.tsv.zst.renew
+aws s3 cp nextclade.tsv.zst.renew s3://nextstrain-ncov-private/aligned.fasta.zst.renew
 aws s3 cp nextclade.tsv.zst.renew s3://nextstrain-data/files/ncov/open/nextclade.tsv.zst.renew
+aws s3 cp nextclade.tsv.zst.renew s3://nextstrain-data/files/ncov/open/aligned.fasta.zst.renew
 ```
 
 Ingest will automatically remove the touchfiles after it has completed the rerun.
@@ -148,15 +150,6 @@ To rerun Nextclade using the `sars-cov-2-21L` dataset - which is only necessary 
 touch nextclade.tsv.zst.renew
 aws s3 cp nextclade.tsv.zst.renew s3://nextstrain-ncov-private/nextclade_21L.tsv.zst.renew
 aws s3 cp nextclade.tsv.zst.renew s3://nextstrain-data/files/ncov/open/nextclade_21L.tsv.zst.renew
-```
-
-If Nextclade's alignment algorithm has changed or the alignment parameters have been changed in a dataset release, the alignment needs to be rerun as well.
-To do this, you need to add an (empty) touchfile to the s3 bucket:
-
-```bash
-touch aligned.fasta.zst.renew
-aws s3 cp aligned.fasta.zst.renew s3://nextstrain-ncov-private/aligned.fasta.zst.renew
-aws s3 cp aligned.fasta.zst.renew s3://nextstrain-data/files/ncov/open/aligned.fasta.zst.renew
 ```
 
 ## Required environment variables

--- a/workflow/snakemake_rules/nextclade.smk
+++ b/workflow/snakemake_rules/nextclade.smk
@@ -110,7 +110,7 @@ rule get_sequences_without_nextclade_annotations:
                 --input_tsv={input.nextclade} \
                 --output_fasta={output.fasta}
         else
-            cp {input.fasta} {output.fasta}
+            ln {input.fasta} {output.fasta}
         fi
         echo "[ INFO] Number of {wildcards.reference} sequences to run Nextclade on: $(grep -c '^>' {output.fasta})"
         """


### PR DESCRIPTION
### Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->
1. Switch from `cp` to `ln` for full run sequences to improve disk usage and run time
    The remaining uses of `cp` only apply when providing the `keep_temp` flag for debugging purposes. I'm avoiding using links for these to avoid the [issue](https://github.com/snakemake/snakemake/issues/1140) of Snakemake re-runs working unexpectedly during debugging. 
2. Update full Nextclade instructions to avoid appending full run sequences to the cached `aligned.fasta`. See https://github.com/nextstrain/ncov-ingest/pull/380#pullrequestreview-1254080828


### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
