### PR TITLE
Update links for GISAID and GenBank accessions

### DIFF
--- a/bin/fetch-accession-links
+++ b/bin/fetch-accession-links
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+curl "https://hgwdev.gi.ucsc.edu/~angie/epiToPublicAndDate.latest" \
+    --fail --silent --show-error \
+    --header 'User-Agent: https://github.com/nextstrain/ncov-ingest (hello@nextstrain.org)' \
+    | csvtk -t add-header --names gisaid_epi_isl,genbank_accession,strain,date \
+    | csvtk -t cut --fields genbank_accession,gisaid_epi_isl  \
+    | gzip -c

--- a/bin/fetch-accession-links
+++ b/bin/fetch-accession-links
@@ -5,5 +5,4 @@ curl "https://hgwdev.gi.ucsc.edu/~angie/epiToPublicAndDate.latest" \
     --fail --silent --show-error \
     --header 'User-Agent: https://github.com/nextstrain/ncov-ingest (hello@nextstrain.org)' \
     | csvtk -t add-header --names gisaid_epi_isl,genbank_accession,strain,date \
-    | csvtk -t cut --fields genbank_accession,gisaid_epi_isl  \
-    | gzip -c
+    | csvtk -t cut --fields genbank_accession,gisaid_epi_isl

--- a/bin/transform-genbank
+++ b/bin/transform-genbank
@@ -207,8 +207,8 @@ if __name__ == '__main__':
                               | ParseGeographicColumnsGenbank( base / 'source-data/us-state-codes.tsv' )
                               | AbbreviateAuthors()
                               | ApplyUserGeoLocationSubstitutionRules(geoRules)
-                              | MergeUserAnnotatedMetadata(annotations, idKey = 'genbank_accession' )
                               | MergeUserAnnotatedMetadata(accessions, idKey = 'genbank_accession_rev' )
+                              | MergeUserAnnotatedMetadata(annotations, idKey = 'genbank_accession' )
                               | FillDefaultLocationData()
                               | patchUKData(args.cog_uk_accessions, args.cog_uk_metadata)
                               | GenbankProblematicFilter( args.problem_data,
@@ -301,4 +301,3 @@ if __name__ == '__main__':
                     strain_name = updated_strain_names_by_line_no[entry[LINE_NUMBER_KEY]]
                     print( '>' , strain_name , sep='' , file= fasta_OUT)
                     print( entry['sequence'] , file= fasta_OUT)
-

--- a/bin/transform-gisaid
+++ b/bin/transform-gisaid
@@ -182,8 +182,8 @@ if __name__ == '__main__':
 
         pipeline = (pipeline
             | ApplyUserGeoLocationSubstitutionRules(geoRules)
-            | MergeUserAnnotatedMetadata(annotations)
             | MergeUserAnnotatedMetadata(accessions)
+            | MergeUserAnnotatedMetadata(annotations)
             | FillDefaultLocationData()
         )
 

--- a/workflow/snakemake_rules/curate.smk
+++ b/workflow/snakemake_rules/curate.smk
@@ -23,6 +23,19 @@ Produces different output files for GISAID vs GenBank:
 """
 
 
+rule fetch_accession_links:
+    """
+    Fetch the accession links between GISAID and GenBank
+    """
+    output:
+        accessions="data/accessions.tsv.gz",
+    retries: 5
+    shell:
+        """
+        ./bin/fetch-accession-links > {output.accessions:q}
+        """
+
+
 rule transform_rki_data:
     input:
         ndjson="data/rki.ndjson",
@@ -60,7 +73,8 @@ rule transform_genbank_data:
         biosample = "data/genbank/biosample.tsv",
         ndjson = "data/genbank.ndjson",
         cog_uk_accessions = "data/cog_uk_accessions.tsv",
-        cog_uk_metadata = "data/cog_uk_metadata.csv.gz"
+        cog_uk_metadata = "data/cog_uk_metadata.csv.gz",
+        accessions = "data/accessions.tsv.gz",
     output:
         fasta = "data/genbank_sequences.fasta",
         metadata = "data/genbank_metadata_transformed.tsv",
@@ -75,6 +89,7 @@ rule transform_genbank_data:
             --duplicate-biosample {output.duplicate_biosample} \
             --cog-uk-accessions {input.cog_uk_accessions} \
             --cog-uk-metadata {input.cog_uk_metadata} \
+            --accessions {input.accessions} \
             --output-metadata {output.metadata} \
             --output-fasta {output.fasta} > {output.flagged_annotations}
         """
@@ -105,7 +120,8 @@ rule merge_open_data:
 
 rule transform_gisaid_data:
     input:
-        ndjson = "data/gisaid.ndjson"
+        ndjson = "data/gisaid.ndjson",
+        accessions = "data/accessions.tsv.gz",
     output:
         fasta = "data/gisaid/sequences.fasta",
         metadata = "data/gisaid/metadata_transformed.tsv",
@@ -116,6 +132,7 @@ rule transform_gisaid_data:
     shell:
         """
         ./bin/transform-gisaid {input.ndjson} \
+            --accessions {input.accessions} \
             --output-metadata {output.metadata} \
             --output-fasta {output.fasta}  \
             --output-additional-info {output.additional_info} \


### PR DESCRIPTION
## Description of proposed changes

Adds a rule to fetch GISAID and GenBank accession links from UCSC
and uses the output in the `transform_genbank` and `transform_gisaid`
rules.

The UCSC file is modified to keep the headers and format exactly the
same as the current `source-data/accessions.tsv.gz` file so that it can
be directly replaced.

## Related issue(s)

Resolves https://github.com/nextstrain/ncov-ingest/issues/484

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [GISAID trial run](https://github.com/nextstrain/ncov-ingest/actions/runs/12364597364)
- [x] [GenBank trial run](https://github.com/nextstrain/ncov-ingest/actions/runs/12364600337)
- [x] [2nd GISAID trial](https://github.com/nextstrain/ncov-ingest/actions/runs/12383552360)
- [x] [2nd GenBank trial](https://github.com/nextstrain/ncov-ingest/actions/runs/12383553984)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
