### PR TITLE
GISAID ingest: Bump CPUs and memory

### DIFF
--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -76,10 +76,11 @@ jobs:
       run: |
         nextstrain build \
           --aws-batch \
+          --aws-batch-queue nextstrain-job-queue-c7a-12xlarge \
           --detach \
           --no-download \
-          --cpus 32 \
-          --memory 60GiB \
+          --cpus 48 \
+          --memory 90GiB \
           --env GITHUB_RUN_ID \
           --env SLACK_TOKEN \
           --env SLACK_CHANNELS \


### PR DESCRIPTION
## Description of proposed changes

Reverts "Reduce AWS Batch CPU and memory to fit c7a.8xlarge cap" (b5cf23f) for this file. Needs a custom `--aws-batch-queue` specified because the default job queue's compute environment is limited to c7a.8xlarge.

## Related issue(s)

Closes #532

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] https://github.com/nextstrain/infra/pull/74
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
