### PR TITLE
Add retries to trigger rules

### DIFF
--- a/workflow/snakemake_rules/trigger.smk
+++ b/workflow/snakemake_rules/trigger.smk
@@ -22,6 +22,7 @@ rule trigger_rebuild_pipeline:
         f"benchmarks/trigger_rebuild_pipeline_{database}.txt"
     params:
         dispatch_type = f"{database}/rebuild"
+    retries: 5
     shell:
         """
         ./vendored/trigger-on-new-data \
@@ -41,6 +42,7 @@ rule trigger_counts_pipeline:
         f"benchmarks/trigger_counts_pipeline_{database}.txt"
     params:
         dispatch_type = f"{database}/clade-counts"
+    retries: 5
     shell:
         """
         ./vendored/trigger nextstrain/forecasts-ncov {params.dispatch_type}


### PR DESCRIPTION
## Description of proposed changes

Add retires to trigger rules so that the workflow can automatically
retry them if it encounters transient network errors.

Picked 5 retries to match what is set for the various fetch rules.

## Related issue(s)

Resolves https://github.com/nextstrain/ncov-ingest/issues/462

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
