### PR TITLE
Remove the 21L Nextclade run

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,6 @@ aws s3 cp - s3://nextstrain-data/files/ncov/open/nextclade.tsv.zst.renew < /dev/
 
 Ingest will automatically remove the touchfiles after it has completed the rerun.
 
-To rerun Nextclade using the `sars-cov-2-21L` dataset - which is only necessary when the calculation of `immune_escape` and `ace2_binding` changes - you need to add an (empty) touchfile to the s3 bucket (available as `./scripts/developer_scripts/rerun-nextclade-21L.sh`:
-
-```bash
-aws s3 cp - s3://nextstrain-ncov-private/nextclade_21L.tsv.zst.renew < /dev/null
-aws s3 cp - s3://nextstrain-data/files/ncov/open/nextclade_21L.tsv.zst.renew < /dev/null
-```
-
 ## Required environment variables
 
 - `GISAID_API_ENDPOINT`

--- a/bin/join-metadata-and-clades
+++ b/bin/join-metadata-and-clades
@@ -19,8 +19,6 @@ column_map = {
     "clade_nextstrain": "clade_nextstrain",
     "clade_who": "clade_who",
     "Nextclade_pango": "Nextclade_pango",
-    "immune_escape": "immune_escape",
-    "ace2_binding": "ace2_binding",
     "totalMissing": "missing_data",
     "totalSubstitutions": "divergence",
     "totalNonACGTNs": "nonACGTN",
@@ -46,7 +44,6 @@ column_map = {
 # Nextstrain_clade is added later based on clade_nextstrain and a yml mapping
 new_columns = list(column_map.values()) + ["Nextstrain_clade"]
 
-clades_21L_columns = {"immune_escape","ace2_binding"}
 
 def reorder_columns(result: pd.DataFrame):
     """
@@ -69,7 +66,6 @@ def parse_args():
     )
     parser.add_argument("--metadata", required=True)
     parser.add_argument("--nextclade-tsv", required=True)
-    parser.add_argument("--nextclade-21L-tsv", required=True)
     parser.add_argument("--clade-legacy-mapping", required=True)
     parser.add_argument("-o", default=sys.stdout)
     return parser.parse_args()
@@ -94,20 +90,9 @@ def main():
                            sep='\t', low_memory=False, na_filter = False)
 
     clades = pd.read_csv(args.nextclade_tsv, index_col=NEXTCLADE_JOIN_COLUMN_NAME,
-                         usecols=[NEXTCLADE_JOIN_COLUMN_NAME, *(set(column_map.keys()) - clades_21L_columns)],
+                         usecols=[NEXTCLADE_JOIN_COLUMN_NAME, *column_map.keys()],
                          sep='\t', low_memory=True, dtype="object", na_filter = False) \
             .rename(columns=column_map)
-
-    clades_21L = pd.read_csv(args.nextclade_21L_tsv, index_col=NEXTCLADE_JOIN_COLUMN_NAME,
-                         sep='\t', low_memory=True,
-                         usecols=[NEXTCLADE_JOIN_COLUMN_NAME, *clades_21L_columns],
-                         dtype={NEXTCLADE_JOIN_COLUMN_NAME: "string", "immune_escape":float, "ace2_binding":float}) \
-            .rename(columns=column_map)
-
-    # Reduce false precision in immune_escape and ace2_binding
-    clades_21L = clades_21L.round(3)
-
-    clades = pd.merge(clades, clades_21L, left_index=True, right_index=True, how='left')
 
     # Add clade_legacy column as Nextstrain_clade
     # Use yml mapping
@@ -118,10 +103,6 @@ def main():
         return clade_legacy_mapping_dict.get(clade_nextstrain, f"{clade_nextstrain} (Omicron)")
         
     clades["Nextstrain_clade"] = clades["clade_nextstrain"].map(clade_legacy_mapping)
-
-    # Remove immune_escape and ace2_binding when clade <21L and not recombinant
-    clades.loc[clades.Nextstrain_clade < "21L",["immune_escape","ace2_binding"]] = float('nan')
-
 
     clades = clades[new_columns]
 

--- a/scripts/developer_scripts/rerun-nextclade-21L.sh
+++ b/scripts/developer_scripts/rerun-nextclade-21L.sh
@@ -1,8 +1,0 @@
-#! /usr/bin/env bash
-set -euo pipefail
-echo "Adding touchfiles to trigger full nextclade 21L rerun"
-set -x
-aws s3 cp - s3://nextstrain-ncov-private/nextclade_21L.tsv.zst.renew < /dev/null
-aws s3 cp - s3://nextstrain-data/files/ncov/open/nextclade_21L.tsv.zst.renew < /dev/null
-set +x
-echo "Done"

--- a/workflow/snakemake_rules/nextclade.smk
+++ b/workflow/snakemake_rules/nextclade.smk
@@ -2,10 +2,7 @@
 This part of the workflow handles all rules related to NextClade.
 Depends on the main Snakefile to define the variable `database`, which is NOT a wildcard.
 
-We run Nextclade twice, once on the normal sars-cov-2 dataset and once on the 21L sars-cov-2-21L dataset.
-To keep the Snakefile dry, we use a wildcard `{reference}` that is either empty or `_21L`.
-Since alignments are identical, we don't merge and upload the 21L alignments to S3.
-21L outputs are used for `immune_escape` and `ace2_binding` columns.
+We run Nextclade on the sars-cov-2 dataset to align sequences and assign clades.
 
 Expects the following inputs:
     fasta = "data/{database}/sequences.fasta"
@@ -29,16 +26,15 @@ Produces the following outputs:
 
 
 wildcard_constraints:
-    reference="|_21L",
     seqtype="aligned|translation_[^.]+",
 
 
 rule create_empty_nextclade_info:
     """Creating empty NextClade info cache file"""
     output:
-        touch(f"data/{database}/nextclade{{reference}}_old.tsv"),
+        touch(f"data/{database}/nextclade_old.tsv"),
     benchmark:
-        f"benchmarks/create_empty_nextclade_info_{database}{{reference}}.txt"
+        f"benchmarks/create_empty_nextclade_info_{database}.txt"
 
 
 rule create_empty_nextclade_aligned:
@@ -66,12 +62,12 @@ if config.get("s3_dst") and config.get("s3_src"):
     rule use_nextclade_cache:
         input:
             nextclade="data/nextclade",
-            nextclade_dataset=lambda w: f"data/nextclade_data/sars-cov-2{w.reference.replace('_','-')}.zip",
+            nextclade_dataset="data/nextclade_data/sars-cov-2.zip",
         params:
             dst_source=config["s3_dst"],
             src_source=config["s3_src"],
         output:
-            use_nextclade_cache=f"data/{database}/use_nextclade_cache{{reference}}.txt",
+            use_nextclade_cache=f"data/{database}/use_nextclade_cache.txt",
         shell:
             """
             ./bin/use-nextclade-cache \
@@ -79,7 +75,6 @@ if config.get("s3_dst") and config.get("s3_src"):
                 {params.src_source:q} \
                 {input.nextclade:q} \
                 {input.nextclade_dataset:q} \
-                {wildcards.reference:q} \
                 > {output.use_nextclade_cache}
             """
 
@@ -89,25 +84,25 @@ if config.get("s3_dst") and config.get("s3_src"):
         If there's a .renew touchfile, do not use the cache
         """
         input:
-            use_nextclade_cache=f"data/{database}/use_nextclade_cache{{reference}}.txt",
+            use_nextclade_cache=f"data/{database}/use_nextclade_cache.txt",
         params:
-            dst_source=config["s3_dst"] + "/nextclade{reference}.tsv.zst",
-            src_source=config["s3_src"] + "/nextclade{reference}.tsv.zst",
+            dst_source=config["s3_dst"] + "/nextclade.tsv.zst",
+            src_source=config["s3_src"] + "/nextclade.tsv.zst",
             lines=config.get("subsample", {}).get("nextclade", 0),
         output:
-            nextclade=f"data/{database}/nextclade{{reference}}_old.tsv",
+            nextclade=f"data/{database}/nextclade_old.tsv",
         benchmark:
-            f"benchmarks/download_nextclade_tsv_from_s3_{database}{{reference}}.txt"
+            f"benchmarks/download_nextclade_tsv_from_s3_{database}.txt"
         shell:
             """
             use_nextclade_cache=$(cat {input.use_nextclade_cache})
 
             if [[ "$use_nextclade_cache" == 'true' ]]; then
-                echo "[INFO] Downloading cached nextclade{wildcards.reference}.tsv.zst"
+                echo "[INFO] Downloading cached nextclade.tsv.zst"
                 ./vendored/download-from-s3 {params.dst_source} {output.nextclade} {params.lines} ||  \
                 ./vendored/download-from-s3 {params.src_source} {output.nextclade} {params.lines}
             else
-                echo "[INFO] Ignoring cached nextclade{wildcards.reference}.tsv.zst"
+                echo "[INFO] Ignoring cached nextclade.tsv.zst"
                 touch {output.nextclade}
             fi
             """
@@ -144,11 +139,11 @@ rule get_sequences_without_nextclade_annotations:
     """Find sequences in FASTA which don't have clades assigned yet"""
     input:
         fasta=f"data/{database}/sequences.fasta",
-        nextclade=f"data/{database}/nextclade{{reference}}_old.tsv",
+        nextclade=f"data/{database}/nextclade_old.tsv",
     output:
-        fasta=f"data/{database}/nextclade{{reference}}.sequences.fasta",
+        fasta=f"data/{database}/nextclade.sequences.fasta",
     benchmark:
-        f"benchmarks/get_sequences_without_nextclade_annotations_{database}{{reference}}.txt"
+        f"benchmarks/get_sequences_without_nextclade_annotations_{database}.txt"
     shell:
         """
         if [[ -s {input.nextclade} ]]; then
@@ -159,7 +154,7 @@ rule get_sequences_without_nextclade_annotations:
         else
             ln {input.fasta} {output.fasta}
         fi
-        echo "[ INFO] Number of {wildcards.reference} sequences to run Nextclade on: $(grep -c '^>' {output.fasta})"
+        echo "[ INFO] Number of sequences to run Nextclade on: $(grep -c '^>' {output.fasta})"
         """
 
 
@@ -240,39 +235,15 @@ rule run_wuhan_nextclade:
         """
 
 
-rule run_21L_nextclade:
-    """
-    Like wuhan nextclade, but TSV only, no alignments output
-    """
-    input:
-        nextclade_path="data/nextclade",
-        dataset=lambda w: f"data/nextclade_data/sars-cov-2-21L.zip",
-        sequences=f"data/{database}/nextclade_21L.sequences.fasta",
-    output:
-        info=f"data/{database}/nextclade_21L_new_raw.tsv",
-    threads:
-        workflow.cores * 0.5
-    benchmark:
-        f"benchmarks/run_21L_nextclade_{database}.txt"
-    shell:
-        """
-        ./{input.nextclade_path} run \
-        -j {threads} \
-        {input.sequences} \
-        --input-dataset={input.dataset} \
-        --output-tsv={output.info} \
-        """
-
-
 rule nextclade_tsv_concat_versions:
     input:
         nextclade="data/nextclade",
-        tsv=f"data/{database}/nextclade{{reference}}_new_raw.tsv",
-        dataset=lambda w: f"data/nextclade_data/sars-cov-2{w.reference.replace('_','-')}.zip",
+        tsv=f"data/{database}/nextclade_new_raw.tsv",
+        dataset="data/nextclade_data/sars-cov-2.zip",
     output:
-        tsv=f"data/{database}/nextclade{{reference}}_new.tsv",
+        tsv=f"data/{database}/nextclade_new.tsv",
     benchmark:
-        f"benchmarks/nextclade_tsv_concat_versions_{database}{{reference}}.txt"
+        f"benchmarks/nextclade_tsv_concat_versions_{database}.txt"
     shell:
         """
         if [ -s {input.tsv} ]; then
@@ -303,12 +274,12 @@ rule nextclade_info:
     Generates nextclade info TSV for all sequences (new + old)
     """
     input:
-        old_info=f"data/{database}/nextclade{{reference}}_old.tsv",
+        old_info=f"data/{database}/nextclade_old.tsv",
         new_info=rules.nextclade_tsv_concat_versions.output.tsv,
     output:
-        nextclade_info=f"data/{database}/nextclade{{reference}}.tsv",
+        nextclade_info=f"data/{database}/nextclade.tsv",
     benchmark:
-        f"benchmarks/nextclade_info_{database}{{reference}}.txt"
+        f"benchmarks/nextclade_info_{database}.txt"
     shell:
         """
         tsv-append -H {input.old_info} {input.new_info} \
@@ -322,10 +293,10 @@ rule nextclade_version_json:
     """
     input:
         nextclade_path="data/nextclade",
-        nextclade_dataset=lambda w: f"data/nextclade_data/sars-cov-2{w.reference.replace('_','-')}.zip",
-        nextclade_tsv=f"data/{database}/nextclade{{reference}}.tsv",
+        nextclade_dataset="data/nextclade_data/sars-cov-2.zip",
+        nextclade_tsv=f"data/{database}/nextclade.tsv",
     output:
-        nextclade_version_json=f"data/{database}/nextclade{{reference}}_version.json",
+        nextclade_version_json=f"data/{database}/nextclade_version.json",
     shell:
         """
         ./bin/generate-nextclade-version-json \
@@ -371,7 +342,6 @@ rule combine_alignments:
 rule generate_metadata:
     input:
         nextclade_tsv=f"data/{database}/nextclade.tsv",
-        nextclade_21L_tsv=f"data/{database}/nextclade_21L.tsv",
         existing_metadata=f"data/{database}/metadata_transformed.tsv",
         clade_legacy_mapping="defaults/clade-legacy-mapping.yml",
     output:
@@ -383,7 +353,6 @@ rule generate_metadata:
         ./bin/join-metadata-and-clades \
             --metadata {input.existing_metadata} \
             --nextclade-tsv {input.nextclade_tsv} \
-            --nextclade-21L-tsv {input.nextclade_21L_tsv} \
             --clade-legacy-mapping {input.clade_legacy_mapping} \
             -o {output.metadata}
         """
@@ -393,9 +362,6 @@ rule metadata_version_json:
     """
     Generates the metadata version JSON by adding the metadata TSV sha256sum
     to the Nextclade version JSON.
-
-    TODO: Merge the 21L Nextclade version JSON to track data provenence for
-    specific columns
     """
     input:
         metadata=f"data/{database}/metadata.tsv",

--- a/workflow/snakemake_rules/upload.smk
+++ b/workflow/snakemake_rules/upload.smk
@@ -25,10 +25,8 @@ def compute_files_to_upload():
 
                         "nextclade.tsv.zst":           f"data/{database}/nextclade.tsv",
                         "aligned.fasta.zst":           f"data/{database}/aligned.fasta",
-                        "nextclade_21L.tsv.zst":       f"data/{database}/nextclade_21L.tsv",
 
                         "nextclade_version.json":          f"data/{database}/nextclade_version.json",
-                        "nextclade_21L_version.json":      f"data/{database}/nextclade_21L_version.json",
                         "metadata_version.json":           f"data/{database}/metadata_version.json",
                     }
     files_to_upload = files_to_upload | {
@@ -196,7 +194,6 @@ rule upload:
         touchfile_removes=[
             f"data/{database}/{remote_file}.renew.deleted" for remote_file in [
                 "nextclade.tsv.zst",
-                "nextclade_21L.tsv.zst",
             ]
         ],
         mv_processed=["data/mv-processed/all-gisaid-tars.done"] if should_move_processed_gisaid_tars() else [],


### PR DESCRIPTION
_Via Claude_

## Summary

ncov-ingest runs Nextclade **twice** on every sequence — once against the primary `sars-cov-2` (Wuhan) dataset and once against `sars-cov-2-21L` (BA.2), parameterized by a `{reference}` wildcard — solely to produce the `immune_escape` and `ace2_binding` metadata columns.

Those two columns are no longer consumed by anyone:
- the dedicated `ncov/gisaid/21L/global/6m` build was retired last fall;
- the main ncov build references neither column (only a historical `change_log.md` mention);
- `nextclade_21L.tsv.zst` is **not** an advertised remote input, and the two columns live only inside the advertised `metadata.tsv.zst`, which nothing reads for them.

So the 21L run is dead weight — a full redundant Nextclade pass (per the master benchmarks, e.g. `get_sequences…gisaid_21L` ~3635s, `nextclade_info_gisaid_21L` ~671s, plus the `_21L` uploads) and a second big TSV that the memory-heavy `generate_metadata` join has to load.

## What this does
- **`nextclade.smk`**: delete `run_21L_nextclade`, strip the `{reference}` wildcard from the seven shared rules so Nextclade runs exactly once, and make the dataset paths static (`sars-cov-2.zip`). Drop the 21L input from `generate_metadata`.
- **`upload.smk`**: drop the `nextclade_21L.tsv.zst` + `nextclade_21L_version.json` uploads and the renew-touchfile entry.
- **`join-metadata-and-clades`**: remove the `immune_escape`/`ace2_binding` columns, the `--nextclade-21L-tsv` input, and the associated read/merge/round/null-out.
- Delete the now-dead `scripts/developer_scripts/rerun-nextclade-21L.sh` and its README section.

Net: **−98 / +27 lines**, one file deleted. Also drops one input from `generate_metadata`, which helps the planned Phase 5b memory work on that join.

## Correctness
The published `metadata.tsv` loses **exactly two columns** (`immune_escape`, `ace2_binding`); everything else is byte-identical.

- **Join output-equivalence:** ran `join-metadata-and-clades` old-vs-new on a 4000-record slice of the real open `nextclade.tsv`. The new output is **byte-for-byte equal to the old output with those two columns dropped** — same columns (in order), same values, and the two removed columns were populated in the old output (so the merge + `< 21L` null-out path was exercised).
- **DAG:** `snakemake -n` for **both** `config/genbank.yaml` and `config/gisaid.yaml` resolves cleanly with **zero `_21L` jobs**; all primary Nextclade rules remain present and wired (the de-parameterization introduced no broken/orphaned dependencies).
- Source grep is clean of `21L` / `immune_escape` / `ace2_binding` / `{reference}`.

## Notes
- The stale `nextclade_21L.tsv.zst` already on S3 is orphaned but harmless; deleting it from the bucket is an optional manual follow-up, not part of this change.
- Separate from the Phase 5 memory series (#537).

## Test plan
- [x] Join output byte-identical vs `master` except the two 21L columns removed (4000-record slice)
- [x] `snakemake -n` clean for genbank + gisaid, zero `_21L` jobs, primary Nextclade rules intact
- [x] Source grep clean of 21L references
- [x] Full production run (GenBank + GISAID) completes; `metadata.tsv` lacks the two columns; no `nextclade_21L.*` uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Resolves #504_