### PR TITLE
Add recombinant to legacy mapping

### DIFF
--- a/defaults/clade-legacy-mapping.yml
+++ b/defaults/clade-legacy-mapping.yml
@@ -31,3 +31,4 @@
 22F: 22F (Omicron)
 23A: 23A (Omicron)
 23B: 23B (Omicron)
+recombinant: recombinant


### PR DESCRIPTION
One possibly clade output from Nextclade is `recombinant`. However, in the move to change the clade names, and remap them, this has gotten lost.

I use this in CoVariants so it would be great if we can add `recombinant` back in. I think this is as simple as one-to-one mapping, but I would appreciate if someone could run a test to check this does work as expected.