### PR TITLE
Bump CPUs for fetch-and-ingest workflows

### DIFF
--- a/.github/workflows/fetch-and-ingest-genbank-master.yml
+++ b/.github/workflows/fetch-and-ingest-genbank-master.yml
@@ -101,7 +101,7 @@ jobs:
           --aws-batch \
           --detach \
           --no-download \
-          --cpus 16 \
+          --cpus 36 \
           --memory 68GiB \
           --env GITHUB_RUN_ID \
           --env SLACK_TOKEN \

--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -100,7 +100,7 @@ jobs:
           --aws-batch \
           --detach \
           --no-download \
-          --cpus 16 \
+          --cpus 48 \
           --memory 90GiB \
           --env GISAID_API_ENDPOINT \
           --env GISAID_USERNAME_AND_PASSWORD \


### PR DESCRIPTION
I've been only bumping the memory but not the CPUs for the fetch-and-ingest workflows. Might as well use all the compute that we are paying for. GenBank should be using c5.9xlarge and GISAID should be using c5.12xlarge, so bumping CPUs to match the instances.¹

Maybe this will magically help https://github.com/nextstrain/ncov-ingest/issues/446?

¹ <https://aws.amazon.com/ec2/instance-types/c5/>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [x] [GISAID workflow](https://github.com/nextstrain/ncov-ingest/actions/runs/9474169604)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
