### PR TITLE
Remove schedule from fetch-and-ingest-gisaid-master

### DIFF
--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -1,20 +1,6 @@
 name: GISAID fetch and ingest
 
 on:
-  schedule:
-    # Note times are in UTC, which is 1 or 2 hours behind CET depending on daylight savings.
-    #
-    # Currently, we aim to trigger runs at 6pm UTC on Saturday
-    #
-    # Note, '*' is a special character in YAML, so you have to quote this string.
-    #
-    # Docs:
-    #  - https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
-    #
-    # Looks like you are about to modify this schedule? Make sure you also modify the schedule for the
-    # sister GenBank job, so that we don't need to keep two schedules in our heads.
-    - cron: '0 18 * * 6'
-
   # Manually triggered using `./vendored/trigger nextstrain/ncov-ingest gisaid/fetch-and-ingest`
   repository_dispatch:
     types:


### PR DESCRIPTION

## Description of proposed changes

Upstream GISAID flat file is no longer updated so remove the scheduled  automated runs until we figure out how to continue updates.

Leaving the GH Action workflow in place with the manual triggers so we can  still run the workflow manually as needed.

## Related issue(s)

Related to https://github.com/nextstrain/ncov/pull/1186

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
