### PR TITLE
Fix: add clade_legacy back via mapping

### DIFF
--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -4,6 +4,7 @@ import sys
 from datetime import datetime
 import pandas as pd
 import numpy as np
+import yaml
 
 INSERT_BEFORE_THIS_COLUMN = "pango_lineage"
 COLUMN_TO_REORDER = "Nextstrain_clade"
@@ -15,7 +16,6 @@ rate_per_day = 0.0007 * 29903 / 365
 reference_day = datetime(2020,1,1).toordinal()
 
 column_map = {
-    "clade_legacy": "Nextstrain_clade",
     "clade_nextstrain": "clade_nextstrain",
     "clade_who": "clade_who",
     "Nextclade_pango": "Nextclade_pango",
@@ -43,13 +43,16 @@ column_map = {
     "aaSubstitutions": "aaSubstitutions"
 }
 
+# Nextstrain_clade is added later based on clade_nextstrain and a yml mapping
+new_columns = list(column_map.values()) + ["Nextstrain_clade"]
+
 clades_21L_columns = {"immune_escape","ace2_binding"}
 
 def reorder_columns(result: pd.DataFrame):
     """
     Moves COLUMN_TO_REORDER right before INSERT_BEFORE_THIS_COLUMN
     """
-    if COLUMN_TO_REORDER not in list(column_map.values()):
+    if COLUMN_TO_REORDER not in new_columns:
         raise ValueError(f"Column {COLUMN_TO_REORDER} not found in values of column_map {column_map}")
     columns = list(result.columns)
     if INSERT_BEFORE_THIS_COLUMN not in columns:
@@ -62,11 +65,12 @@ def reorder_columns(result: pd.DataFrame):
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Joins metadata file with Nextclade clade output",
+        description="Joins metadata file with Nextclade tsvs. Adds clade_legacy column.",
     )
-    parser.add_argument("first_file")
-    parser.add_argument("second_file")
-    parser.add_argument("nextclade_21L")
+    parser.add_argument("--metadata", required=True)
+    parser.add_argument("--nextclade-tsv", required=True)
+    parser.add_argument("--nextclade-21L-tsv", required=True)
+    parser.add_argument("--clade-legacy-mapping", required=True)
     parser.add_argument("-o", default=sys.stdout)
     return parser.parse_args()
 
@@ -86,16 +90,16 @@ def isfloat(value):
 def main():
     args = parse_args()
 
