### PR TITLE
Update GitHub Actions cron timing

### DIFF
--- a/.github/workflows/fetch-and-ingest-genbank-master.yml
+++ b/.github/workflows/fetch-and-ingest-genbank-master.yml
@@ -4,23 +4,16 @@ on:
   schedule:
     # Note times are in UTC, which is 1 or 2 hours behind CET depending on daylight savings.
     #
-    # Currently, we aim to trigger ingest every day at 18:07 UTC which is 19:07 CET (as of Mar 2022).
-    # Note the actual runs might be late. As of right now, the action starts around 20 past the hour.
-    # Numerous people were confused, about that, including me:
-    #  - https://github.community/t/scheduled-action-running-consistently-late/138025/11
-    #  - https://github.com/github/docs/issues/3059
+    # Currently, we aim to trigger runs at 6pm UTC on Saturday
     #
     # Note, '*' is a special character in YAML, so you have to quote this string.
     #
     # Docs:
     #  - https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
     #
-    # Tool that deciphers this particular format of crontab string:
-    #  - https://crontab.guru/
-    #
     # Looks like you are about to modify this schedule? Make sure you also modify the schedule for the
     # sister GISAID job, so that we don't need to keep two schedules in our heads.
-    - cron:  '7 18 * * *'
+    - cron: '0 18 * * 6'
 
   # Manually triggered using `./vendored/trigger nextstrain/ncov-ingest genbank/fetch-and-ingest` (or `fetch-and-ingest`, which
   # includes GISAID)

--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -4,23 +4,16 @@ on:
   schedule:
     # Note times are in UTC, which is 1 or 2 hours behind CET depending on daylight savings.
     #
-    # Currently, we aim to trigger ingest every day at 18:07 UTC which is 19:07 CET (as of Mar 2022).
-    # Note the actual runs might be late. As of right now, the action starts around 20 past the hour.
-    # Numerous people were confused, about that, including me:
-    #  - https://github.community/t/scheduled-action-running-consistently-late/138025/11
-    #  - https://github.com/github/docs/issues/3059
+    # Currently, we aim to trigger runs at 6pm UTC on Saturday
     #
     # Note, '*' is a special character in YAML, so you have to quote this string.
     #
     # Docs:
     #  - https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
     #
-    # Tool that deciphers this particular format of crontab string:
-    #  - https://crontab.guru/
-    #
     # Looks like you are about to modify this schedule? Make sure you also modify the schedule for the
     # sister GenBank job, so that we don't need to keep two schedules in our heads.
-    - cron:  '7 18 * * *'
+    - cron: '0 18 * * 6'
 
   # Manually triggered using `./vendored/trigger nextstrain/ncov-ingest gisaid/fetch-and-ingest`
   repository_dispatch:


### PR DESCRIPTION
Instead of checking for sequences every day, instead check for sequences every week, only on Saturdays. Using Saturday here empirically as the latest updates have been:

- Sat Mar 22
- Sat Mar 15
- Sat Mar 8
- Sat Mar 1
- Sat Feb 22
- Sat Feb 15
- Sat Feb 8
- Sat Feb 1

