### PR TITLE
Fix RKI ingest

### DIFF
--- a/bin/transform-rki
+++ b/bin/transform-rki
@@ -33,7 +33,7 @@ COLUMN_MAP = {
     "date_of_submission": "date_submitted",
     "prime_diagnostic_lab.demis_lab_id": "originating_lab",
     "sequencing_lab.demis_lab_id": "submitting_lab",
-    "lineages": "pango_lineage",
+    "genome.gtrs": "genomic_typing_results",
     "sequencing_reason": "sampling_strategy",
 }
 


### PR DESCRIPTION
Fix the RKI ingest based on their latest metadata columns outlined in <https://github.com/robert-koch-institut/SARS-CoV-2-Sequenzdaten_aus_Deutschland/issues/69>

Since we can no longer find the latest lineage assignment by filtering for "PANGOLIN_LATEST", we now filter for the method name "Pangolin Lineage" and then  sort the results by "date_of_assignment" to get the latest assignment. 

Resolves https://github.com/nextstrain/ncov-ingest/issues/505

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Trial run](https://github.com/nextstrain/ncov-ingest/actions/runs/16301431537)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