-    metadata = pd.read_csv(args.first_file, index_col=METADATA_JOIN_COLUMN_NAME,
+    metadata = pd.read_csv(args.metadata, index_col=METADATA_JOIN_COLUMN_NAME,
                            sep='\t', low_memory=False, na_filter = False)
 
     # Read and rename clade column to be more descriptive
-    clades = pd.read_csv(args.second_file, index_col=NEXTCLADE_JOIN_COLUMN_NAME,
+    clades = pd.read_csv(args.nextclade_tsv, index_col=NEXTCLADE_JOIN_COLUMN_NAME,
                          usecols=[NEXTCLADE_JOIN_COLUMN_NAME, *(set(column_map.keys()) - clades_21L_columns)],
                          sep='\t', low_memory=True, dtype="object", na_filter = False) \
             .rename(columns=column_map)
 
-    clades_21L = pd.read_csv(args.nextclade_21L, index_col=NEXTCLADE_JOIN_COLUMN_NAME,
+    clades_21L = pd.read_csv(args.nextclade_21L_tsv, index_col=NEXTCLADE_JOIN_COLUMN_NAME,
                          sep='\t', low_memory=True,
                          usecols=[NEXTCLADE_JOIN_COLUMN_NAME, *clades_21L_columns],
                          dtype={NEXTCLADE_JOIN_COLUMN_NAME: "string", "immune_escape":float, "ace2_binding":float}) \
@@ -106,11 +110,16 @@ def main():
 
     clades = pd.merge(clades, clades_21L, left_index=True, right_index=True, how='left')
 
+    # Add clade_legacy column as Nextstrain_clade
+    # Use yml mapping
+    clade_legacy_mapping= yaml.safe_load(open(args.clade_legacy_mapping))
+    clades["Nextstrain_clade"] = clades["clade_nextstrain"].map(clade_legacy_mapping)
+
     # Remove immune_escape and ace2_binding when clade <21L and not recombinant
     clades.loc[clades.Nextstrain_clade < "21L",["immune_escape","ace2_binding"]] = float('nan')
 
 
-    clades = clades[list(column_map.values())]
+    clades = clades[new_columns]
 
     # Concatenate on columns
     result = pd.merge(
@@ -136,7 +145,7 @@ def main():
     result["clock_deviation"] = np.array(div_array - ((t-reference_day)*rate_per_day + offset), dtype=int)
     result.loc[np.isnan(div_array)|np.isnan(t), "clock_deviation"] = np.nan
 
-    for col in list(column_map.values()) + ["clock_deviation"]:
+    for col in new_columns + ["clock_deviation"]:
         result[col] = result[col].fillna(VALUE_MISSING_DATA)
 
     # Move the new column so that it's next to other clade columns

--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -112,7 +112,8 @@ def main():
 
     # Add clade_legacy column as Nextstrain_clade
     # Use yml mapping
-    clade_legacy_mapping= yaml.safe_load(open(args.clade_legacy_mapping))
+    with open(args.clade_legacy_mapping, 'r') as legacy_mapping_file:
+         clade_legacy_mapping = yaml.safe_load(legacy_mapping_file)
     clades["Nextstrain_clade"] = clades["clade_nextstrain"].map(clade_legacy_mapping)
 
     # Remove immune_escape and ace2_binding when clade <21L and not recombinant

--- a/defaults/clade-legacy-mapping.yml
+++ b/defaults/clade-legacy-mapping.yml
@@ -1,0 +1,33 @@
+19A: 19A
+19B: 19B
+20A: 20A
+20B: 20B
+20C: 20C
+20D: 20D
+20E: 20E (EU1)
+20F: 20F
+20G: 20G
+20H: 20H (Beta, V2)
+20I: 20I (Alpha, V1)
+20J: 20J (Gamma, V3)
+21A: 21A (Delta)
+21I: 21I (Delta)
+21J: 21J (Delta)
+21B: 21B (Kappa)
+21C: 21C (Epsilon)
+21D: 21D (Eta)
+21E: 21E (Theta)
+21F: 21F (Iota)
+21G: 21G (Lambda)
+21H: 21H (Mu)
+21K: 21K (Omicron)
+21L: 21L (Omicron)
+21M: 21M (Omicron)
+22A: 22A (Omicron)
+22B: 22B (Omicron)
+22C: 22C (Omicron)
+22D: 22D (Omicron)
+22E: 22E (Omicron)
+22F: 22F (Omicron)
+23A: 23A (Omicron)
+23B: 23B (Omicron)

--- a/workflow/snakemake_rules/nextclade.smk
+++ b/workflow/snakemake_rules/nextclade.smk
@@ -274,6 +274,7 @@ rule generate_metadata:
         nextclade_tsv=f"data/{database}/nextclade.tsv",
         nextclade_21L_tsv=f"data/{database}/nextclade_21L.tsv",
         existing_metadata=f"data/{database}/metadata_transformed.tsv",
+        clade_legacy_mapping="defaults/clade-legacy-mapping.yml",
     output:
         metadata=f"data/{database}/metadata.tsv",
     benchmark:
@@ -281,8 +282,9 @@ rule generate_metadata:
     shell:
         """
         ./bin/join-metadata-and-clades \
-            {input.existing_metadata} \
-            {input.nextclade_tsv} \
-            {input.nextclade_21L_tsv} \
+            --metadata {input.existing_metadata} \
+            --nextclade-tsv {input.nextclade_tsv} \
+            --nextclade-21L-tsv {input.nextclade_21L_tsv} \
+            --clade-legacy-mapping {input.clade_legacy_mapping} \
             -o {output.metadata}
         """


### PR DESCRIPTION
### Description of proposed changes

This PR fixes ingest to work with the latest Nextclade dataset release: at the moment it fails due to `clade_legacy` no longer being output by Nextclade starting with dataset release `2023-06-16`.

(This is due to https://github.com/neherlab/nextclade_data_workflows/pull/42 which in turn was triggered by a refactor in ncov of how we annotate clades https://github.com/nextstrain/ncov/pull/1065.)

So as not to break downstream workflows that rely on ingest output `metadata.tsv` having `clade_legacy`, this PR adds a `clade_legacy` column to `metadata.tsv`

The values are defined as a simple mapping from `clade_nextstrain` (year-letter, e.g. 22F) to `clade_legacy` in `defaults/clade-legacy-mapping.yml`

This file lives in ingest for now to make this PR work without requiring changes to `ncov`.

### Testing

- [x] Locally with `snakemake -c all --configfile config/debug_sample_gisaid.yaml  -p --ri -F`
- [x] Full test runs succeeded (at least `open`, `gisaid` was still running)
  - AWS run: https://us-east-1.console.aws.amazon.com/batch/home?region=us-east-1#jobs/detail/d4606714-a821-4373-9cd7-8fa1a23a81ee
  - Output files downloadable from: `s3://nextstrain-staging/files/ncov/open/branch/cornelius/add-legacy-clade-names`

### Future work

- [ ] Add a reasonable default for `clade_legacy` so that new clade doesn't require changes in ingest. E.g., we could use the `WHO` column, or simply add ` (Omicron)`, or add nothing at all, i.e. map to itself. Tracked in https://github.com/nextstrain/ncov-ingest/issues/406

