### PR TITLE
Reduce memory

### DIFF
--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -40,6 +40,7 @@ column_map = {
     "aaSubstitutions": "aaSubstitutions"
 }
 
+clades_21L_columns = {"immune_escape","ace2_binding"}
 
 def reorder_columns(result: pd.DataFrame):
     """
@@ -83,12 +84,13 @@ def main():
 
     # Read and rename clade column to be more descriptive
     clades = pd.read_csv(args.second_file, index_col=NEXTCLADE_JOIN_COLUMN_NAME,
+                         usecols=[NEXTCLADE_JOIN_COLUMN_NAME, *(set(column_map.keys()) - clades_21L_columns)],
                          sep='\t', low_memory=False, na_filter = False) \
             .rename(columns=column_map)
 
     clades_21L = pd.read_csv(args.nextclade_21L, index_col=NEXTCLADE_JOIN_COLUMN_NAME,
                          sep='\t', low_memory=False,
-                         usecols=[NEXTCLADE_JOIN_COLUMN_NAME,"immune_escape","ace2_binding"],
+                         usecols=[NEXTCLADE_JOIN_COLUMN_NAME, *clades_21L_columns],
                          dtype={"immune_escape":float, "ace2_binding":float}) \
             .rename(columns=column_map)
 

--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -85,13 +85,13 @@ def main():
     # Read and rename clade column to be more descriptive
     clades = pd.read_csv(args.second_file, index_col=NEXTCLADE_JOIN_COLUMN_NAME,
                          usecols=[NEXTCLADE_JOIN_COLUMN_NAME, *(set(column_map.keys()) - clades_21L_columns)],
-                         sep='\t', low_memory=False, na_filter = False) \
+                         sep='\t', low_memory=True, dtype="object", na_filter = False) \
             .rename(columns=column_map)
 
     clades_21L = pd.read_csv(args.nextclade_21L, index_col=NEXTCLADE_JOIN_COLUMN_NAME,
-                         sep='\t', low_memory=False,
+                         sep='\t', low_memory=True,
                          usecols=[NEXTCLADE_JOIN_COLUMN_NAME, *clades_21L_columns],
-                         dtype={"immune_escape":float, "ace2_binding":float}) \
+                         dtype={NEXTCLADE_JOIN_COLUMN_NAME: "string", "immune_escape":float, "ace2_binding":float}) \
             .rename(columns=column_map)
 
     # Reduce false precision in immune_escape and ace2_binding

--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -98,10 +98,10 @@ def main():
                          usecols=[NEXTCLADE_JOIN_COLUMN_NAME,"immune_escape","ace2_binding"],
                          dtype={"immune_escape":float, "ace2_binding":float}) \
             .rename(columns=column_map)
-    
+
     # Reduce false precision in immune_escape and ace2_binding
     clades_21L = clades_21L.round(3)
-    
+
     clades = pd.merge(clades, clades_21L, left_index=True, right_index=True, how='left')
 
     # Remove immune_escape and ace2_binding when clade <21L and not recombinant

--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -40,13 +40,6 @@ column_map = {
     "aaSubstitutions": "aaSubstitutions"
 }
 
-preferred_types = {
-    "divergence": "int32",
-    "nonACGTN": "int32",
-    "missing_data": "int32",
-    "snp_clusters": "int32",
-    "rare_mutations": "int32"
-}
 
 def reorder_columns(result: pd.DataFrame):
     """
@@ -138,7 +131,7 @@ def main():
         result[col] = result[col].fillna(VALUE_MISSING_DATA)
 
     # Move the new column so that it's next to other clade columns
-    result = reorder_columns(result) #.astype(preferred_types)
+    result = reorder_columns(result)
 
     result.to_csv(args.o, index_label=METADATA_JOIN_COLUMN_NAME, sep='\t')
 


### PR DESCRIPTION
### Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->
Reduce memory usage of the `join-metadata-and-clades` script as this was the most recent culprit an OOM error in the pipeline. 

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

In my local testing/profiling with [Fil](https://pythonspeed.com/fil/docs/) using a subset of 100,000 records, these changes reduced total memory usage from ~750MiB to ~380MiB. 

Triggered a GISAID ingest run without fetch (`82bce0fa-a633-4a0e-95f0-28c11fcf99be`)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
