### PR TITLE
Dockerfile: Remove ~/.cache dirs created by Pip and Pipenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     xz-utils
 
 # Install Python deps
-RUN python3 -m pip install pipenv
+RUN python3 -m pip install pipenv \
+ && rm -rf ~/.cache
+
 COPY Pipfile Pipfile.lock /nextstrain/ncov-ingest/
-RUN PIPENV_PIPFILE=/nextstrain/ncov-ingest/Pipfile pipenv sync --system
+
+RUN PIPENV_PIPFILE=/nextstrain/ncov-ingest/Pipfile pipenv sync --system \
+ && rm -rf ~/.cache
 
 # Put any bin/ dir in the cwd on the path for more convenient invocation of
 # ncov-ingest's programs.


### PR DESCRIPTION
This directory was getting created as root during image build which then made it unwriteable by non-root users at run time.  This wasn't an issue for a while, but Snakemake, as of newer versions¹, now uses the same user cache dir for its own subdir (~/.cache/snakemake, i.e. /nextstrain/.cache/snakemake).  Snakemake fails to create its own subdir if the user cache dir is owned by root.

Like most in-image caching, these are not useful and only serve to increase image size.

It's easiest to remove the directories explicitly rather than disable their creation (possible for Pip with --no-cache-dir or PIP_NO_CACHE_DIR=1, not possible for Pipenv).

An alternative would be to set HOME differently during build, but that seems like a potential source of other unforeseen issues.  Maybe in the future when we have a more general "derivative image" recipe.

¹ <https://github.com/nextstrain/docker-base/issues/135>
  <https://github.com/nextstrain/docker-base/pull/136>


### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Locally builds and no longer has the ~/.cache dir.
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
