### PR TITLE
Fix Genbank geographic parsing

### DIFF
--- a/lib/utils/transformpipeline/transforms.py
+++ b/lib/utils/transformpipeline/transforms.py
@@ -686,7 +686,7 @@ class ParseGeographicColumnsGenbank(Transformer):
             division , j , location = geographic_data[1].partition(',')
 
         elif len(geographic_data) > 2:
-            assert False, f"Found unknown format for geographic data: {value}"
+            assert False, f"Found unknown format for geographic data: {entry['location']!r}"
 
 
         # Special parsing for US locations because the format varies

--- a/lib/utils/transformpipeline/transforms.py
+++ b/lib/utils/transformpipeline/transforms.py
@@ -686,7 +686,7 @@ class ParseGeographicColumnsGenbank(Transformer):
             division , j , location = geographic_data[1].partition(',')
 
         elif len(geographic_data) > 2:
-            assert False, f"Found unknown format for geographic data: {entry['location']!r}"
+            print(f"WARNING: Unable to parse division and location because of unknown format for geographic data: {entry['location']!r}")
 
 
         # Special parsing for US locations because the format varies


### PR DESCRIPTION
## Description of proposed changes

Fixes the `NameError` and replaces the assertion with a warning log. 

Clearly, this hasn't been an issue since the `NameError` bug has existed since it was implemented ~4 years ago and hasn't 
come up in our automated runs (until now). However, it is annoying for the long running job to fail on a single bad data entry.

## Related issue(s)

Resolves https://github.com/nextstrain/ncov-ingest/issues/500

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
