### PR TITLE
MergeBiosampleMetadata: Add special handling for 'location' field

### DIFF
--- a/lib/utils/transformpipeline/transforms.py
+++ b/lib/utils/transformpipeline/transforms.py
@@ -655,6 +655,10 @@ class ParseGeographicColumnsGenbank(Transformer):
         * "country"
         * "country: division"
         * "country: division, location"
+        * "country: region, division, location"
+
+    Note: region might be any value after the colon and will be stripped from
+    the location if it matches the `region` field in the entry.
     """
     def __init__(self, us_state_code_file_name ):
         # Create dict of US state codes and their full names
@@ -671,6 +675,14 @@ class ParseGeographicColumnsGenbank(Transformer):
         location = ''
 
         if len(geographic_data) == 2 :
+            # Remove potential region value in the location
+            # See <https://github.com/nextstrain/ncov-ingest/pull/497#issuecomment-2779337493>
+            region = entry['region'].strip()
+            detailed_locations = [loc.strip() for loc in geographic_data[1].split(',')]
+            if region in detailed_locations:
+                detailed_locations.remove(region)
+                geographic_data[1] = ','.join(detailed_locations)
+
             division , j , location = geographic_data[1].partition(',')
 
         elif len(geographic_data) > 2:


### PR DESCRIPTION
## Description of proposed changes

Use the BioSample record 'location' if it has additional location data that is not found in the GenBank record. Includes a check that the country of the BioSample record and the GenBank record are the same to ensure that they are not completely different locations.

## Related issue(s)

Resolves https://github.com/nextstrain/ncov-ingest/issues/496

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Trial run](https://github.com/nextstrain/ncov-ingest/actions/runs/14231118367)
- [x] [Trial 2](https://github.com/nextstrain/ncov-ingest/actions/runs/14272191019)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
