### PR TITLE
Scale GenBank and GISAID AWS Batch requests to 16 cpus / 28 GiB

### DIFF
--- a/.github/workflows/fetch-and-ingest-genbank-master.yml
+++ b/.github/workflows/fetch-and-ingest-genbank-master.yml
@@ -94,8 +94,8 @@ jobs:
           --aws-batch \
           --detach \
           --no-download \
-          --cpus 32 \
-          --memory 60GiB \
+          --cpus 16 \
+          --memory 28GiB \
           --env GITHUB_RUN_ID \
           --env SLACK_TOKEN \
           --env SLACK_CHANNELS \

--- a/.github/workflows/fetch-and-ingest-gisaid-master.yml
+++ b/.github/workflows/fetch-and-ingest-gisaid-master.yml
@@ -76,11 +76,10 @@ jobs:
       run: |
         nextstrain build \
           --aws-batch \
-          --aws-batch-queue nextstrain-job-queue-c7a-12xlarge \
           --detach \
           --no-download \
-          --cpus 48 \
-          --memory 90GiB \
+          --cpus 16 \
+          --memory 28GiB \
           --env GITHUB_RUN_ID \
           --env SLACK_TOKEN \
           --env SLACK_CHANNELS \


### PR DESCRIPTION
Scale both master ingest builds down from their current AWS Batch sizing to **--cpus 16 --memory 28GiB** (c7a.4xlarge).

## Rationale — perf baseline
The two integration/perf-baseline runs (2026-07-11) showed large memory headroom (peak per-rule `max_rss`):

| Build | Was | Peak rule (RSS) | New |
|-------|-----|-----------------|-----|
| GenBank | 32 cpu / 60 GiB (c7a.8xlarge) | `transform_genbank_data` — 19.9 GB | 16 cpu / 28 GiB (c7a.4xlarge) |
| GISAID | 48 cpu / 90 GiB (c7a.12xlarge) | `transform_gisaid_data` — 14.6 GB | 16 cpu / 28 GiB (c7a.4xlarge) |

28 GiB still leaves >1.5× over the hungriest rule on each side. `--cpus` and `--memory` scale together, so both move as a pair; c7a.4xlarge is the next convenient step down (nothing sits between it and c7a.8xlarge).

## Changes
- Both workflows: `--cpus 16 --memory 28GiB`.
- GISAID: removed the explicit `--aws-batch-queue nextstrain-job-queue-c7a-12xlarge` pin so it uses the default queue and the instance is sized by the resource request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)