### PR TITLE
Update `SLACK_CHANNELS` envvar

### DIFF
--- a/.github/workflows/fetch-and-ingest-genbank-master.yml
+++ b/.github/workflows/fetch-and-ingest-genbank-master.yml
@@ -95,7 +95,7 @@ jobs:
         CONFIG_OVERRIDES: ${{ needs.set_config_overrides.outputs.config_overrides }}
         GITHUB_RUN_ID: ${{ github.run_id }}
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image || 'nextstrain/ncov-ingest' }}
-        SLACK_CHANNELS: ${{ inputs.trial_name && vars.TEST_SLACK_CHANNEL || 'ncov-genbank-updates' }}
+        SLACK_CHANNELS: ${{ inputs.trial_name && vars.TEST_SLACK_CHANNEL || vars.NCOV_GENBANK_SLACK_CHANNEL }}
       run: |
         nextstrain build \
           --aws-batch \

--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -94,7 +94,7 @@ jobs:
         CONFIG_OVERRIDES: ${{ needs.set_config_overrides.outputs.config_overrides }}
         GITHUB_RUN_ID: ${{ github.run_id }}
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image || 'nextstrain/ncov-ingest' }}
-        SLACK_CHANNELS: ${{ inputs.trial_name && vars.TEST_SLACK_CHANNEL || 'ncov-gisaid-updates' }}
+        SLACK_CHANNELS: ${{ inputs.trial_name && vars.TEST_SLACK_CHANNEL || vars.NCOV_GISAID_SLACK_CHANNEL }}
       run: |
         nextstrain build \
           --aws-batch \


### PR DESCRIPTION
## Description of proposed changes

With the latest update to the new Slack APIs for uploading files, the `SLACK_CHANNELS` envvar is required to be a channel id instead of a channel name.¹ Rather than hard-coding the channel id in the workflows, I've made them GH Action environment variables that are shared across the Nexstrain org so they can be shared with the ncov repo.²

¹ <https://github.com/nextstrain/ingest/pull/47>
² <https://github.com/organizations/nextstrain/settings/variables/actions>

## Related issue(s)

Related to https://github.com/nextstrain/ingest/issues/46

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
