### PR TITLE
trigger_rebuild_pipeline: Update inputs to match ncov builds

### DIFF
--- a/workflow/snakemake_rules/trigger.smk
+++ b/workflow/snakemake_rules/trigger.smk
@@ -14,8 +14,8 @@ These output files are empty flag files to force Snakemake to run the trigger ru
 rule trigger_rebuild_pipeline:
     message: "Triggering nextstrain/ncov rebuild action (via repository dispatch)"
     input:
-        metadata_upload = f"data/{database}/metadata.tsv.gz.upload",
-        fasta_upload = f"data/{database}/sequences.fasta.xz.upload",
+        metadata_upload = f"data/{database}/metadata.tsv.zst.upload",
+        fasta_upload = f"data/{database}/aligned.fasta.zst.upload",
     output:
         touch(f"data/{database}/trigger-rebuild.done")
     params:


### PR DESCRIPTION
The inputs required to trigger downstream ncov builds were originally set in Nov 2022 (80e53848c73a35de3b90be30bcd8144b29c92129).

The downstream ncov builds have since been updated to use different input files from S3 in April 2023:
1. use aligned.fasta instead of sequences.fasta
2. use zst instead of gz/xz files
3. 21L inputs were updated to aligned.fasta and zst files

This commit updates the inputs for the trigger rule to ensure that the downstream ncov builds are only triggered after the appropriate files have been uploaded to S3.

[1] https://github.com/nextstrain/ncov/commit/1376d8238fe48dd47fe6dbbf5f9835dc3789baff
[2] https://github.com/nextstrain/ncov/commit/ad0d1e3ac630dcde308a89fc5a04cda669058466
[3] https://github.com/nextstrain/ncov/commit/2323afde0533f18a09629e759948ff2e67856eb0

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
