### PR TITLE
combine_alignments: remove `benchmark` directive

### DIFF
--- a/workflow/snakemake_rules/nextclade.smk
+++ b/workflow/snakemake_rules/nextclade.smk
@@ -345,8 +345,10 @@ rule combine_alignments:
         new_alignment=f"data/{database}/nextclade.{{seqtype}}.upd.fasta",
     output:
         alignment=f"data/{database}/{{seqtype}}.fasta",
-    benchmark:
-        f"benchmarks/combine_alignments_{database}{{seqtype}}.txt"
+    # Not using benchmark for this rule because the inputs potentially get
+    # renamed to output which could lead to error described in
+    # <https://github.com/nextstrain/ncov-ingest/issues/524>
+    #     -Jover, 30 March 2026
     params:
         keep_temp=config.get("keep_temp", "false"),
     shell:


### PR DESCRIPTION
## Description of proposed changes

With Nextstrain CLI v10.5.0, the `--benchmark-extended` flag is automatically added in `nextstrain build` commands. This causes a `FileNotFoundError` during benchmark generation for the `combine_alignments` rule because the shell block potentially renames the input files to output. Renaming inputs to outputs is an unusual practice in Snakemake workflows because it can mess up the DAG for partial runs, but we do so here to speed up the workflow by avoiding copying giant FASTA files. We do not want to slow down the workflow for benchmark generation, so just remove the `benchmark` directive for the affected rule.



## Related issue(s)

Resolves https://github.com/nextstrain/ncov-ingest/issues/524
Related to https://github.com/nextstrain/cli/pull/513

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Confirmed locally that workflow no longer raises `FileNotFoundError`
- [ ] ~Update changelog~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
