### PR TITLE
fix: tsv-uniq use column name instead of brittle column order

### DIFF
--- a/workflow/snakemake_rules/nextclade.smk
+++ b/workflow/snakemake_rules/nextclade.smk
@@ -193,15 +193,8 @@ rule nextclade_info:
         nextclade_info = f"data/{database}/nextclade{{reference}}.tsv"
     shell:
         """
-        TMPFILE="data/{database}/nextclade{{reference}}.tmp.tsv"
-        if [[ -s {input.old_info} ]]; then
-            mv {input.old_info} $TMPFILE
-            tail -n +2 {input.new_info} >> $TMPFILE
-        else
-            mv {input.new_info} $TMPFILE
-        fi
-        tsv-uniq -H -f seqName $TMPFILE > {output.nextclade_info}
-        rm $TMPFILE
+        tsv-append -H {input.old_info} {input.new_info} \
+        | tsv-uniq -H -f seqName > {output.nextclade_info}
         """
 
 rule combine_alignments:

--- a/workflow/snakemake_rules/nextclade.smk
+++ b/workflow/snakemake_rules/nextclade.smk
@@ -193,9 +193,15 @@ rule nextclade_info:
         nextclade_info = f"data/{database}/nextclade{{reference}}.tsv"
     shell:
         """
-        # Header taken from first non-empty file
-        keep-header {input.old_info:q} {input.new_info:q} -- \
-        tsv-uniq -f 1 > {output.nextclade_info}
+        TMPFILE="data/{database}/nextclade{{reference}}.tmp.tsv"
+        if [[ -s {input.old_info} ]]; then
+            mv {input.old_info} $TMPFILE
+            tail -n +2 {input.new_info} >> $TMPFILE
+        else
+            mv {input.new_info} $TMPFILE
+        fi
+        tsv-uniq -H -f seqName $TMPFILE > {output.nextclade_info}
+        rm $TMPFILE
         """
 
 rule combine_alignments:


### PR DESCRIPTION
Should fix bug where new sequences don't get output in nextclade.tsv
Discussed in https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1675087025824499
Requires full runs of both reference datasets

### Testing

- [x] Running locally with debug profile using partial cached tsv

To fully verify that it works, we should check after the full rerun that new sequences actually end up in nextclade.tsv - this will take a few days.