### PR TITLE
Add build dir for notify-on-job-start

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -92,7 +92,7 @@ onstart:
         print(f"\t${{{var}}}: " + ("YES" if os.environ.get(var, "") else "NO") + f"({description})")
     if send_notifications:
         message="🥗 GISAID ingest" if database=="gisaid" else "🥣 GenBank ingest"
-        shell(f"./vendored/notify-on-job-start \"{message}\" nextstrain/ncov-ingest")
+        shell(f"./vendored/notify-on-job-start \"{message}\" nextstrain/ncov-ingest '.'")
 
 onsuccess:
     message = "✅ This pipeline has successfully finished 🎉"


### PR DESCRIPTION
ncov-ingest is the only repo where the ingest pipeline is in a separate repository than the phylogenetic workflow. Therefore, the build dir that should be sent with the onstart Slack message is the current directory instead of the default "ingest" directory.

Follow-up on #412 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
