### PR TITLE
Map clades not in clade-legacy-mapping.yml to itself

### DIFF
--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -114,6 +114,17 @@ def main():
     # Use yml mapping
     with open(args.clade_legacy_mapping, 'r') as legacy_mapping_file:
          clade_legacy_mapping = yaml.safe_load(legacy_mapping_file)
+
+    # For any clade not in the mapping, map it to itself
+    # Still better to update clade-legacy-mapping.yml when new clades are added
+    clade_legacy_mapping = {
+        **clade_legacy_mapping,
+        **{
+            clade: clade
+            for clade in clades["clade_nextstrain"].unique()
+            if clade not in clade_legacy_mapping
+        },
+    }
     clades["Nextstrain_clade"] = clades["clade_nextstrain"].map(clade_legacy_mapping)
 
     # Remove immune_escape and ace2_binding when clade <21L and not recombinant


### PR DESCRIPTION
When we add new clades, we need to add them to `clade-legacy-mapping.yml` in this repo.

This is easy to forget as all the other changes are in `ncov` directly.

If we don't add them to the mapping file, they end up as `?` in metadata.tsv, which is bad.

This PR maps new clades not in `clade-legacy-mapping.yml` to itself, rather than to `?`.

We may want to discontinue legacy mapping at some point and just report short clades

An alternative here is to error when we find this situation - so that we are directly aware of the issue and can fix the mapping. But the current state is worse than either of the two options.

### Testing

Tested locally that new clades that are not in `clade-legacy-mapping.yml` end up mapped to itself.
