### PR TITLE
github/workflows: Remove `--stats` flag

### DIFF
--- a/.github/workflows/fetch-and-ingest-genbank-master.yml
+++ b/.github/workflows/fetch-and-ingest-genbank-master.yml
@@ -101,6 +101,5 @@ jobs:
           --env SLACK_CHANNELS \
           --env PAT_GITHUB_DISPATCH="$GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH" \
           . \
-            --stats snakemake_stats.json \
             --configfile config/genbank.yaml \
             $CONFIG_OVERRIDES

--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -102,6 +102,5 @@ jobs:
           --env SLACK_CHANNELS \
           --env PAT_GITHUB_DISPATCH="$GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH" \
           . \
-            --stats snakemake_stats.json \
             --configfile config/gisaid.yaml \
             $CONFIG_OVERRIDES


### PR DESCRIPTION
## Description of proposed changes

Docker image will be updated to use Snakemake v9 which no longer supports  the `--stats` flag.

## Related issue(s)

Resolves https://github.com/nextstrain/ncov-ingest/issues/452

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Post-merge: run [update-image](https://github.com/nextstrain/ncov-ingest/actions/workflows/update-image.yml) action on master

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
