### PR TITLE
Add translations as extra ingest output 

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,6 +1,10 @@
 from subprocess import CalledProcessError
 import os
 
+GENES = "E,M,N,ORF1a,ORF1b,ORF3a,ORF6,ORF7a,ORF7b,ORF8,ORF9b,S"
+GENES_SPACE_DELIMITED = GENES.replace(",", " ")
+GENE_LIST = GENES.split(",")
+
 #################################################################
 ####################### general setup ###########################
 #################################################################

--- a/workflow/snakemake_rules/nextclade.smk
+++ b/workflow/snakemake_rules/nextclade.smk
@@ -31,7 +31,7 @@ from shlex import quote as shellquote
 
 wildcard_constraints:
     reference="|_21L",
-    seqtype="[^.]+",
+    seqtype="aligned|translation_[^.]+",
 
 
 rule create_empty_nextclade_info:

--- a/workflow/snakemake_rules/nextclade.smk
+++ b/workflow/snakemake_rules/nextclade.smk
@@ -45,15 +45,8 @@ rule create_empty_nextclade_aligned:
     message:
         """Creating empty NextClade aligned cache file"""
     output:
-        alignment=f"data/{database}/nextclade.aligned.old.fasta",
-        translations=[
-            f"data/{database}/nextclade.translation_{gene}.old.fasta"
-            for gene in GENE_LIST
-        ],
-    shell:
-        """
-        touch {output}
-        """
+        touch(f"data/{database}/nextclade.aligned.old.fasta"),
+        *[touch(f"data/{database}/nextclade.translation_{gene}.old.fasta") for gene in GENE_LIST],
 
 
 # Only include rules to fetch from S3 if S3 config params are provided

--- a/workflow/snakemake_rules/upload.smk
+++ b/workflow/snakemake_rules/upload.smk
@@ -32,7 +32,12 @@ def compute_files_to_upload():
                         "nextclade.tsv.zst":           f"data/{database}/nextclade.tsv",
                         "aligned.fasta.zst":           f"data/{database}/aligned.fasta",
                         "nextclade_21L.tsv.zst":       f"data/{database}/nextclade_21L.tsv",
+
                     }
+    files_to_upload = files_to_upload | {
+        f"translation_{gene}.fasta.zst" : f"data/{database}/translation_{gene}.fasta" 
+        for gene in GENE_LIST
+    }
 
     if database=="genbank":
         files_to_upload["biosample.tsv.gz"] =           f"data/{database}/biosample.tsv"


### PR DESCRIPTION
Feature request from @chaoran-chen which would save covSpectrum a lot of money by not having to run nextclade for open data anymore.

Translations will be uploaded to same bucket as "aligned.fasta.zst"
but with "aligned" replaced by "translation_N" (etc. for other genes, E, S)
Cache is used like for aligned sequences
Only producing zst compressed output as we're moving there in the future
and xz/gz is only for backwards compatibility of existing scripts

Resolves https://github.com/nextstrain/ncov-ingest/issues/394

Testing
- I tested locally with the debug config file
- I will run a genbank trial ingest to see, if that works should be good to merge, if there's a bug we can always revert: `nextstrain build --aws-batch --attach ce172ab3-0ece-48df-83e8-0fbea3ba02f5 /home/runner/work/ncov-ingest/ncov-ingest`: previous run had an error, trying again :(