### PR TITLE
fetch-and-ingest-gisaid: Never trigger rebuild and counts

### DIFF
--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -41,6 +41,8 @@ jobs:
           FETCH_FROM_DATABASE: ${{ github.event_name != 'workflow_dispatch' && true || inputs.fetch_from_database }}
         run: |
           config="--config"
+          config+=" trigger_rebuild=False"
+          config+=" trigger_counts=False"
 
           if [[ "$FETCH_FROM_DATABASE" == true ]]; then
             config+=" fetch_from_database=True"
@@ -49,12 +51,7 @@ jobs:
           fi
 
           if [[ "$TRIAL_NAME" ]]; then
-            config+=" trigger_rebuild=False"
-            config+=" trigger_counts=False"
             config+=" s3_dst=s3://nextstrain-ncov-private/trial/${TRIAL_NAME}"
-          else
-            config+=" trigger_rebuild=True"
-            config+=" trigger_counts=True"
           fi
 
           echo "config=$config" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Description of proposed changes

We've removed scheduled runs but still allow manual runs of the workflow. Prevent manual runs of the GH Action workflow from triggering downstream rebuild  and counts workflows.

## Related issue(s)

Related to https://github.com/nextstrain/ncov/pull/1188

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
