### PR TITLE
transforms/AbbreviateAuthors: remove double quotes

### DIFF
--- a/lib/utils/transformpipeline/transforms.py
+++ b/lib/utils/transformpipeline/transforms.py
@@ -389,6 +389,11 @@ class AbbreviateAuthors(Transformer):
             if not entry['authors'].strip('. ').endswith(" et al"): # if it does not already finishes with " et al.", add it
                 entry['authors'] += ' et al'
 
+            # Strip all double quotes from the authors value to prevent
+            # unclosed quotes from causing errors in table readers when reading
+            # the transformed metadata TSV
+            entry['authors'] = entry['authors'].replace('"', '')
+
         return entry
 
 


### PR DESCRIPTION
### Description of proposed changes

For some reason, certain author values from GISAID are double quoted and this leaves an unclosed quote when we truncate the authors to `"...et al`. This unclosed quote can lead to errors in table readers such as Excel as reported in #395.

This commit strips all `"` from the truncated authors string as an easy and quick fix for the issue.

### Related issue(s)

Fixes #395

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Test GISAID ingest w/o fetch ([GH Action](https://github.com/nextstrain/ncov-ingest/actions/runs/4431104248) | [AWS Batch job](https://us-east-1.console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/db1c24e2-0fdd-40b9-803a-40e0db302e28) `db1c24e2-0fdd-40b9-803a-40e0db302e28`)
- [ ] Test GenBank ingest w/o fetch ([GH Action](https://github.com/nextstrain/ncov-ingest/actions/runs/4431105670) | [AWS Batch job](https://us-east-1.console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/61c7d176-1350-4df7-8352-71f0edfa913b) `61c7d176-1350-4df7-8352-71f0edfa913b`)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
