### PR TITLE
Use built-in Snakemake `retries` directive

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,5 +1,9 @@
 from subprocess import CalledProcessError
+from snakemake.utils import min_version
 import os
+
+# Snakemake 7.7.0 introduced `retries` directive used in fetch_sequences
+min_version("7.7.0")
 
 GENES = "E,M,N,ORF1a,ORF1b,ORF3a,ORF6,ORF7a,ORF7b,ORF8,ORF9b,S"
 GENES_SPACE_DELIMITED = GENES.replace(",", " ")


### PR DESCRIPTION
## Description of proposed changes
We've been using a custom automatic retry for rules that fail occasionally during fetching of online resources since the workflow was still a bash script.¹

When the workflow was converted a Snakemake workflow, Snakemake did not have rule specific retries yet.²

The latest GISAID ingest failed³ due to an error in `run_shell_command_n_times`, so I figured it's time to loop back and replace it with the built-it Snakemake `retries` directive that has been available since v7.7.0.

¹ https://github.com/nextstrain/ncov-ingest/commit/75ee3921137f879a94d6996f73770a77727408af 
² https://github.com/nextstrain/ncov-ingest/pull/231/files#r758769573 
³ https://bedfordlab.slack.com/archives/CTZKJC7PZ/p1706908574251489?thread_ts=1706905060.565059&cid=CTZKJC7PZ


## Related issue(s)

- Related to https://github.com/nextstrain/ncov-ingest/issues/239

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Test GISAID workflow](https://github.com/nextstrain/ncov-ingest/actions/runs/7762065458)
- [x] [Test GenBank workflow](https://github.com/nextstrain/ncov-ingest/actions/runs/7762071768)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
