### PR TITLE
Add more clade columns to metadata

### DIFF
--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -16,6 +16,10 @@ reference_day = datetime(2020,1,1).toordinal()
 
 column_map = {
     "clade_legacy": "Nextstrain_clade",
+    "clade_nextstrain": "year_letter_clade",
+    "clade_who": "clade_who",
+    "clade_legacy": "clade_legacy",
+    "clade_legacy": "display_clade",
     "Nextclade_pango": "Nextclade_pango",
     "immune_escape": "immune_escape",
     "ace2_binding": "ace2_binding",

--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -18,7 +18,6 @@ column_map = {
     "clade_legacy": "Nextstrain_clade",
     "clade_nextstrain": "clade_nextstrain",
     "clade_who": "clade_who",
-    "clade_legacy": "clade_legacy",
     "Nextclade_pango": "Nextclade_pango",
     "immune_escape": "immune_escape",
     "ace2_binding": "ace2_binding",

--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -16,10 +16,9 @@ reference_day = datetime(2020,1,1).toordinal()
 
 column_map = {
     "clade_legacy": "Nextstrain_clade",
-    "clade_nextstrain": "year_letter_clade",
+    "clade_nextstrain": "clade_nextstrain",
     "clade_who": "clade_who",
     "clade_legacy": "clade_legacy",
-    "clade_legacy": "display_clade",
     "Nextclade_pango": "Nextclade_pango",
     "immune_escape": "immune_escape",
     "ace2_binding": "ace2_binding",


### PR DESCRIPTION
We have updated Nextclade to separate out clade names (`23A`, `Omicron`, `23A (Omicron)`), but we have never followed up by doing the same in ingest, to give us more columns both to work with, and some overlap before we potentially change what `Nextstrain_clade` is. 
This PR adds `clade_nextstrain` (`23A`) and `clade_who` (`Omicron`).
It also adds `clade_legacy` (which would be `23A (Omicron`) - I'm happy to remove this after discussion about what our longer-term plans are - if we don't plan to adjust `Nextstrain_clade` then we don't need it.

~~This also adds a column `display_clade` which currently is the legacy clade (`23A (Omicron)`) but could be changed to reflect whatever we want to display, and be guaranteed to be 'unstable' (don't base any workflows on this).~~
12 Apr: This column is now removed in favour of doing this 'name creation' for the labels somewhere in `ncov`.

### Description of proposed changes

This pulls in all available 'new' clade names from Nextclade, allowing users time to start changing workflows to use other columns apart from `Nextstrain_clade` (if we may want to change this in future).
It also gives us more flexibility on columns we can use for things like labelling but also for processing/filtering.
~~Finally it gives us a new column `display_clade` that we can modify to help us easily show whatever type of clade labels we want in the future, without breaking workflows (hopefully, if we make it know it's not stable).~~ _See above_

### Related issue(s)

This is related to wanting to change the display labels for ncov builds, but running into issues with coloring etc. [ncov ingest issue 1050](https://github.com/nextstrain/ncov/pull/1050)

### Testing

This needs to be tested, but also - feedback on the column names is appreciated.
