### PR TITLE
Update divisions to countries

### DIFF
--- a/source-data/gisaid_geoLocationRules.tsv
+++ b/source-data/gisaid_geoLocationRules.tsv
@@ -8713,7 +8713,7 @@ Europe/Norway/Telemark/*	Europe/Norway/Vestfold Og Telemark/*
 Europe/Norway/Vestfold – Telemark/*	Europe/Norway/Vestfold Og Telemark/*
 Europe/Norway/Vestland/Bergen	Europe/Norway/Vestland/Bergen NO
 Europe/Norway/Buskerud/	Europe/Norway/Viken/Buskerud
-Europe/Gibraltar//	Europe/United Kingdom/Gibraltar/Gibraltar
+Europe/Gibraltar//	Europe/Gibraltar/Gibraltar
 Europe/Lithuania/Vilnius R./*	Europe/Lithuania/Vilnius/*
 Europe/Lithuania/Marijampole Apskritis/*	Europe/Lithuania/Marijampoles Apskritis/*
 Europe/Lithuania/Ignalina/	Europe/Lithuania/Utena Apskritis/Ignalina
@@ -41907,8 +41907,8 @@ North America/Puerto Rico/Pr/Hatillo	North America/USA/Puerto Rico/Hatillo Count
 North America/Puerto Rico/Pr/*	North America/USA/Puerto Rico/*
 North America/Puerto Rico/Las Piedras/	North America/USA/Puerto Rico/Las Piedras County
 North America/Caribbean/Barbados/	North America/Barbados/Barbados/
-North America/Caribbean/British Virgin Islands/	Europe/United Kingdom/British Virgin Islands/
-North America/Caribbean/Cayman Islands/	Europe/United Kingdom/Cayman Islands/
+North America/Caribbean/British Virgin Islands/	North America/British Virgin Islands/British Virgin Islands/
+North America/Caribbean/Cayman Islands/	North America/Cayman Islands/Cayman Islands/
 North America/Brazil/Mato Grosso do Sul/Santo Anastacio	North America/Brazil/São Paulo/Santo Anastacio
 North America/Dominican Republic/Caribbean/*	North America/Dominican Republic//*
 North America/Dominican Republic/San Juan/*	North America/Dominican Republic/San Juan DO/*
@@ -41923,10 +41923,10 @@ North America/Saint Barthelemy/*/*	North America/Saint Barthélemy/*/*
 North America/Saint Barthélemy/Saint Barthelemy/*	North America/Saint Barthélemy/Saint Barthélemy/*
 North America/Saint Barthélemy/Saint Martin/	North America/Saint Barthélemy/Saint Barthélemy/
 North America/St. Lucia/*/*	North America/Saint Lucia/*/*
-North America/Cayman Islands//	Europe/United Kingdom/Cayman Islands/
-North America/Cayman Islands/Caribbean/	Europe/United Kingdom/Cayman Islands/
-North America/British Virgin Islands//	Europe/United Kingdom/British Virgin Islands/
-North America/British Virgin Islands/Caribbean/*	Europe/United Kingdom/British Virgin Islands/*
+North America/Cayman Islands//	North America/Cayman Islands/Cayman Islands/
+North America/Cayman Islands/Caribbean/	North America/Cayman Islands/Cayman Islands/
+North America/British Virgin Islands//	North America/British Virgin Islands/British Virgin Islands/
+North America/British Virgin Islands/Caribbean/*	North America/British Virgin Islands/British Virgin Islands/*
 North America/Germany/Rhineland-Palatinate/*	Europe/Germany/Rheinland-Pfalz/*
 North America/México/*/*	North America/Mexico/*/*
 North America/Trinidad and Tobago/*/*	South America/Trinidad and Tobago/*/*
@@ -43722,9 +43722,9 @@ South America/Antigua/Caribbean/*	North America/Antigua and Barbuda/Antigua and 
 South America/Antigua/*/*	North America/Antigua and Barbuda/*/*
 South America/Anguilla//	Europe/United Kingdom/Anguilla/
 South America/Anguilla/Anguilla/	Europe/United Kingdom/Anguilla/
-South America/British Virgin Islands//	Europe/United Kingdom/British Virgin Islands/
-South America/British Virgin Islands/British Virgin Islands/	Europe/United Kingdom/British Virgin Islands/
-South America/British Virgin Islands/Caribbean/	Europe/United Kingdom/British Virgin Islands/
+South America/British Virgin Islands//	North America/British Virgin Islands/British Virgin Islands/
+South America/British Virgin Islands/British Virgin Islands/	North America/British Virgin Islands/British Virgin Islands/
+South America/British Virgin Islands/Caribbean/	North America/British Virgin Islands/British Virgin Islands/
 South America/Bermuda//	North America/Bermuda/Bermuda/
 South America/Bermuda/Bermuda/	North America/Bermuda/Bermuda/
 South America/Saint Lucia//	North America/Saint Lucia/Saint Lucia/

--- a/source-data/location_hierarchy.tsv
+++ b/source-data/location_hierarchy.tsv
@@ -8158,6 +8158,8 @@ Europe	Germany	Thuringia
 Europe	Germany	Thuringia	Jena
 Europe	Germany	Western Pomerania	
 Europe	Germany	Western Pomerania	Rostock
+Europe	Gibraltar	Gibraltar	
+Europe	Gibraltar	Gibraltar	Gibraltar
 Europe	Greece	Aegean Islands	
 Europe	Greece	Aegean Islands	Ikaria
 Europe	Greece	Aegean Islands	Kalymnos
@@ -14499,8 +14501,6 @@ Europe	Ukraine	Zaporizhzhia
 Europe	United Kingdom	?	
 Europe	United Kingdom	Anguilla	
 Europe	United Kingdom	Birmingham	
-Europe	United Kingdom	British Virgin Islands	
-Europe	United Kingdom	Cayman Islands	
 Europe	United Kingdom	England	
 Europe	United Kingdom	England	Berkshire
 Europe	United Kingdom	England	Berkshire GB
@@ -14517,8 +14517,6 @@ Europe	United Kingdom	England	South Yorkshire
 Europe	United Kingdom	England	Suffolk
 Europe	United Kingdom	England	Warwickshire
 Europe	United Kingdom	England	Yorkshire
-Europe	United Kingdom	Gibraltar	
-Europe	United Kingdom	Gibraltar	Gibraltar
 Europe	United Kingdom	Montserrat	
 Europe	United Kingdom	Northern Ireland	
 Europe	United Kingdom	Scotland	
@@ -14540,6 +14538,7 @@ North America	Belize	Orange Walk
 North America	Belize	Stann Creek	
 North America	Belize	Toledo	
 North America	Bermuda	Bermuda	
+North America	British Virgin Islands	British Virgin Islands	
 North America	Canada	Alberta	
 North America	Canada	Alberta	Calgary
 North America	Canada	British Columbia	
@@ -14559,6 +14558,7 @@ North America	Canada	Quebec	Lanaudière
 North America	Canada	Quebec	Montérégie
 North America	Canada	Quebec	Quebec City
 North America	Canada	Saskatchewan	
+North America	Cayman Islands	Cayman Islands	
 North America	Costa Rica	Alajuela	
 North America	Costa Rica	Alajuela	Alajuela
 North America	Costa Rica	Alajuela	Atenas


### PR DESCRIPTION
The following divisions have been updated to countries:

* British Virgin Islands
* Cayman Islands
* Gibraltar

This change keeps these locations consistent with being top-level geographic units in GISAID and allows them to be subsampled as individual countries within the ncov builds.

This change was motivated by a question from sequence submitters asking why their sequences from Cayman Islands was not showing up in the Nextstrain builds: https://bedfordlab.slack.com/archives/CBVHPFMGX/p1686581931753179.
